### PR TITLE
v0.3.2: Fix updater running git from wrong directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -59,7 +59,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/updater.py
+++ b/src/arenamcp/updater.py
@@ -8,12 +8,23 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from pathlib import Path
 from typing import Tuple
 
 logger = logging.getLogger(__name__)
 
 # Timeout (seconds) for git network operations
 _GIT_TIMEOUT = 5
+
+
+def _get_repo_root() -> Path:
+    """Get the git repo root for the arenamcp package.
+
+    Derives the repo root from this file's location so that git commands
+    work regardless of the process's current working directory.
+    """
+    # This file is at src/arenamcp/updater.py, repo root is 3 levels up
+    return Path(__file__).resolve().parent.parent.parent
 
 
 def check_for_update() -> Tuple[bool, str, str]:
@@ -27,11 +38,13 @@ def check_for_update() -> Tuple[bool, str, str]:
     from arenamcp import __version__ as local_version
 
     try:
+        repo_root = _get_repo_root()
         result = subprocess.run(
             ["git", "ls-remote", "--tags", "origin"],
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            cwd=str(repo_root),
         )
         if result.returncode != 0:
             logger.debug("git ls-remote failed: %s", result.stderr.strip())
@@ -85,11 +98,13 @@ def apply_update() -> Tuple[bool, str]:
         (success, message)
     """
     try:
+        repo_root = _get_repo_root()
         result = subprocess.run(
             ["git", "pull", "--ff-only", "origin", "master"],
             capture_output=True,
             text=True,
             timeout=30,
+            cwd=str(repo_root),
         )
         if result.returncode == 0:
             summary = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "Updated"


### PR DESCRIPTION
## Summary
- Updater's `git ls-remote` and `git pull` had no `cwd` parameter, so they ran from the process's working directory instead of the repo root
- This caused update checks to silently fail (returning "Up to date") when the app was launched from a non-repo directory
- Fix: derive repo root from `__file__` path and pass as `cwd` to all subprocess calls

## Test plan
- [ ] Launch app from a non-repo directory and verify update check works
- [ ] Verify "Update available" prompt appears when a newer tag exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)