### PR TITLE
v0.3.3: Fix TTS clipping first word of advice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.3.2"
+version = "0.3.3"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -59,7 +59,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/tts.py
+++ b/src/arenamcp/tts.py
@@ -444,9 +444,10 @@ class VoiceOutput:
             if len(samples) == 0:
                 return
 
-            # Add a small amount of leading silence (200ms) to prevent cutting off the first word
-            # on some audio devices/Bluetooth that have a wake-up delay.
-            silence_len = int(sample_rate * 0.2)
+            # Add leading silence (500ms) to prevent cutting off the first word.
+            # Audio devices (especially Bluetooth/USB) need time to wake up after
+            # sd.stop() or when the stream first opens.  200ms was not enough.
+            silence_len = int(sample_rate * 0.5)
             silence = np.zeros(silence_len, dtype=np.float32)
             samples = np.concatenate([silence, samples])
 
@@ -491,8 +492,8 @@ class VoiceOutput:
         if len(samples) == 0:
             return
 
-        # Add a small amount of leading silence (200ms) to prevent cutting off the first word
-        silence_len = int(sample_rate * 0.2)
+        # Add leading silence (500ms) to prevent cutting off the first word.
+        silence_len = int(sample_rate * 0.5)
         silence = np.zeros(silence_len, dtype=np.float32)
         samples = np.concatenate([silence, samples])
 


### PR DESCRIPTION
## Summary
- TTS leading silence increased from 200ms to 500ms to prevent the first word from being clipped
- Affects both blocking and async playback paths
- Fixes issue where "KEEP" or "MULLIGAN" was cut off at the start of mulligan advice

## Test plan
- [ ] Verify mulligan advice speaks "KEEP" or "MULLIGAN" clearly without clipping
- [ ] Verify other advice (combat, draft picks) also starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)