### PR TITLE
v0.3.5: Fix post-match analysis bugs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.3.4"
+version = "0.3.5"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -59,7 +59,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/coach.py
+++ b/src/arenamcp/coach.py
@@ -3384,18 +3384,31 @@ class CoachEngine:
             trigger = entry.get("trigger", "unknown")
             advice_text = entry.get("advice", "")
             ctx = entry.get("game_context", "") or ""
-            ctx_snippet = ctx[:300] + "..." if len(ctx) > 300 else ctx
 
-            lines.append(f"\n--- Turn {turn}, {phase} [{trigger}] ---")
+            # Include life totals from snapshot for each entry
+            life_str = ""
+            players = snap.get("players", [])
+            if players:
+                parts = [f"Seat{p.get('seat_id')}={p.get('life_total')}" for p in players]
+                life_str = f" Life: {', '.join(parts)}"
+
+            board_info = ""
+            if snap.get("battlefield_count"):
+                board_info = f" Board:{snap['battlefield_count']} Hand:{snap.get('hand_count', '?')}"
+
+            # Include enough context for LLM to understand the board position
+            ctx_snippet = ctx[:800] + "..." if len(ctx) > 800 else ctx
+
+            lines.append(f"\n--- Turn {turn}, {phase} [{trigger}]{life_str}{board_info} ---")
             if ctx_snippet:
                 lines.append(f"Context: {ctx_snippet}")
             lines.append(f"Advice: {advice_text}")
 
         user_message = "\n".join(lines)
 
-        # Truncate if too long
-        if len(user_message) > 12000:
-            user_message = user_message[:12000] + "\n\n[... truncated ...]"
+        # Allow larger context for better analysis quality
+        if len(user_message) > 24000:
+            user_message = user_message[:24000] + "\n\n[... truncated ...]"
 
         logger.info(
             f"[POST-MATCH] Generating analysis: {len(advice_history)} entries, "

--- a/src/arenamcp/gamestate.py
+++ b/src/arenamcp/gamestate.py
@@ -205,6 +205,8 @@ class GameState:
         # Recent game events from GRE annotations (ring buffer, max 50)
         self.recent_events: list[dict] = []
         self._max_recent_events: int = 50
+        # Persists across reset() so the coaching loop can read it after match ends
+        self.last_game_result: Optional[str] = None  # "win", "loss", or None
         # Cumulative damage tracking per player this game: {seat_id: total_damage_taken}
         self.damage_taken: dict[int, int] = {}
         # Cards revealed to us by opponent (from CardRevealed/InstanceRevealedToOpponent)
@@ -246,6 +248,9 @@ class GameState:
         self.recent_events = []
         self.damage_taken = {}
         self.revealed_cards = {}
+        # NOTE: last_game_result is intentionally NOT cleared here.
+        # The coaching loop reads it after reset() to detect the match outcome.
+        # It is cleared by the coaching loop once consumed.
 
     # Backward compatibility for _seat_manually_set
     @property
@@ -452,6 +457,7 @@ class GameState:
             "recent_events": self.recent_events[-10:],  # Last 10 events for display
             "damage_taken": self.damage_taken,
             "revealed_cards": revealed,
+            "last_game_result": self.last_game_result,
         }
         return snapshot
 
@@ -1201,11 +1207,14 @@ class GameState:
                     })
 
                 elif ann_type in ("AnnotationType_LossOfGame", "AnnotationType_WinTheGame"):
+                    result = "loss" if "Loss" in ann_type else "win"
                     self._add_event({
                         "type": "game_end",
-                        "result": "loss" if "Loss" in ann_type else "win",
+                        "result": result,
                         "affected_ids": affected_ids,
                     })
+                    # Persist result so it survives reset() for post-match analysis
+                    self.last_game_result = result
 
                 elif ann_type == "AnnotationType_ModifiedLife":
                     self._add_event({

--- a/src/arenamcp/standalone.py
+++ b/src/arenamcp/standalone.py
@@ -288,6 +288,7 @@ class StandaloneCoach:
         self._saved_advice_history: list[dict] = []
         self._last_match_result: Optional[str] = None
         self._last_match_final_state: Optional[dict] = None
+        self._game_end_handled: bool = False  # Prevents duplicate triggers
 
     def speak_advice(self, text: str, blocking: bool = True) -> None:
         """Speak advice using local Kokoro TTS."""
@@ -573,12 +574,34 @@ class StandaloneCoach:
                 phase = turn.get("phase", "")
                 curr_match_id = curr_state.get("match_id")
 
+                # ── GAME END DETECTION ──
+                # Fires as soon as the GRE sends a WinTheGame/LossOfGame annotation,
+                # BEFORE any reset() clears the state.  This is the primary trigger
+                # for post-match analysis.
+                game_result = curr_state.get("last_game_result")
+                if game_result and not self._game_end_handled and self._advice_history:
+                    self._game_end_handled = True
+                    logger.info(f"Game ended: {game_result} — launching post-match analysis")
+                    self._saved_advice_history = list(self._advice_history)
+                    self._last_match_result = game_result
+                    self._last_match_final_state = dict(curr_state)
+                    threading.Thread(
+                        target=self._post_match_analysis_worker,
+                        daemon=True,
+                    ).start()
+                    # Clear the persistent flag so it won't re-trigger
+                    try:
+                        from arenamcp.server import game_state as gs
+                        gs.last_game_result = None
+                    except Exception:
+                        pass
+
                 # Detect new match via match_id change (most reliable signal)
                 if curr_match_id and curr_match_id != last_match_id:
                     if last_match_id is not None:
                         logger.info(f"New match detected via match_id change ({last_match_id} -> {curr_match_id}), resetting coaching state")
 
-                        # Save match data for post-match analysis BEFORE clearing
+                        # Fallback: trigger analysis if game_end detection above missed it
                         if self._advice_history and not self._saved_advice_history:
                             self._saved_advice_history = list(self._advice_history)
                             self._last_match_result = self._detect_match_result()
@@ -594,6 +617,7 @@ class StandaloneCoach:
                         seat_announced = False
                         self._advice_history = []
                         self._deck_analyzed = False
+                        self._game_end_handled = False
                         if self._coach:
                             self._coach.clear_deck_strategy()
                     last_match_id = curr_match_id
@@ -610,7 +634,7 @@ class StandaloneCoach:
                 if turn_num > 0 and turn_num < last_advice_turn:
                     logger.info(f"New game detected in coaching loop (turn {last_advice_turn} -> {turn_num}), resetting advice tracking")
 
-                    # Save match data for post-match analysis BEFORE clearing
+                    # Fallback: trigger analysis if game_end detection above missed it
                     if self._advice_history and not self._saved_advice_history:
                         self._saved_advice_history = list(self._advice_history)
                         self._last_match_result = self._detect_match_result()
@@ -627,6 +651,7 @@ class StandaloneCoach:
                     # Clear advice history for new match
                     self._advice_history = []
                     self._deck_analyzed = False
+                    self._game_end_handled = False
                     if self._coach:
                         self._coach.clear_deck_strategy()
                     logger.info("Cleared advice history for new match")
@@ -1628,12 +1653,23 @@ BE DECISIVE. Start with your recommendation immediately. Keep it to 1-2 sentence
             self._recent_errors = self._recent_errors[-10:]
 
     def _detect_match_result(self) -> str:
-        """Detect win/loss from recent game events.
+        """Detect win/loss from game state.
+
+        Uses the persistent ``last_game_result`` field on GameState which
+        survives ``reset()`` (unlike ``recent_events``).  Falls back to
+        scanning ``recent_events`` if the persistent field isn't set.
 
         Returns "win", "loss", or "unknown".
         """
         try:
             game_state = self._mcp.get_game_state()
+
+            # Preferred: persistent field set when game_end annotation fires
+            persistent = game_state.get("last_game_result")
+            if persistent:
+                return persistent
+
+            # Fallback: scan recent_events (may already be cleared by reset)
             recent = game_state.get("recent_events", [])
             for event in reversed(recent):
                 if event.get("type") == "game_end":


### PR DESCRIPTION
## Summary
- Fix auto-trigger: analysis now fires immediately on game end annotation, not on next match start
- Fix "unknown" match result: persistent `last_game_result` field on GameState survives `reset()`
- Fix shallow analysis: context per entry increased 300→800 chars, life totals added per turn, prompt cap raised 12k→24k

## Test plan
- [ ] Play a match to completion → analysis should auto-trigger within ~3s of game ending
- [ ] Analysis should show correct win/loss result (not "unknown")
- [ ] Analysis should reference specific cards and turns throughout the match
- [ ] Start next match → coaching works normally, no leftover state

🤖 Generated with [Claude Code](https://claude.com/claude-code)