### PR TITLE
v0.3.6: Fix match boundary detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.3.5"
+version = "0.3.6"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -59,7 +59,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/server.py
+++ b/src/arenamcp/server.py
@@ -424,15 +424,40 @@ def stop_draft_helper() -> None:
 
 
 def _handle_match_created(payload: dict) -> None:
-    """Handle MatchCreated events to capture local seat ID.
+    """Handle MatchCreated / MatchGameRoomStateChangedEvent.
 
     The MatchCreated message contains systemSeatId which definitively
     identifies the local player's seat.
+
+    MatchGameRoomStateChangedEvent also fires at match end with result data.
+    We capture the result into ``last_game_result`` so the coaching loop can
+    detect it even if the WinTheGame/LossOfGame annotation was missed (e.g.
+    concede).
     """
-    # Try to extract match ID to detect new matches
+    # ── Match result detection (from finalMatchResult) ──
+    # MTGA sends this in MatchGameRoomStateChangedEvent when the match ends.
+    room_info = payload.get("matchGameRoomInfo", {})
+    results = room_info.get("finalMatchResult", {}).get("resultList", [])
+    if results and not game_state.last_game_result:
+        # Find our result by matching local seat_id
+        for r in results:
+            scope = r.get("scope", "")
+            seat = r.get("seatId")
+            result_str = r.get("result", "")
+            win_condition = r.get("winningTeamId", "")
+            if scope == "MatchScope_Game":
+                if seat == game_state.local_seat_id:
+                    if "Win" in result_str:
+                        game_state.last_game_result = "win"
+                        logger.info(f"Match result from finalMatchResult: win (seat {seat})")
+                    elif "Loss" in result_str:
+                        game_state.last_game_result = "loss"
+                        logger.info(f"Match result from finalMatchResult: loss (seat {seat})")
+
+    # ── Match ID tracking ──
     match_id = (
-        payload.get("matchId") or 
-        payload.get("matchGameRoomInfo", {}).get("gameRoomConfig", {}).get("matchId") or
+        payload.get("matchId") or
+        room_info.get("gameRoomConfig", {}).get("matchId") or
         payload.get("gameRoomConfig", {}).get("matchId")
     )
 
@@ -441,7 +466,7 @@ def _handle_match_created(payload: dict) -> None:
             logger.info(f"New match detected (ID: {match_id}). Resetting game state.")
             game_state.reset()
             game_state.match_id = match_id
-            
+
             # Since we reset state, notify draft helper effectively if needed
             # (though draft state is separate)
     

--- a/src/arenamcp/standalone.py
+++ b/src/arenamcp/standalone.py
@@ -596,30 +596,34 @@ class StandaloneCoach:
                     except Exception:
                         pass
 
-                # Detect new match via match_id change (most reliable signal)
-                if curr_match_id and curr_match_id != last_match_id:
-                    if last_match_id is not None:
-                        logger.info(f"New match detected via match_id change ({last_match_id} -> {curr_match_id}), resetting coaching state")
+                # Detect match boundary via match_id change.
+                # Two cases:
+                #   (a) match_id goes FROM something TO a different value (new match started)
+                #   (b) match_id goes FROM something TO None (match ended, back to menu)
+                match_id_changed = curr_match_id != last_match_id
+                if match_id_changed and last_match_id is not None:
+                    logger.info(f"Match boundary detected ({last_match_id} -> {curr_match_id}), resetting coaching state")
 
-                        # Fallback: trigger analysis if game_end detection above missed it
-                        if self._advice_history and not self._saved_advice_history:
-                            self._saved_advice_history = list(self._advice_history)
-                            self._last_match_result = self._detect_match_result()
-                            self._last_match_final_state = dict(prev_state) if prev_state else None
-                            threading.Thread(
-                                target=self._post_match_analysis_worker,
-                                daemon=True,
-                            ).start()
+                    # Trigger analysis if game_end detection above missed it
+                    if self._advice_history and not self._saved_advice_history:
+                        self._saved_advice_history = list(self._advice_history)
+                        self._last_match_result = self._detect_match_result()
+                        self._last_match_final_state = dict(prev_state) if prev_state else None
+                        threading.Thread(
+                            target=self._post_match_analysis_worker,
+                            daemon=True,
+                        ).start()
 
-                        prev_state = {}
-                        last_advice_turn = 0
-                        last_advice_phase = ""
-                        seat_announced = False
-                        self._advice_history = []
-                        self._deck_analyzed = False
-                        self._game_end_handled = False
-                        if self._coach:
-                            self._coach.clear_deck_strategy()
+                    prev_state = {}
+                    last_advice_turn = 0
+                    last_advice_phase = ""
+                    seat_announced = False
+                    self._advice_history = []
+                    self._deck_analyzed = False
+                    self._game_end_handled = False
+                    if self._coach:
+                        self._coach.clear_deck_strategy()
+                if match_id_changed:
                     last_match_id = curr_match_id
 
                 # Debug: Log if turn_num is 0 (every 30 seconds)


### PR DESCRIPTION
## Summary
- Fix advice history not clearing between games when match_id goes null (root cause of incomplete/missing post-match analysis)
- Add concede result detection from MatchGameRoomStateChangedEvent finalMatchResult payload
- Match_id transitions now tracked correctly for both null→value and value→null cases

## Root cause
When a match ends, MTGA sets `match_id` to null. The old check `if curr_match_id and ...` short-circuited on null, so advice history was never cleared. New mulligan advice piled onto the old game's history. Post-match analysis either didn't fire or mixed data from both games.

## Test plan
- [ ] Play a match → analysis fires automatically when game ends
- [ ] Start next match → advice history is fresh (no old game data)
- [ ] Concede a match → result should show "loss" not "unknown"
- [ ] Opponent concedes → result should show "win" not "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)