### PR TITLE
v0.3.7: Fix game-end detection with cross-thread signaling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.3.6"
+version = "0.3.7"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -59,7 +59,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/gamestate.py
+++ b/src/arenamcp/gamestate.py
@@ -6,6 +6,7 @@ snapshot of the current game state from parsed MTGA log events.
 
 import json
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -212,6 +213,15 @@ class GameState:
         # Cards revealed to us by opponent (from CardRevealed/InstanceRevealedToOpponent)
         self.revealed_cards: dict[int, set[int]] = {}  # seat_id -> set of grp_ids
 
+        # ── Cross-thread game-end signaling ──
+        # The parser thread sets this event when the game ends (IntermissionReq).
+        # The coaching loop checks it to detect game end immediately, even if
+        # blocked on an LLM call or in between polls.
+        self.game_ended_event: threading.Event = threading.Event()
+        # Snapshot of the full game state captured BEFORE reset(), so the
+        # post-match analysis has the final board state even after reset clears it.
+        self._pre_reset_snapshot: Optional[dict] = None
+
     def reset(self) -> None:
         """Reset the game state to essentially empty (for new match)."""
         logger.info("Resetting GameState for new match")
@@ -251,6 +261,59 @@ class GameState:
         # NOTE: last_game_result is intentionally NOT cleared here.
         # The coaching loop reads it after reset() to detect the match outcome.
         # It is cleared by the coaching loop once consumed.
+        # NOTE: game_ended_event and _pre_reset_snapshot are NOT cleared here.
+        # They are cleared by the coaching loop once consumed.
+
+    def prepare_for_game_end(self) -> None:
+        """Capture final state and infer result BEFORE reset().
+
+        Called by the IntermissionReq handler (parser thread) right before
+        ``reset()`` wipes the board.  This ensures:
+        1. ``last_game_result`` is set even if no WinTheGame/LossOfGame annotation fired
+        2. ``_pre_reset_snapshot`` preserves the final board state for analysis
+        3. ``game_ended_event`` is set so the coaching loop detects it immediately
+        """
+        # 1. Infer game result from life totals if not already set
+        if not self.last_game_result and self.local_seat_id is not None:
+            for seat_id, player in self.players.items():
+                if player.life_total <= 0:
+                    if seat_id == self.local_seat_id:
+                        self.last_game_result = "loss"
+                        logger.info(f"Inferred game result from life totals: loss (seat {seat_id} life={player.life_total})")
+                    else:
+                        self.last_game_result = "win"
+                        logger.info(f"Inferred game result from life totals: win (opponent seat {seat_id} life={player.life_total})")
+                    break  # First player at ≤0 life determines result
+
+        # 2. Save a snapshot of the full state before reset wipes it
+        try:
+            self._pre_reset_snapshot = self.to_dict()
+        except Exception as e:
+            logger.warning(f"Failed to capture pre-reset snapshot: {e}")
+            self._pre_reset_snapshot = None
+
+        # 3. Signal the coaching loop
+        self.game_ended_event.set()
+        logger.info(f"Game-end prepared: result={self.last_game_result}, snapshot={'yes' if self._pre_reset_snapshot else 'no'}")
+
+    def consume_game_end(self) -> tuple[Optional[str], Optional[dict]]:
+        """Consume the game-end signal and return (result, snapshot).
+
+        Called by the coaching loop after detecting ``game_ended_event``.
+        Clears the event and persistent fields so they don't re-trigger.
+
+        Returns:
+            Tuple of (result, pre_reset_snapshot) where result is "win",
+            "loss", or None, and snapshot is the full game state dict
+            captured before reset().
+        """
+        result = self.last_game_result
+        snapshot = self._pre_reset_snapshot
+        # Clear consumed data
+        self.last_game_result = None
+        self._pre_reset_snapshot = None
+        self.game_ended_event.clear()
+        return result, snapshot
 
     # Backward compatibility for _seat_manually_set
     @property
@@ -1505,6 +1568,8 @@ def create_game_state_handler(game_state: GameState) -> Callable[[dict], None]:
                 # set a Mulligan decision — the actual mulligan SubmitDeckReq will come
                 # later if a new game starts.
                 logger.info(f"IntermissionReq received (turn {game_state.turn_info.turn_number}) - game over/transition")
+                # Capture final state and infer result BEFORE reset wipes the board
+                game_state.prepare_for_game_end()
                 game_state.reset()
                 # Clear any stale decision from the finished game
                 game_state.pending_decision = None

--- a/src/arenamcp/server.py
+++ b/src/arenamcp/server.py
@@ -436,23 +436,36 @@ def _handle_match_created(payload: dict) -> None:
     """
     # ── Match result detection (from finalMatchResult) ──
     # MTGA sends this in MatchGameRoomStateChangedEvent when the match ends.
+    # NOTE: IntermissionReq may have already wiped local_seat_id via reset().
+    # Use the pre-reset snapshot's seat_id as fallback.
     room_info = payload.get("matchGameRoomInfo", {})
     results = room_info.get("finalMatchResult", {}).get("resultList", [])
     if results and not game_state.last_game_result:
-        # Find our result by matching local seat_id
-        for r in results:
-            scope = r.get("scope", "")
-            seat = r.get("seatId")
-            result_str = r.get("result", "")
-            win_condition = r.get("winningTeamId", "")
-            if scope == "MatchScope_Game":
-                if seat == game_state.local_seat_id:
-                    if "Win" in result_str:
-                        game_state.last_game_result = "win"
-                        logger.info(f"Match result from finalMatchResult: win (seat {seat})")
-                    elif "Loss" in result_str:
-                        game_state.last_game_result = "loss"
-                        logger.info(f"Match result from finalMatchResult: loss (seat {seat})")
+        # Determine our seat_id — may have been cleared by reset()
+        our_seat = game_state.local_seat_id
+        if our_seat is None and game_state._pre_reset_snapshot:
+            our_seat = game_state._pre_reset_snapshot.get("local_seat_id")
+        if our_seat is not None:
+            # Find our result by matching local seat_id
+            for r in results:
+                scope = r.get("scope", "")
+                seat = r.get("seatId")
+                result_str = r.get("result", "")
+                if scope == "MatchScope_Game":
+                    if seat == our_seat:
+                        if "Win" in result_str:
+                            game_state.last_game_result = "win"
+                            logger.info(f"Match result from finalMatchResult: win (seat {seat})")
+                        elif "Loss" in result_str:
+                            game_state.last_game_result = "loss"
+                            logger.info(f"Match result from finalMatchResult: loss (seat {seat})")
+                        # Signal the coaching loop if not already signaled
+                        if not game_state.game_ended_event.is_set():
+                            game_state.game_ended_event.set()
+                            logger.info("Game-end event set from finalMatchResult")
+                        break
+        else:
+            logger.warning(f"finalMatchResult received but no local seat_id available (results: {results})")
 
     # ── Match ID tracking ──
     match_id = (

--- a/src/arenamcp/standalone.py
+++ b/src/arenamcp/standalone.py
@@ -575,28 +575,29 @@ class StandaloneCoach:
                 curr_match_id = curr_state.get("match_id")
 
                 # ── GAME END DETECTION ──
-                # Fires as soon as the GRE sends a WinTheGame/LossOfGame annotation,
-                # BEFORE any reset() clears the state.  This is the primary trigger
-                # for post-match analysis.
-                game_result = curr_state.get("last_game_result")
-                if game_result and not self._game_end_handled and self._advice_history:
-                    self._game_end_handled = True
-                    logger.info(f"Game ended: {game_result} — launching post-match analysis")
-                    self._saved_advice_history = list(self._advice_history)
-                    self._last_match_result = game_result
-                    self._last_match_final_state = dict(curr_state)
-                    threading.Thread(
-                        target=self._post_match_analysis_worker,
-                        daemon=True,
-                    ).start()
-                    # Clear the persistent flag so it won't re-trigger
-                    try:
-                        from arenamcp.server import game_state as gs
-                        gs.last_game_result = None
-                    except Exception:
-                        pass
+                # PRIMARY: Check threading.Event set by parser thread
+                # (IntermissionReq or finalMatchResult). This fires immediately
+                # regardless of whether the coaching loop was blocked on LLM.
+                try:
+                    from arenamcp.server import game_state as gs
+                    if gs.game_ended_event.is_set() and not self._game_end_handled and self._advice_history:
+                        self._game_end_handled = True
+                        result, snapshot = gs.consume_game_end()
+                        game_result = result or "unknown"
+                        logger.info(f"Game ended (event signal): {game_result} — launching post-match analysis")
+                        self._saved_advice_history = list(self._advice_history)
+                        self._last_match_result = game_result
+                        # Use pre-reset snapshot (full final state) if available,
+                        # otherwise fall back to current (already-reset) state
+                        self._last_match_final_state = snapshot or dict(curr_state)
+                        threading.Thread(
+                            target=self._post_match_analysis_worker,
+                            daemon=True,
+                        ).start()
+                except Exception as e:
+                    logger.debug(f"Game-end event check failed: {e}")
 
-                # Detect match boundary via match_id change.
+                # SECONDARY: Detect match boundary via match_id change.
                 # Two cases:
                 #   (a) match_id goes FROM something TO a different value (new match started)
                 #   (b) match_id goes FROM something TO None (match ended, back to menu)
@@ -634,7 +635,7 @@ class StandaloneCoach:
                         logger.debug(f"turn_num=0, players={len(curr_state.get('players', []))}, battlefield={len(curr_state.get('battlefield', []))}")
                         self._last_turn0_log = time.time()
 
-                # Detect new game (turn number decreased) — fallback for same-match restarts
+                # TERTIARY: Detect new game (turn number decreased) — fallback for same-match restarts
                 if turn_num > 0 and turn_num < last_advice_turn:
                     logger.info(f"New game detected in coaching loop (turn {last_advice_turn} -> {turn_num}), resetting advice tracking")
 
@@ -1659,22 +1660,33 @@ BE DECISIVE. Start with your recommendation immediately. Keep it to 1-2 sentence
     def _detect_match_result(self) -> str:
         """Detect win/loss from game state.
 
-        Uses the persistent ``last_game_result`` field on GameState which
-        survives ``reset()`` (unlike ``recent_events``).  Falls back to
-        scanning ``recent_events`` if the persistent field isn't set.
+        Checks multiple sources in priority order:
+        1. Persistent ``last_game_result`` field on GameState (survives reset)
+        2. Pre-reset snapshot's ``last_game_result``
+        3. ``recent_events`` (may be cleared by reset)
 
         Returns "win", "loss", or "unknown".
         """
         try:
-            game_state = self._mcp.get_game_state()
+            from arenamcp.server import game_state as gs
 
             # Preferred: persistent field set when game_end annotation fires
-            persistent = game_state.get("last_game_result")
-            if persistent:
-                return persistent
+            if gs.last_game_result:
+                return gs.last_game_result
 
-            # Fallback: scan recent_events (may already be cleared by reset)
-            recent = game_state.get("recent_events", [])
+            # Fallback 1: pre-reset snapshot
+            if gs._pre_reset_snapshot:
+                snap_result = gs._pre_reset_snapshot.get("last_game_result")
+                if snap_result:
+                    return snap_result
+
+            # Fallback 2: scan recent_events from snapshot (live ones may be cleared)
+            snapshot = gs._pre_reset_snapshot or {}
+            recent = snapshot.get("recent_events", [])
+            if not recent:
+                # Try live recent_events
+                game_state_dict = self._mcp.get_game_state()
+                recent = game_state_dict.get("recent_events", [])
             for event in reversed(recent):
                 if event.get("type") == "game_end":
                     return event.get("result", "unknown")


### PR DESCRIPTION
## Summary
- Fix post-match analysis firing 25+ seconds late with `result=unknown` by adding `threading.Event`-based signaling from parser thread to coaching loop
- `IntermissionReq` handler now captures game state snapshot and infers result from life totals BEFORE `reset()` wipes the board
- `finalMatchResult` handler falls back to pre-reset snapshot for seat_id when `IntermissionReq` has already cleared it

## Root Cause
The parser thread fires `IntermissionReq` → `reset()` synchronously, wiping all game state. The coaching loop polls on a separate thread (1.5s interval) and can be blocked on an LLM call for 3-10s. By the time it polls, the game state is already empty with no result, no life totals, and no seat ID.

Additionally, `WinTheGame`/`LossOfGame` annotations don't always fire (e.g., combat damage kills), and `finalMatchResult` couldn't match seats because `local_seat_id` was already wiped by `reset()`.

## Changes
- **`gamestate.py`**: Add `game_ended_event` (threading.Event), `_pre_reset_snapshot`, `prepare_for_game_end()`, and `consume_game_end()`
- **`gamestate.py`**: `IntermissionReq` handler calls `prepare_for_game_end()` before `reset()`
- **`server.py`**: `finalMatchResult` handler falls back to snapshot's `local_seat_id`
- **`standalone.py`**: Coaching loop checks `game_ended_event` as PRIMARY trigger (instant), with match_id/turn-number fallbacks

## Test plan
- [x] All 19 existing tests pass
- [ ] Play a match → analysis fires immediately on game end with correct result
- [ ] "Analyze Match" button still works mid-match
- [ ] New match starts normally after analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)