### PR TITLE
v0.5.2: Enhanced decision types and watchdog improvements

### DIFF
--- a/src/arenamcp/__init__.py
+++ b/src/arenamcp/__init__.py
@@ -62,7 +62,7 @@ except ImportError:
 
 from arenamcp.gamestate import save_match_state, load_match_state, mark_match_ended
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 def create_log_pipeline(

--- a/src/arenamcp/coach.py
+++ b/src/arenamcp/coach.py
@@ -1494,6 +1494,50 @@ Compare each mode's impact:
 - Consider mana efficiency and follow-up plays
 Answer: "Choose mode [X]" with brief reason (1 sentence).
 """,
+    "sacrifice": """
+SACRIFICE DECISION: Choose which permanent(s) to sacrifice.
+- Sacrifice the LEAST valuable permanent for the current board state
+- Keep: key synergy pieces, win conditions, blockers you need
+- Sacrifice: redundant creatures, tokens, low-impact permanents
+Answer: "Sacrifice [card name]" with brief reason (1 sentence).
+""",
+    "exile": """
+EXILE DECISION: Choose which card(s) to exile.
+- Consider: exiled cards are much harder to recover than destroyed/discarded ones
+- Exile: least impactful or already-used cards
+- Keep: anything with graveyard synergy or future utility
+Answer: "Exile [card name]" with brief reason (1 sentence).
+""",
+    "destroy": """
+DESTROY DECISION: Choose which permanent(s) to destroy.
+- Target the biggest threat or most impactful permanent
+- Consider: indestructible, regeneration, death triggers
+Answer: "Destroy [card name]" with brief reason (1 sentence).
+""",
+    "return": """
+RETURN DECISION: Choose which permanent(s) to return.
+- Return: least impactful or cheapest to replay
+- Keep: expensive/critical permanents on the battlefield
+Answer: "Return [card name]" with brief reason (1 sentence).
+""",
+    "choose_creature": """
+CHOOSE CREATURE: Select a creature.
+- Evaluate board impact: which creature matters most right now?
+- Consider power/toughness, abilities, synergies
+Answer: "Choose [card name]" with brief reason (1 sentence).
+""",
+    "choose_permanent": """
+CHOOSE PERMANENT: Select a permanent.
+- Evaluate which permanent has the most board impact
+- Consider card types, abilities, and current game state
+Answer: "Choose [card name]" with brief reason (1 sentence).
+""",
+    "choose": """
+CHOOSE: Make a selection from the available options.
+- Evaluate which option best advances your game plan
+- Consider immediate impact and future implications
+Answer: "Choose [option]" with brief reason (1 sentence).
+""",
 }
 
 WIN_PLAN_PROMPT = """You are a Magic: The Gathering strategic planner. Given the board state, hand, mana, and library summary, outline a concrete plan to win in {n} turns.
@@ -2092,6 +2136,56 @@ class CoachEngine:
                 elif dec_type == "choose_starting_player":
                     lines.append("!!! DECISION: PLAY OR DRAW !!!")
                     lines.append("Aggro decks: PLAY (tempo). Control/limited: DRAW (card advantage)")
+
+                elif dec_type == "sacrifice":
+                    count = decision_context.get("count", 1)
+                    opts = decision_context.get("option_cards")
+                    lines.append(f"!!! DECISION: SACRIFICE {count} !!!")
+                    if opts:
+                        lines.append(f"Options: {', '.join(opts[:8])}")
+                    lines.append("Choose: sacrifice least valuable permanent for the board state")
+
+                elif dec_type == "exile":
+                    count = decision_context.get("count", 1)
+                    opts = decision_context.get("option_cards")
+                    lines.append(f"!!! DECISION: EXILE {count} !!!")
+                    if opts:
+                        lines.append(f"Options: {', '.join(opts[:8])}")
+                    lines.append("Choose: exile least impactful card")
+
+                elif dec_type == "destroy":
+                    count = decision_context.get("count", 1)
+                    opts = decision_context.get("option_cards")
+                    lines.append(f"!!! DECISION: DESTROY {count} !!!")
+                    if opts:
+                        lines.append(f"Options: {', '.join(opts[:8])}")
+                    lines.append("Choose: destroy biggest threat on the board")
+
+                elif dec_type == "return":
+                    count = decision_context.get("count", 1)
+                    opts = decision_context.get("option_cards")
+                    lines.append(f"!!! DECISION: RETURN {count} !!!")
+                    if opts:
+                        lines.append(f"Options: {', '.join(opts[:8])}")
+                    lines.append("Choose: return least important permanent")
+
+                elif dec_type == "mill":
+                    count = decision_context.get("count", 1)
+                    lines.append(f"!!! DECISION: MILL {count} !!!")
+
+                elif dec_type == "explore":
+                    lines.append("!!! DECISION: EXPLORE !!!")
+                    lines.append("Keep land on top if needed, otherwise bottom for a better draw")
+
+                elif dec_type in ("choose_creature", "choose_land", "choose_enchantment",
+                                  "choose_artifact", "choose_permanent", "choose"):
+                    count = decision_context.get("count", 1)
+                    label = dec_type.replace("choose_", "").upper() or "ITEM"
+                    opts = decision_context.get("option_cards")
+                    lines.append(f"!!! DECISION: CHOOSE {label} ({count}) !!!")
+                    if opts:
+                        lines.append(f"Options: {', '.join(opts[:8])}")
+                    lines.append("Choose: pick the option that best advances your game plan")
 
                 elif dec_type == "select_replacement":
                     lines.append("!!! DECISION: ORDER REPLACEMENT EFFECTS !!!")

--- a/src/arenamcp/gamestate.py
+++ b/src/arenamcp/gamestate.py
@@ -194,6 +194,7 @@ class GameState:
         # PHASE 1: Enhanced decision context
         self.decision_context: Optional[dict] = None  # Rich context: source_card, options, etc.
         self.decision_timestamp: float = 0  # Track when decision was set
+        self.last_cleared_decision: Optional[str] = None  # For watchdog validation
         self.legal_actions: list[str] = [] # List of exact legal actions from GRE
 
         # Match tracking (to avoid stale state across matches)
@@ -516,6 +517,7 @@ class GameState:
             "pending_decision": self.pending_decision,
             "decision_seat_id": self.decision_seat_id,
             "decision_context": self.decision_context,
+            "last_cleared_decision": self.last_cleared_decision,
             "legal_actions": self.legal_actions,
             # Annotation-derived data
             "recent_events": self.recent_events[-10:],  # Last 10 events for display
@@ -1637,28 +1639,94 @@ def create_game_state_handler(game_state: GameState) -> Callable[[dict], None]:
                 }
                 
             elif msg_type == "GREMessageType_SelectNReq":
-                # PHASE 1: Capture rich context for N-selection (discard, scry, etc.)
+                # Capture rich context for N-selection decisions.
+                # MTGA sends PromptReq (e.g. "Choose a creature") right before
+                # SelectNReq.  We merge both to get the most descriptive text.
                 import time
                 req = msg.get("selectNReq", {})
                 context_data = req.get("context", {})
                 num_to_select = req.get("count", 1)
                 min_select = req.get("minCount", num_to_select)
                 max_select = req.get("maxCount", num_to_select)
-                
-                # Try to determine the type of selection (discard, scry, etc.)
-                # This is heuristic-based on MTGA's context strings
+                option_ids = req.get("ids", [])
+
+                # Build combined context from selectNReq AND any preceding PromptReq
                 context_str = str(context_data).lower()
+                prior_prompt = ""
+                if (game_state.pending_decision
+                        and game_state.decision_context
+                        and game_state.decision_context.get("type") == "prompt"):
+                    prior_prompt = game_state.decision_context.get("text", "").lower()
+                    context_str = f"{context_str} {prior_prompt}"
+
+                # Determine selection type — more specific keywords first
                 if "discard" in context_str:
                     selection_type = "discard"
+                    decision_text = "Discard"
+                elif "sacrifice" in context_str:
+                    selection_type = "sacrifice"
+                    decision_text = "Sacrifice"
+                elif "exile" in context_str:
+                    selection_type = "exile"
+                    decision_text = "Exile"
+                elif "destroy" in context_str:
+                    selection_type = "destroy"
+                    decision_text = "Destroy"
+                elif "return" in context_str:
+                    selection_type = "return"
+                    decision_text = "Return"
                 elif "scry" in context_str:
                     selection_type = "scry"
+                    decision_text = "Scry"
                 elif "surveil" in context_str:
                     selection_type = "surveil"
+                    decision_text = "Surveil"
+                elif "mill" in context_str:
+                    selection_type = "mill"
+                    decision_text = "Mill"
+                elif "explore" in context_str:
+                    selection_type = "explore"
+                    decision_text = "Explore"
+                elif "creature" in context_str:
+                    selection_type = "choose_creature"
+                    decision_text = "Choose Creature"
+                elif "land" in context_str:
+                    selection_type = "choose_land"
+                    decision_text = "Choose Land"
+                elif "enchantment" in context_str:
+                    selection_type = "choose_enchantment"
+                    decision_text = "Choose Enchantment"
+                elif "artifact" in context_str:
+                    selection_type = "choose_artifact"
+                    decision_text = "Choose Artifact"
+                elif "permanent" in context_str:
+                    selection_type = "choose_permanent"
+                    decision_text = "Choose Permanent"
+                elif "choose" in context_str:
+                    selection_type = "choose"
+                    decision_text = "Choose"
+                elif prior_prompt:
+                    # Fall back to the PromptReq text directly
+                    selection_type = "select_n"
+                    decision_text = game_state.decision_context.get("text", "Select Items")
                 else:
                     selection_type = "select_n"
-                
-                logger.info(f"Captured Decision: Select {num_to_select} Items ({selection_type})")
-                game_state.pending_decision = "Select Items"
+                    decision_text = "Select Items"
+
+                # Resolve selectable instance IDs to card names for coaching
+                option_cards: list[str] = []
+                for oid in option_ids[:20]:  # cap to avoid perf issues
+                    obj = game_state.game_objects.get(oid)
+                    if obj and obj.grp_id:
+                        try:
+                            from arenamcp import server
+                            info = server.get_card_info(obj.grp_id)
+                            option_cards.append(info.get("name", f"Card#{obj.grp_id}"))
+                        except Exception:
+                            option_cards.append(f"Card#{obj.grp_id}")
+
+                logger.info(f"Captured Decision: {decision_text} ({num_to_select} items, type={selection_type}, options={option_cards or option_ids[:5]})")
+                game_state.pending_decision = decision_text
                 game_state.decision_timestamp = time.time()
                 game_state.decision_context = {
                     "type": selection_type,
@@ -1666,6 +1734,8 @@ def create_game_state_handler(game_state: GameState) -> Callable[[dict], None]:
                     "min": min_select,
                     "max": max_select,
                     "context_raw": context_data,
+                    "prior_prompt": prior_prompt or None,
+                    "option_cards": option_cards or None,
                 }
                 
             elif msg_type == "GREMessageType_GroupReq":
@@ -2072,6 +2142,7 @@ def create_game_state_handler(game_state: GameState) -> Callable[[dict], None]:
                         pass
                     else:
                         logger.debug(f"Clearing decision '{game_state.pending_decision}' due to {msg_type}")
+                        game_state.last_cleared_decision = game_state.pending_decision
                         game_state.pending_decision = None
                         game_state.decision_seat_id = None
                         game_state.decision_context = None

--- a/src/arenamcp/standalone.py
+++ b/src/arenamcp/standalone.py
@@ -52,6 +52,9 @@ from arenamcp.settings import get_settings
 LOG_DIR = Path.home() / ".arenamcp"
 LOG_DIR.mkdir(exist_ok=True)
 LOG_FILE = LOG_DIR / "standalone.log"
+WATCHDOG_SCREENSHOT_DIR = LOG_DIR / "watchdog_screenshots"
+WATCHDOG_SCREENSHOT_DIR.mkdir(exist_ok=True)
+WATCHDOG_SCREENSHOT_MAX = 20  # Keep last N screenshots (pruned at match end)
 
 file_handler = logging.FileHandler(LOG_FILE, mode='a', encoding='utf-8')
 file_handler.setLevel(logging.DEBUG)
@@ -404,6 +407,8 @@ class StandaloneCoach:
         self._vision_mapper: Optional[Any] = None  # VisionMapper (shared with autopilot)
         self._vlm_card_cache: dict[int, str] = {}  # grpId -> resolved name (persists per match)
         self._vlm_card_failures: set[int] = set()  # grpIds we already tried and failed
+        self._recent_gre_log: list[str] = []  # Ring buffer of recent GRE/decision log lines
+        self._recent_gre_log_max = 30
 
     def speak_advice(self, text: str, blocking: bool = True) -> None:
         """Speak advice using local Kokoro TTS."""
@@ -947,6 +952,7 @@ class StandaloneCoach:
                     self._game_end_handled = False
                     self._tempo_tracker.reset()
                     self._missed_decisions = []
+                    self._recent_gre_log.clear()
                     self._vlm_card_cache.clear()
                     self._vlm_card_failures.clear()
                     if self._coach:
@@ -987,6 +993,7 @@ class StandaloneCoach:
                     self._game_end_handled = False
                     self._tempo_tracker.reset()
                     self._missed_decisions = []
+                    self._recent_gre_log.clear()
                     self._vlm_card_cache.clear()
                     self._vlm_card_failures.clear()
                     if self._coach:
@@ -1077,6 +1084,23 @@ class StandaloneCoach:
                     if triggers:
                         logger.info(f"Triggers detected: {triggers}")
 
+                    # Feed the GRE log ring buffer for watchdog context
+                    _turn = curr_state.get("turn", {})
+                    _gre_line = (
+                        f"{datetime.now().strftime('%H:%M:%S')} "
+                        f"T{_turn.get('turn_number', 0)} "
+                        f"{_turn.get('phase', '')} "
+                        f"{_turn.get('step', '')} "
+                        f"active={_turn.get('active_player', '?')} "
+                        f"prio={_turn.get('priority_player', '?')} "
+                        f"decision={curr_state.get('pending_decision')} "
+                        f"last_cleared={curr_state.get('last_cleared_decision')} "
+                        f"triggers={triggers or 'none'}"
+                    )
+                    self._recent_gre_log.append(_gre_line)
+                    if len(self._recent_gre_log) > self._recent_gre_log_max:
+                        self._recent_gre_log.pop(0)
+
                     # TEMPO ANOMALY + VISION WATCHDOG
                     # Track game progression cadence. When normal pace (0.3-0.5s
                     # between state changes) stalls for >1.5s, trigger a vision
@@ -1087,9 +1111,25 @@ class StandaloneCoach:
                     _watchdog_cooldown = getattr(self, '_watchdog_last_fire', 0)
                     _watchdog_ready = (time.time() - _watchdog_cooldown) > 30
 
+                    # Only fire when WE have priority — stalls on opponent's
+                    # turn are normal (they're thinking) and shouldn't trigger
+                    # vision checks.
+                    _turn_info = curr_state.get("turn", {})
+                    _priority_player = _turn_info.get("priority_player", 0)
+                    _local_seat_wd = None
+                    for _p in curr_state.get("players", []):
+                        if _p.get("is_local"):
+                            _local_seat_wd = _p.get("seat_id")
+                            break
+                    _we_have_priority = (
+                        _local_seat_wd is not None
+                        and _priority_player == _local_seat_wd
+                    )
+
                     if (
                         stall_detected
                         and _watchdog_ready
+                        and _we_have_priority
                         and self._vision_mapper
                         and not curr_state.get("pending_decision")
                         and not triggers
@@ -1123,13 +1163,63 @@ class StandaloneCoach:
                                 png_bytes = buf.getvalue()
 
                                 decision = mapper.detect_pending_decision(png_bytes)
-                                if decision and decision.get("waiting_for_input"):
+
+                                # Build validation context for this detection
+                                _active_player = _turn_info.get("active_player", 0)
+                                _step = _turn_info.get("step", "")
+                                _is_our_turn = (_active_player == _local_seat_wd) if _local_seat_wd else None
+                                _last_gre_decision = curr_state.get("last_cleared_decision")  # set by gamestate
+
+                                # Save screenshot to rotating cache for verification
+                                _wd_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                                _wd_detected = bool(decision and decision.get("waiting_for_input"))
+                                _wd_label = "HIT" if _wd_detected else "MISS"
+                                _wd_filename = f"wd_{_wd_ts}_T{turn_num}_{_wd_label}.png"
+                                _wd_path = WATCHDOG_SCREENSHOT_DIR / _wd_filename
+                                try:
+                                    screenshot.save(str(_wd_path), format='PNG')
+                                    # Write sidecar metadata with validation context
+                                    _wd_meta = {
+                                        "timestamp": _wd_ts,
+                                        "turn": turn_num, "phase": phase, "step": _step,
+                                        "local_seat": _local_seat_wd,
+                                        "active_player": _active_player,
+                                        "priority_player": _priority_player,
+                                        "is_our_turn": _is_our_turn,
+                                        "we_have_priority": _we_have_priority,
+                                        "stall_s": round(stall_dur, 2),
+                                        "avg_tempo_s": round(avg, 3),
+                                        "detected": _wd_detected,
+                                        "last_gre_decision": _last_gre_decision,
+                                        "vlm_response": decision,
+                                        "log_context": list(self._recent_gre_log[-10:]),
+                                    }
+                                    (_wd_path.with_suffix(".json")).write_text(
+                                        json.dumps(_wd_meta, indent=2, default=str)
+                                    )
+                                    # Prune old screenshots beyond WATCHDOG_SCREENSHOT_MAX
+                                    _existing = sorted(
+                                        WATCHDOG_SCREENSHOT_DIR.glob("wd_*.png"),
+                                        key=lambda p: p.stat().st_mtime,
+                                    )
+                                    while len(_existing) > WATCHDOG_SCREENSHOT_MAX:
+                                        _old = _existing.pop(0)
+                                        _old.unlink(missing_ok=True)
+                                        _old.with_suffix(".json").unlink(missing_ok=True)
+                                except Exception as _save_err:
+                                    logger.debug(f"Failed to save watchdog screenshot: {_save_err}")
+
+                                if _wd_detected:
                                     d_type = decision.get("decision_type", "unknown")
                                     d_prompt = decision.get("prompt_text", "")
                                     d_conf = decision.get("confidence", 0)
                                     logger.info(
                                         f"VISION WATCHDOG: Detected unmapped decision! "
-                                        f"type={d_type}, prompt='{d_prompt}', conf={d_conf:.2f}"
+                                        f"type={d_type}, prompt='{d_prompt}', conf={d_conf:.2f} | "
+                                        f"seat={_local_seat_wd} active={_active_player} "
+                                        f"priority={_priority_player} "
+                                        f"our_turn={_is_our_turn} "
+                                        f"last_gre={_last_gre_decision}"
                                     )
                                     # Inject synthetic trigger
                                     curr_state["pending_decision"] = f"Vision: {d_type}"
@@ -1144,26 +1234,36 @@ class StandaloneCoach:
                                     self.ui.log(
                                         f"[bold magenta]Vision detected decision: "
                                         f"{d_prompt or d_type} "
-                                        f"(conf={d_conf:.0%}, {d_type})[/]"
+                                        f"(conf={d_conf:.0%}, {d_type}) "
+                                        f"— screenshot: {_wd_path.name}[/]"
                                     )
                                     # Record for end-of-match bug filing
                                     self._missed_decisions.append({
                                         "timestamp": datetime.now().isoformat(),
                                         "turn": turn_num,
                                         "phase": phase,
+                                        "step": _step,
                                         "decision_type": d_type,
                                         "prompt_text": d_prompt,
                                         "confidence": d_conf,
                                         "stall_duration_s": round(stall_dur, 2),
                                         "avg_tempo_s": round(avg, 3),
                                         "num_options": decision.get("num_options", 0),
+                                        "screenshot": _wd_filename,
+                                        "local_seat": _local_seat_wd,
+                                        "active_player": _active_player,
+                                        "priority_player": _priority_player,
+                                        "is_our_turn": _is_our_turn,
+                                        "last_gre_decision": _last_gre_decision,
+                                        "log_context": list(self._recent_gre_log[-10:]),
                                     })
                                 else:
                                     # VLM said no decision pending — show in TUI
                                     vlm_conf = decision.get("confidence", 0) if decision else 0
                                     self.ui.log(
                                         f"[dim]Watchdog: no decision detected "
-                                        f"(conf={vlm_conf:.0%})[/]"
+                                        f"(conf={vlm_conf:.0%}) "
+                                        f"— screenshot: {_wd_path.name}[/]"
                                     )
                             else:
                                 self.ui.log("[dim]Watchdog: MTGA window not found[/]")
@@ -2377,22 +2477,48 @@ class StandaloneCoach:
         ]
 
         for i, d in enumerate(missed, 1):
+            local_seat = d.get("local_seat", "?")
+            active = d.get("active_player", "?")
+            priority = d.get("priority_player", "?")
+            is_ours = d.get("is_our_turn")
+            turn_owner = "OURS" if is_ours else ("OPPONENT" if is_ours is False else "?")
+            last_gre = d.get("last_gre_decision", "none")
+            screenshot = d.get("screenshot", "")
+
             lines.append(f"#### Decision {i}")
             lines.append(f"- **Timestamp:** {d.get('timestamp', 'N/A')}")
             lines.append(f"- **Turn:** {d.get('turn', 'N/A')}")
             lines.append(f"- **Phase:** {d.get('phase', 'N/A')}")
+            lines.append(f"- **Step:** {d.get('step', '')}")
             lines.append(f"- **Type:** {d.get('decision_type', 'N/A')}")
             lines.append(f"- **Prompt:** {d.get('prompt_text', 'N/A')}")
             lines.append(f"- **Confidence:** {d.get('confidence', 'N/A')}")
             lines.append(f"- **Stall duration:** {d.get('stall_duration_s', 'N/A')}s")
             lines.append(f"- **Avg tempo:** {d.get('avg_tempo_s', 'N/A')}s")
             lines.append(f"- **Num options:** {d.get('num_options', 'N/A')}")
+            lines.append(f"- **Validation context:**")
+            lines.append(f"  - Local seat: {local_seat} | Active player: {active} | Priority: {priority}")
+            lines.append(f"  - Turn owner: **{turn_owner}** | We have priority: {priority == local_seat}")
+            lines.append(f"  - Last cleared GRE decision: `{last_gre}`")
+            if screenshot:
+                lines.append(f"  - Screenshot: `~/.arenamcp/watchdog_screenshots/{screenshot}`")
+            log_ctx = d.get("log_context", [])
+            if log_ctx:
+                # Show last 5 in GH issue (full 10 in local JSON sidecar)
+                trimmed = log_ctx[-5:]
+                lines.append(f"- **Game log ({len(trimmed)} of {len(log_ctx)} states before detection):**")
+                lines.append("```")
+                for log_line in trimmed:
+                    lines.append(log_line)
+                lines.append("```")
             lines.append("")
 
         lines.append("### Suggested Action")
         lines.append("")
-        lines.append("Add trigger mappings or GRE message handlers for the above decision types")
-        lines.append("so the coaching agent proactively offers advice at these points.")
+        lines.append("Review each detection's validation context. Detections where turn owner is OPPONENT")
+        lines.append("or where a GRE decision was recently cleared are likely **false positives**.")
+        lines.append("True positives (our turn, our priority, no recent GRE decision) indicate gaps")
+        lines.append("in the trigger/GRE message mapping.")
         lines.append("")
         lines.append("---")
         lines.append("*Auto-filed by ArenaMCP vision watchdog*")


### PR DESCRIPTION
## Summary
- Add coach/gamestate support for **sacrifice, exile, destroy, return, mill, explore, and choose_*** decision types with prompt templates and TUI rendering
- Watchdog now **only fires when we have priority** (eliminates false positives on opponent turns)
- Rotating **screenshot cache with JSON sidecar metadata** for debugging watchdog detections
- **GRE log ring buffer** and validation context (seat, priority, turn owner) included in auto-filed bug reports
- Version bump to `0.5.2`

## Test plan
- [ ] Start a match and verify new decision types (sacrifice, exile, etc.) display correctly in TUI
- [ ] Confirm watchdog does not fire during opponent's turn
- [ ] Check `~/.arenamcp/watchdog_screenshots/` for rotating screenshot + JSON metadata
- [ ] Verify `/update` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)