### PR TITLE
fix: unstick autopilot and harden backend/snapshot pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arenamcp"
-version = "0.5.1"
+version = "0.5.8"
 description = "Real-time MCP server bridging MTGA game logs to Claude for conversational game analysis"
 requires-python = ">=3.10"
 license = "MIT"

--- a/src/arenamcp/action_planner.py
+++ b/src/arenamcp/action_planner.py
@@ -120,8 +120,7 @@ output a JSON action plan that the autopilot will execute by clicking in the MTG
 CRITICAL RULES:
 - ONLY suggest actions that appear in the "Legal:" line. Never hallucinate actions.
 - ONE ACTION PER PLAN: You must suggest only ONE card to play or ONE button to click per JSON response.
-- EXCEPTION: For "declare_attackers" or "declare_blockers", you MUST list all creatures to attack/block with, AND THEN add a final action to click "1 attacker", "2 attackers", or "done" to confirm.
-  - Example: [{"action_type": "declare_attackers", "attacker_names": ["Elf", "Bear"]}, {"action_type": "click_button", "card_name": "done"}]
+- EXCEPTION: For "declare_attackers" or "declare_blockers", provide the full attacker/blocker set in one action. Do NOT add a separate "done" click action (the executor handles confirmation).
 - DO NOT sequence plays (e.g. do not suggest "play land" AND "cast spell"). Suggest the land, wait for the next trigger, then suggest the spell.
 - Creatures tagged [SS] have SUMMONING SICKNESS — they CANNOT attack.
 - Tokens are prefixed with * (e.g. "*Soldier"). Counters shown as [3P1P] = 3 +1/+1 counters.
@@ -189,9 +188,16 @@ class ActionPlanner:
             return ActionPlan(trigger=trigger)
 
         # Parse response
-        plan = self._parse_response(response)
+        plan = self._parse_response(response, legal_actions or [])
         plan.trigger = trigger
         plan.turn_number = game_state.get("turn", {}).get("turn_number", 0)
+
+        if not plan.actions:
+            fallback = self._fallback_plan(response, legal_actions or [])
+            fallback.trigger = trigger
+            fallback.turn_number = plan.turn_number
+            if fallback.actions:
+                plan = fallback
 
         logger.info(f"Planned {len(plan.actions)} actions: {plan.overall_strategy}")
         return plan
@@ -327,7 +333,7 @@ class ActionPlanner:
 
         return "\n".join(parts)
 
-    def _parse_response(self, response: str) -> ActionPlan:
+    def _parse_response(self, response: str, legal_actions: list[str]) -> ActionPlan:
         """Parse LLM response into an ActionPlan.
 
         Handles markdown fences, trailing commas, missing fields, and
@@ -362,6 +368,106 @@ class ActionPlanner:
                 plan.actions.append(action)
 
         return plan
+
+    def _fallback_plan(self, response: str, legal_actions: list[str]) -> ActionPlan:
+        """Fallback parser for non-JSON backend output.
+
+        Works across backends that may return plain text / markdown advice.
+        """
+        plan = ActionPlan()
+        if not legal_actions:
+            return plan
+
+        selected = self._match_legal_action_in_text(response, legal_actions)
+        if not selected:
+            selected = self._pick_preferred_legal_action(legal_actions)
+        if not selected:
+            return plan
+
+        action = self._legal_action_to_action(selected)
+        if not action:
+            return plan
+
+        plan.actions = [action]
+        plan.overall_strategy = f"Fallback from legal action: {selected}"
+        return plan
+
+    @staticmethod
+    def _match_legal_action_in_text(response: str, legal_actions: list[str]) -> Optional[str]:
+        text = (response or "").lower()
+        if not text:
+            return None
+        # Prefer longer legal actions to avoid matching generic fragments first.
+        for legal in sorted(legal_actions, key=len, reverse=True):
+            if legal.lower() in text:
+                return legal
+        return None
+
+    @staticmethod
+    def _pick_preferred_legal_action(legal_actions: list[str]) -> Optional[str]:
+        """Pick a deterministic fallback action when model output is invalid."""
+        if not legal_actions:
+            return None
+
+        def score(action: str) -> int:
+            a = action.lower().strip()
+            if a.startswith("play land:"):
+                return 100
+            if a.startswith("cast "):
+                return 90
+            if a.startswith("declare attackers:") or a.startswith("attack with:"):
+                return 80
+            if a.startswith("activate "):
+                return 70
+            if a.startswith("select target:"):
+                return 60
+            if "choose: play" in a or "choose: draw" in a:
+                return 55
+            if "done" in a or "auto-pay" in a:
+                return 40
+            if "pass" in a or "wait" in a:
+                return 30
+            return 10
+
+        return max(legal_actions, key=score)
+
+    def _legal_action_to_action(self, legal_action: str) -> Optional[GameAction]:
+        """Convert a rules-engine legal action string into a GameAction."""
+        act = (legal_action or "").strip()
+        lower = act.lower()
+
+        if lower.startswith("play land:"):
+            return GameAction(
+                action_type=ActionType.PLAY_LAND,
+                card_name=act.split(":", 1)[1].strip(),
+            )
+        if lower.startswith("cast "):
+            return GameAction(action_type=ActionType.CAST_SPELL, card_name=act[5:].strip())
+        if lower.startswith("activate "):
+            return GameAction(action_type=ActionType.ACTIVATE_ABILITY, card_name=act[9:].strip())
+        if lower.startswith("declare attackers:"):
+            names = [n.strip() for n in act.split(":", 1)[1].split(",") if n.strip()]
+            return GameAction(action_type=ActionType.DECLARE_ATTACKERS, attacker_names=names)
+        if lower.startswith("attack with:"):
+            names = [n.strip() for n in act.split(":", 1)[1].split(",") if n.strip()]
+            return GameAction(action_type=ActionType.DECLARE_ATTACKERS, attacker_names=names)
+        if lower.startswith("select target:"):
+            return GameAction(
+                action_type=ActionType.SELECT_TARGET,
+                target_names=[act.split(":", 1)[1].strip()],
+            )
+        if "choose: play" in lower:
+            return GameAction(action_type=ActionType.CHOOSE_STARTING_PLAYER, play_or_draw="play")
+        if "choose: draw" in lower:
+            return GameAction(action_type=ActionType.CHOOSE_STARTING_PLAYER, play_or_draw="draw")
+        if "done" in lower:
+            return GameAction(action_type=ActionType.CLICK_BUTTON, card_name="done")
+        if "resolve" in lower:
+            return GameAction(action_type=ActionType.RESOLVE)
+        if "pass" in lower or "wait" in lower:
+            return GameAction(action_type=ActionType.PASS_PRIORITY)
+
+        return None
 
     def _parse_action(self, data: dict[str, Any]) -> Optional[GameAction]:
         """Parse a single action dict into a GameAction."""

--- a/src/arenamcp/autopilot.py
+++ b/src/arenamcp/autopilot.py
@@ -517,6 +517,23 @@ class AutopilotEngine:
                     self._state = AutopilotState.IDLE
                     return False
 
+                # Some backends still emit an extra "click done" after actions
+                # whose handlers already click Done internally.
+                if (
+                    i > 0
+                    and action.action_type == ActionType.CLICK_BUTTON
+                    and action.card_name.lower().strip() == "done"
+                    and plan.actions[i - 1].action_type
+                    in (
+                        ActionType.DECLARE_ATTACKERS,
+                        ActionType.DECLARE_BLOCKERS,
+                        ActionType.SELECT_N,
+                        ActionType.ORDER_BLOCKERS,
+                    )
+                ):
+                    logger.info("Skipping redundant Done action after auto-confirming handler")
+                    continue
+
                 self._current_action_idx = i
 
                 action_text = f"[{i+1}/{len(plan.actions)}] {action}"

--- a/src/arenamcp/backend_detect.py
+++ b/src/arenamcp/backend_detect.py
@@ -38,7 +38,7 @@ def _which_cli(name: str) -> Optional[str]:
 CUSTOM_ENDPOINTS_FILE = Path.home() / ".arenamcp" / "endpoints.json"
 
 # Preferred auto-select order (first available wins)
-_AUTO_PRIORITY = ["ollama", "claude-code", "gemini-cli", "codex-cli"]
+_AUTO_PRIORITY = ["claude-code", "gemini-cli", "codex-cli", "ollama"]
 
 # Default Ollama model
 DEFAULT_OLLAMA_MODEL = "llama3.2:latest"

--- a/src/arenamcp/coach.py
+++ b/src/arenamcp/coach.py
@@ -683,7 +683,7 @@ class CodexCliBackend:
         combined = (
             f"SYSTEM INSTRUCTIONS:\n{system_prompt}\n\nUSER MESSAGE:\n{user_message}"
         )
-        args = self._build_args() + ["-q", combined]
+        args = self._build_args()
         if self.model:
             args += ["--model", self.model]
 
@@ -694,13 +694,10 @@ class CodexCliBackend:
         env = {k: v for k, v in os.environ.items()
                if k not in ("OPENAI_API_KEY",)}
 
-        try:
-            creationflags = 0
-            if os.name == "nt":
-                creationflags = subprocess.CREATE_NO_WINDOW
-
-            result = subprocess.run(
-                args,
+        def _run(run_args: list[str], input_text: Optional[str]) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                run_args,
+                input=input_text,
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -708,6 +705,48 @@ class CodexCliBackend:
                 creationflags=creationflags,
                 env=env,
             )
+
+        try:
+            creationflags = 0
+            if os.name == "nt":
+                creationflags = subprocess.CREATE_NO_WINDOW
+
+            # Compatibility matrix across Codex CLI variants:
+            # - Some support `-q -` (stdin)
+            # - Some support `-q <prompt>`
+            # - Some reject `-q` entirely and accept stdin/plain args only
+            attempts: list[tuple[list[str], Optional[str], str]] = [
+                (args + ["-q", "-"], combined, "q-stdin"),
+                (args + ["-q", combined], None, "q-inline"),
+                (args + [combined], None, "positional-prompt"),
+                (args, combined, "stdin-no-flag"),
+            ]
+
+            errors: list[str] = []
+            result: Optional[subprocess.CompletedProcess[str]] = None
+
+            for run_args, input_text, label in attempts:
+                # Skip gigantic inline/positional variants on Windows.
+                if os.name == "nt" and input_text is None and len(combined) > 7000:
+                    continue
+                try:
+                    result = _run(run_args, input_text)
+                except subprocess.TimeoutExpired:
+                    errors.append(f"{label}: timed out")
+                    continue
+
+                out = (result.stdout or "").strip()
+                err = (result.stderr or "").strip()
+                if result.returncode == 0 and out:
+                    break
+
+                msg = (err or out or f"exit code {result.returncode}").strip()
+                errors.append(f"{label}: {msg}")
+                result = None
+
+            if result is None:
+                detail = " | ".join(errors[-3:]) if errors else "unknown invocation failure"
+                return f"Error: Codex CLI failed: {detail}"
         except FileNotFoundError:
             if self.progress_callback:
                 self.progress_callback("")
@@ -732,6 +771,7 @@ class CodexCliBackend:
             return f"Error: Codex CLI failed: {err}"
 
         return (result.stdout or "").strip()
+
 
     def list_models(self) -> list[str]:
         return []
@@ -1048,6 +1088,10 @@ _CLI_MODELS: dict[str, list[tuple[str, Optional[str]]]] = {
     ],
     "codex-cli": [
         ("Default", None),
+        ("GPT-5.3 Codex", "gpt-5.3-codex"),
+        ("GPT-5 Codex", "gpt-5-codex"),
+        ("GPT-5 Mini", "gpt-5-mini"),
+        ("GPT-5 Nano", "gpt-5-nano"),
         ("o4-mini", "o4-mini"),
         ("GPT-4.1", "gpt-4.1"),
     ],
@@ -4320,6 +4364,7 @@ class CoachEngine:
                 turn = game_state.get("turn", {})
                 phase = turn.get("phase", "")
                 step = turn.get("step", "")
+                pending_decision = str(game_state.get("pending_decision", "") or "").lower()
                 players = game_state.get("players", [])
                 local_player = next((p for p in players if p.get("is_local")), None)
                 local_seat = local_player.get("seat_id") if local_player else None
@@ -4336,13 +4381,21 @@ class CoachEngine:
                 ):
                     score += 90
                 if "block with" in act and "combat" in phase and "declareblock" in step:
-                    score += 90
+                    score += 120
+                if "block with" in act and "declare blockers" in pending_decision:
+                    score += 120
 
                 # Casting is generally higher priority than activating
                 if act.startswith("cast "):
                     score += 60
                 if act.startswith("activate "):
                     score += 40
+                if act.startswith("activate ") and (
+                    ("combat" in phase and "declareblock" in step)
+                    or ("declare blockers" in pending_decision)
+                ):
+                    # During blocker declaration, avoid replacing with activations.
+                    score -= 100
 
                 # Penalize "wait/pass" actions if anything else exists
                 if "wait" in act or "pass priority" in act:
@@ -4402,7 +4455,25 @@ class CoachEngine:
 
             if not matches:
                 # Force to best legal action to avoid illegal recommendations
-                best = max(legal_actions, key=_score_action)
+                turn = game_state.get("turn", {})
+                phase = str(turn.get("phase", "") or "").lower()
+                step = str(turn.get("step", "") or "").lower()
+                pending_decision = str(game_state.get("pending_decision", "") or "").lower()
+
+                in_declare_blockers = (
+                    ("combat" in phase and "declareblock" in step)
+                    or ("declare blockers" in pending_decision)
+                )
+                if in_declare_blockers:
+                    blocker_actions = [
+                        a for a in legal_actions if a.lower().startswith("block with:")
+                    ]
+                    if blocker_actions:
+                        best = max(blocker_actions, key=_score_action)
+                    else:
+                        best = max(legal_actions, key=_score_action)
+                else:
+                    best = max(legal_actions, key=_score_action)
                 logger.info(f"Replaced illegal advice with legal action: {best} (original: {advice[:80]})")
                 advice = best
         else:

--- a/src/arenamcp/gamestate.py
+++ b/src/arenamcp/gamestate.py
@@ -4,6 +4,7 @@ This module provides the GameState class that maintains a complete
 snapshot of the current game state from parsed MTGA log events.
 """
 
+import copy
 import json
 import logging
 import threading
@@ -225,6 +226,11 @@ class GameState:
         # post-match analysis has the final board state even after reset clears it.
         self._pre_reset_snapshot: Optional[dict] = None
 
+        # Published immutable snapshot for lock-safe readers
+        self._state_lock = threading.RLock()
+        self._published_snapshot: dict[str, Any] = {}
+        self.publish_snapshot()
+
     def reset(self) -> None:
         """Reset the game state to essentially empty (for new match)."""
         logger.info("Resetting GameState for new match")
@@ -261,6 +267,7 @@ class GameState:
         self.recent_events = []
         self.damage_taken = {}
         self.revealed_cards = {}
+        self.publish_snapshot()
         # NOTE: last_game_result is intentionally NOT cleared here.
         # The coaching loop reads it after reset() to detect the match outcome.
         # It is cleared by the coaching loop once consumed.
@@ -462,76 +469,108 @@ class GameState:
         Returns list of dicts with 'step', 'active_player', 'turn' keys.
         This allows catching fast combat phases that happen between polls.
         """
-        return self._pending_combat_steps.copy()
+        snap = self.get_published_snapshot()
+        return list(snap.get("pending_combat_steps", []))
 
-    def get_snapshot(self) -> dict:
-        """Get a complete, serializable snapshot of the current game state.
-        
-        This 'flattens' the state into a single JSON-ready dictionary, 
-        serving as the 'State Anchor' for the middleware.
+    def _build_raw_snapshot_locked(self) -> dict:
+        """Build a complete serializable snapshot from mutable state.
+
+        Must be called with ``self._state_lock`` held.
         """
-        # Resolve owners
-        local_player = self.players.get(self.local_seat_id) if self.local_seat_id else None
         opponent_seat = self.opponent_seat_id
-        
-        # Enrich objects with card names for TUI display
-        def enrich_obj(obj):
-            """Add card name to object dict for TUI."""
-            data = obj.to_dict()
-            # Lazy import to avoid circular dependency
-            from arenamcp import server
-            card_info = server.get_card_info(obj.grp_id)
-            data["name"] = card_info.get("name", f"Unknown ({obj.grp_id})")
-            data["type_line"] = card_info.get("type_line", "")
-            return data
-        
-        # Serialize zones of interest
-        # We group by meaningful logical zones rather than just raw zone IDs
-        
-        # Manually serialize players to include is_local flag for TUI
+
         players_list = []
         for p in self.players.values():
             p_dict = p.to_dict()
             p_dict["is_local"] = (p.seat_id == self.local_seat_id)
             players_list.append(p_dict)
-            
-        # Serialize revealed cards (sets -> lists for JSON)
+
         revealed = {}
         for seat_id, grp_ids in self.revealed_cards.items():
             revealed[seat_id] = list(grp_ids)
 
-        snapshot = {
+        return {
             "match_id": self.match_id,
             "local_seat_id": self.local_seat_id,
             "opponent_seat_id": opponent_seat,
             "turn_info": self.turn_info.to_dict(),
             "players": players_list,
             "zones": {
-                "battlefield": [enrich_obj(obj) for obj in self.battlefield],
-                "my_hand": [enrich_obj(obj) for obj in self.hand] if self.local_seat_id else [],
+                "battlefield": [obj.to_dict() for obj in self.battlefield],
+                "my_hand": [obj.to_dict() for obj in self.hand] if self.local_seat_id else [],
                 "opponent_hand_count": len(self.get_objects_in_zone(ZoneType.HAND, opponent_seat)) if opponent_seat else 0,
-                "stack": [enrich_obj(obj) for obj in self.stack],
-                "graveyard": [enrich_obj(obj) for obj in self.graveyard],
-                "exile": [enrich_obj(obj) for obj in self.get_objects_in_zone(ZoneType.EXILE)],
-                "command": [enrich_obj(obj) for obj in self.command],
+                "stack": [obj.to_dict() for obj in self.stack],
+                "graveyard": [obj.to_dict() for obj in self.graveyard],
+                "exile": [obj.to_dict() for obj in self.get_objects_in_zone(ZoneType.EXILE)],
+                "command": [obj.to_dict() for obj in self.command],
                 "library_count": len(self.get_objects_in_zone(ZoneType.LIBRARY, self.local_seat_id)) if self.local_seat_id else "?",
             },
             "pending_decision": self.pending_decision,
             "decision_seat_id": self.decision_seat_id,
             "decision_context": self.decision_context,
             "last_cleared_decision": self.last_cleared_decision,
-            "legal_actions": self.legal_actions,
-            # Annotation-derived data
-            "recent_events": self.recent_events[-10:],  # Last 10 events for display
-            "damage_taken": self.damage_taken,
+            "legal_actions": list(self.legal_actions),
+            "pending_combat_steps": self._pending_combat_steps.copy(),
+            "recent_events": self.recent_events[-10:],
+            "damage_taken": dict(self.damage_taken),
             "revealed_cards": revealed,
             "last_game_result": self.last_game_result,
+            "deck_cards": list(self.deck_cards),
         }
-        return snapshot
+
+    def publish_snapshot(self) -> None:
+        """Publish a consistent immutable snapshot for readers."""
+        with self._state_lock:
+            self._published_snapshot = self._build_raw_snapshot_locked()
+
+    def get_published_snapshot(self) -> dict:
+        """Return a deep-copied immutable snapshot."""
+        with self._state_lock:
+            return copy.deepcopy(self._published_snapshot)
+
+    def get_snapshot(self) -> dict:
+        """Get a TUI-friendly snapshot with lazy card-name enrichment.
+
+        Reads only from the published immutable snapshot to avoid mixed-frame
+        reads while parser updates are in flight.
+        """
+        raw = self.get_published_snapshot()
+
+        def enrich_obj(data: dict) -> dict:
+            enriched = dict(data)
+            grp_id = int(enriched.get("grp_id", 0) or 0)
+            if grp_id:
+                try:
+                    from arenamcp import server
+                    card_info = server.get_card_info(grp_id)
+                    enriched["name"] = card_info.get("name", f"Unknown ({grp_id})")
+                    enriched["type_line"] = card_info.get("type_line", "")
+                except Exception:
+                    enriched["name"] = f"Unknown ({grp_id})"
+                    enriched["type_line"] = ""
+            else:
+                enriched.setdefault("name", "Unknown")
+                enriched.setdefault("type_line", "")
+            return enriched
+
+        zones = raw.get("zones", {})
+        raw["zones"] = {
+            "battlefield": [enrich_obj(o) for o in zones.get("battlefield", [])],
+            "my_hand": [enrich_obj(o) for o in zones.get("my_hand", [])],
+            "opponent_hand_count": zones.get("opponent_hand_count", 0),
+            "stack": [enrich_obj(o) for o in zones.get("stack", [])],
+            "graveyard": [enrich_obj(o) for o in zones.get("graveyard", [])],
+            "exile": [enrich_obj(o) for o in zones.get("exile", [])],
+            "command": [enrich_obj(o) for o in zones.get("command", [])],
+            "library_count": zones.get("library_count", "?"),
+        }
+        return raw
 
     def clear_pending_combat_steps(self) -> None:
         """Clear the pending combat steps after processing."""
-        self._pending_combat_steps.clear()
+        with self._state_lock:
+            self._pending_combat_steps.clear()
+            self._published_snapshot = self._build_raw_snapshot_locked()
     
     def get_seat_source_name(self) -> str:
         """Get human-readable name of the seat ID source."""
@@ -543,7 +582,7 @@ class GameState:
 
     def set_local_seat_id(self, seat_id: int, source: int = 2) -> None:
         """Explicitly set the local player's seat ID if source priority allows.
-        
+
         Source levels:
         1: Inferred (from hand visibility)
         2: System (from MatchCreated events)
@@ -553,29 +592,32 @@ class GameState:
             seat_id: The local player's seat ID.
             source: Priority level (default 2=System).
         """
-        # Only overwrite if new source is >= current source
-        if source >= self._seat_source:
-            self.local_seat_id = seat_id
-            self._seat_source = source
-            source_name = self.get_seat_source_name()
-            logger.info(f"Set local_seat_id to {seat_id} (Source: {source_name})")
-        else:
-            logger.info(f"Ignored seat update to {seat_id} (Source {source} < Current {self._seat_source})")
+        with self._state_lock:
+            if source >= self._seat_source:
+                self.local_seat_id = seat_id
+                self._seat_source = source
+                source_name = self.get_seat_source_name()
+                logger.info(f"Set local_seat_id to {seat_id} (Source: {source_name})")
+            else:
+                logger.info(f"Ignored seat update to {seat_id} (Source {source} < Current {self._seat_source})")
+            self._published_snapshot = self._build_raw_snapshot_locked()
 
     def reset_local_player(self, force: bool = False) -> None:
         """Reset local_seat_id logic.
-        
+
         Args:
             force: If True, reset EVERYTHING (used for full restart).
-                   If False, only reset INFERRED (1) sources. 
+                   If False, only reset INFERRED (1) sources.
                    System (2) and User (3) are preserved across game resets (e.g. BO3).
         """
-        if force or self._seat_source <= 1:
-            self.local_seat_id = None
-            self._seat_source = 0
-            logger.info("Reset local_seat_id (cleared)")
-        else:
-            logger.info(f"Preserving local_seat_id={self.local_seat_id} (Source: {self.get_seat_source_name()})")
+        with self._state_lock:
+            if force or self._seat_source <= 1:
+                self.local_seat_id = None
+                self._seat_source = 0
+                logger.info("Reset local_seat_id (cleared)")
+            else:
+                logger.info(f"Preserving local_seat_id={self.local_seat_id} (Source: {self.get_seat_source_name()})")
+            self._published_snapshot = self._build_raw_snapshot_locked()
 
     def ensure_local_seat_id(self) -> None:
         """Ensure local_seat_id is set by inferring from existing data.
@@ -622,45 +664,48 @@ class GameState:
         Args:
             message: The GameStateMessage dict from parsed log event.
         """
-        # Extract type (full vs diff) - not currently used but logged
-        msg_type = message.get("type", "Unknown")
-        logger.debug(f"Processing GameStateMessage type: {msg_type}")
+        with self._state_lock:
+            # Extract type (full vs diff) - not currently used but logged
+            msg_type = message.get("type", "Unknown")
+            logger.debug(f"Processing GameStateMessage type: {msg_type}")
 
-        # Update turn info FIRST so that zone updates use the correct turn number
-        turn_info = message.get("turnInfo")
-        if turn_info:
-            self._update_turn_info(turn_info)
+            # Update turn info FIRST so that zone updates use the correct turn number
+            turn_info = message.get("turnInfo")
+            if turn_info:
+                self._update_turn_info(turn_info)
 
-        # Update game objects
-        game_objects = message.get("gameObjects", [])
-        for obj_data in game_objects:
-            self._update_game_object(obj_data)
+            # Update game objects
+            game_objects = message.get("gameObjects", [])
+            for obj_data in game_objects:
+                self._update_game_object(obj_data)
 
-        # Update zones
-        zones = message.get("zones", [])
-        for zone_data in zones:
-            self._update_zone(zone_data)
+            # Update zones
+            zones = message.get("zones", [])
+            for zone_data in zones:
+                self._update_zone(zone_data)
 
-        # Update players
-        players = message.get("players", [])
-        for player_data in players:
-            self._update_player(player_data)
-        
-        # Ensure lands_played is correct even when Arena omits player data
-        self._infer_lands_played()
+            # Update players
+            players = message.get("players", [])
+            for player_data in players:
+                self._update_player(player_data)
 
-        # Process annotations (damage, counters, zone transfers, reveals, etc.)
-        annotations = message.get("annotations", [])
-        if annotations:
-            self._process_annotations(annotations)
+            # Ensure lands_played is correct even when Arena omits player data
+            self._infer_lands_played()
 
-        # Clear untap step flag after processing all objects in this message
-        self._in_untap_step = False
+            # Process annotations (damage, counters, zone transfers, reveals, etc.)
+            annotations = message.get("annotations", [])
+            if annotations:
+                self._process_annotations(annotations)
 
-        # MEMORY OPTIMIZATION: Periodically clean up stale objects
-        # Objects can accumulate when tokens die or cards are exiled from exile
-        if len(self.game_objects) > 200:  # Only cleanup when dict gets large
-            self._cleanup_stale_objects()
+            # Clear untap step flag after processing all objects in this message
+            self._in_untap_step = False
+
+            # MEMORY OPTIMIZATION: Periodically clean up stale objects
+            # Objects can accumulate when tokens die or cards are exiled from exile
+            if len(self.game_objects) > 200:  # Only cleanup when dict gets large
+                self._cleanup_stale_objects()
+
+            self._published_snapshot = self._build_raw_snapshot_locked()
 
     def _update_game_object(self, obj_data: dict) -> None:
         """Update or create a game object from message data.
@@ -2157,6 +2202,8 @@ def create_game_state_handler(game_state: GameState) -> Callable[[dict], None]:
         if "gameObjects" in payload or "zones" in payload or "players" in payload:
             game_state.update_from_message(payload)
         
+        game_state.publish_snapshot()
+
         # Record frame if recording is active
         try:
             from arenamcp.match_validator import record_frame

--- a/src/arenamcp/server.py
+++ b/src/arenamcp/server.py
@@ -799,43 +799,66 @@ def get_game_state() -> dict[str, Any]:
     # Ensure local player is detected before serializing
     game_state.ensure_local_seat_id()
 
-    # Serialize turn info
+    # Read from published immutable snapshot to avoid mixed-frame reads
+    snap = game_state.get_published_snapshot()
+    turn_info = snap.get("turn_info", {})
+    zones = snap.get("zones", {})
+    players = list(snap.get("players", []))
+
     turn = {
-        "turn_number": game_state.turn_info.turn_number,
-        "active_player": game_state.turn_info.active_player,
-        "priority_player": game_state.turn_info.priority_player,
-        "phase": game_state.turn_info.phase,
-        "step": game_state.turn_info.step,
-        "pending_combat_steps": game_state.get_pending_combat_steps(),
+        "turn_number": turn_info.get("turn_number", 0),
+        "active_player": turn_info.get("active_player", 0),
+        "priority_player": turn_info.get("priority_player", 0),
+        "phase": turn_info.get("phase", ""),
+        "step": turn_info.get("step", ""),
+        "pending_combat_steps": list(snap.get("pending_combat_steps", [])),
     }
 
-    # Serialize players
-    players = []
-    for player in game_state.players.values():
-        players.append({
-            "seat_id": player.seat_id,
-            "life_total": player.life_total,
-            "mana_pool": player.mana_pool,
-            "is_local": player.seat_id == game_state.local_seat_id,
-            "lands_played": player.lands_played,
-        })
+    def _serialize_snapshot_obj(obj: dict[str, Any]) -> dict[str, Any]:
+        grp_id = int(obj.get("grp_id", 0) or 0)
+        enriched = enrich_with_oracle_text(grp_id)
+        result = {
+            "instance_id": obj.get("instance_id"),
+            "grp_id": grp_id,
+            "name": enriched.get("name") or f"Unknown ({grp_id})",
+            "oracle_text": enriched.get("oracle_text") or "",
+            "type_line": enriched.get("type_line") or "",
+            "mana_cost": enriched.get("mana_cost") or "",
+            "owner_seat_id": obj.get("owner_seat_id"),
+            "controller_seat_id": obj.get("controller_seat_id"),
+            "power": obj.get("power"),
+            "toughness": obj.get("toughness"),
+            "is_tapped": obj.get("is_tapped", False),
+            "is_attacking": obj.get("is_attacking", False),
+            "is_blocking": obj.get("is_blocking", False),
+            "card_types": obj.get("card_types", []),
+            "subtypes": obj.get("subtypes", []),
+            "object_kind": obj.get("object_kind", "UNKNOWN"),
+            "counters": obj.get("counters", {}),
+        }
+        if obj.get("parent_instance_id") is not None:
+            result["parent_instance_id"] = obj.get("parent_instance_id")
+        return result
 
-    # Serialize zones with oracle text enrichment
     battlefield = [
-        _serialize_game_object(obj) for obj in game_state.battlefield
-        if obj.object_kind != GameObjectKind.ABILITY
+        _serialize_snapshot_obj(o)
+        for o in zones.get("battlefield", [])
+        if o.get("object_kind") != "ABILITY"
     ]
-    hand = [_serialize_game_object(obj) for obj in game_state.hand]
-    graveyard = [_serialize_game_object(obj) for obj in game_state.graveyard]
-    stack = [_serialize_game_object(obj) for obj in game_state.stack]
-    exile = [_serialize_game_object(obj) for obj in game_state.get_objects_in_zone(ZoneType.EXILE)]
-    command = [_serialize_game_object(obj) for obj in game_state.command]
+    hand = [_serialize_snapshot_obj(o) for o in zones.get("my_hand", [])]
+    graveyard = [_serialize_snapshot_obj(o) for o in zones.get("graveyard", [])]
+    stack = [_serialize_snapshot_obj(o) for o in zones.get("stack", [])]
+    exile = [_serialize_snapshot_obj(o) for o in zones.get("exile", [])]
+    command = [_serialize_snapshot_obj(o) for o in zones.get("command", [])]
 
     # Save match state on turn changes for recovery
     _save_match_state_if_needed()
 
+    local_seat_id = snap.get("local_seat_id")
+    decision_seat_id = snap.get("decision_seat_id")
+
     return {
-        "match_id": game_state.match_id,
+        "match_id": snap.get("match_id"),
         "turn": turn,
         "players": players,
         "battlefield": battlefield,
@@ -844,12 +867,11 @@ def get_game_state() -> dict[str, Any]:
         "stack": stack,
         "exile": exile,
         "command": command,
-        "pending_decision": game_state.pending_decision if game_state.decision_seat_id == game_state.local_seat_id else None,
-        "decision_context": game_state.decision_context if game_state.decision_seat_id == game_state.local_seat_id else None,
-        "deck_cards": game_state.deck_cards,
-        "damage_taken": dict(game_state.damage_taken),
+        "pending_decision": snap.get("pending_decision") if decision_seat_id == local_seat_id else None,
+        "decision_context": snap.get("decision_context") if decision_seat_id == local_seat_id else None,
+        "deck_cards": list(snap.get("deck_cards", [])),
+        "damage_taken": dict(snap.get("damage_taken", {})),
     }
-
 
 def clear_pending_combat_steps() -> None:
     """Clear pending combat steps after they've been processed.

--- a/src/arenamcp/standalone.py
+++ b/src/arenamcp/standalone.py
@@ -397,12 +397,16 @@ class StandaloneCoach:
         # Match tracking for LLM context
         self._match_number: int = 0  # Incremented on each new match
 
+        # Rolling in-match advice history (used for post-match analysis)
+        self._advice_history: list[dict] = []
+
         # Post-match analysis
         self._saved_advice_history: list[dict] = []
         self._saved_missed_decisions: list[dict] = []
         self._last_match_result: Optional[str] = None
         self._last_match_final_state: Optional[dict] = None
         self._game_end_handled: bool = False  # Prevents duplicate triggers
+        self._last_game_end_check_error: str = ""
 
         # Vision watchdog: tempo anomaly detection + missed decision tracking
         self._tempo_tracker = _TempoTracker()
@@ -412,6 +416,41 @@ class StandaloneCoach:
         self._vlm_card_failures: set[int] = set()  # grpIds we already tried and failed
         self._recent_gre_log: list[str] = []  # Ring buffer of recent GRE/decision log lines
         self._recent_gre_log_max = 30
+
+        # Backend health status (deduped to avoid noisy UI writes)
+        self._last_backend_status: str = ""
+        self._last_backend_error: str = ""
+
+        # Autopilot decision backstop: force decision triggers when parser noise
+        # causes missed trigger edges after an executed action.
+        self._last_forced_decision_sig: Optional[str] = None
+        self._last_forced_decision_ts: float = 0.0
+
+    def _set_backend_status(self, status: str) -> None:
+        """Update backend status in UI only when the value actually changes."""
+        if status == self._last_backend_status:
+            return
+        self._last_backend_status = status
+        try:
+            self.ui.status("BACKEND", status)
+        except Exception:
+            pass
+
+    def _report_backend_failure(self, detail: str) -> None:
+        """Surface backend failures in UI/logs with deduping."""
+        self._set_backend_status(f"ERROR ({self.backend_name})")
+        short = (detail or "backend failure").strip().replace("\n", " ")[:180]
+        if short and short != self._last_backend_error:
+            self._last_backend_error = short
+            try:
+                self.ui.log(f"\n[BACKEND] {short}\n")
+            except Exception:
+                pass
+
+    def _mark_backend_healthy(self) -> None:
+        """Clear backend failure status after successful responses."""
+        self._last_backend_error = ""
+        self._set_backend_status(f"OK ({self.backend_name})")
 
     @staticmethod
     def _is_garbled(text: str, threshold: float = 0.4) -> bool:
@@ -938,7 +977,10 @@ class StandaloneCoach:
                             daemon=True,
                         ).start()
                 except Exception as e:
-                    logger.debug(f"Game-end event check failed: {e}")
+                    msg = str(e)
+                    if msg != self._last_game_end_check_error:
+                        self._last_game_end_check_error = msg
+                        logger.warning(f"Game-end event check failed: {e}")
 
                 # SECONDARY: Detect match boundary via match_id change.
                 # Two cases:
@@ -1097,6 +1139,31 @@ class StandaloneCoach:
                         logger.debug(f"Draft detection error: {e}")
 
                     triggers = self._trigger.check_triggers(prev_state, curr_state)
+
+                    # BACKSTOP: If a pending decision exists but trigger detection
+                    # missed it (e.g. malformed GRE chunks), force a
+                    # decision_required trigger so autopilot can continue after
+                    # the first move.
+                    pending_now = curr_state.get("pending_decision")
+                    if self._autopilot_enabled and self._autopilot and pending_now:
+                        if "decision_required" not in triggers:
+                            dec_ctx = curr_state.get("decision_context") or {}
+                            dec_type = dec_ctx.get("type", "")
+                            legal = curr_state.get("legal_actions", []) or []
+                            sig = f"{pending_now}|{dec_type}|{len(legal)}"
+                            now = time.time()
+                            if (
+                                sig != self._last_forced_decision_sig
+                                or (now - self._last_forced_decision_ts) > 2.0
+                            ):
+                                triggers.append("decision_required")
+                                self._last_forced_decision_sig = sig
+                                self._last_forced_decision_ts = now
+                                logger.info(
+                                    f"Autopilot backstop: forced decision_required for '{pending_now}'"
+                                )
+                    else:
+                        self._last_forced_decision_sig = None
 
                     # Debug: Log trigger results
                     if triggers:
@@ -1470,7 +1537,11 @@ class StandaloneCoach:
                         # NOTE: "new_turn" is excluded — when the player's turn starts, they
                         # always need advice even if a stale ability is still on the stack.
                         stack = curr_state.get("stack", [])
-                        if stack and trigger in ("land_played", "spell_resolved", "priority_gained"):
+                        if (
+                            stack
+                            and trigger in ("land_played", "spell_resolved", "priority_gained")
+                            and not has_pending_decision
+                        ):
                             has_instants = self._trigger._has_castable_instants(curr_state)
                             if not has_instants:
                                 logger.info(f"Quiet: {trigger} (stack active, no responses)")
@@ -1482,7 +1553,7 @@ class StandaloneCoach:
                         # opponent's board/plan, not a "can you respond?" check. Players always
                         # benefit from knowing what the opponent is doing.
                         QUIET_TRIGGERS = {"stack_spell_yours", "stack_spell_opponent", "priority_gained", "spell_resolved"}
-                        if trigger in QUIET_TRIGGERS:
+                        if trigger in QUIET_TRIGGERS and not has_pending_decision:
                             has_instants = self._trigger._has_castable_instants(curr_state)
                             stack = curr_state.get("stack", [])
 
@@ -1620,6 +1691,7 @@ class StandaloneCoach:
                                     f"Empty advice response ({self._consecutive_errors}/{max_errors}) — "
                                     "model timeout or backend hung"
                                 )
+                                self._report_backend_failure("Empty advice response (model timeout or backend hung)")
                                 if self._consecutive_errors >= max_errors:
                                     # Try restarting the backend process first
                                     logger.warning("Too many empty responses, restarting backend...")
@@ -1650,6 +1722,7 @@ class StandaloneCoach:
                                 or (_is_err(advice) and len(advice) < 200)
                             ):
                                 logger.warning(f"Suppressing error advice from TTS: {advice[:80]}")
+                                self._report_backend_failure(advice)
                                 self.ui.error(advice)
                             else:
                                 # Advice was successfully generated — NOW update dedup state
@@ -1657,6 +1730,7 @@ class StandaloneCoach:
                                 last_advice_turn = turn_num
                                 last_advice_phase = phase
                                 self._record_advice(advice, trigger, game_state=curr_state)
+                                self._mark_backend_healthy()
                                 self.ui.advice(advice, seat_info)
                                 # Non-blocking TTS: lets the loop poll for new
                                 # game states (e.g. Select Targets) immediately.
@@ -1765,10 +1839,12 @@ class StandaloneCoach:
                         or (_is_err2(advice) and len(advice) < 200)
                     )
                     if not self.check_advice_for_backend_failure(advice) and not is_error_response:
+                        self._mark_backend_healthy()
                         self.ui.advice(advice, seat_info)
                         self.speak_advice(advice)
                     elif is_error_response:
                         logger.warning(f"Suppressing error advice from voice TTS: {advice[:80]}")
+                        self._report_backend_failure(advice)
                         self.ui.error(advice)
 
                     # Record for debug history with the same game state
@@ -3157,6 +3233,7 @@ class StandaloneCoach:
         if is_query_failure_retriable(advice) and (
             advice.startswith("Error") or len(advice) < 200
         ):
+            self._report_backend_failure(advice)
             self._consecutive_errors = getattr(self, '_consecutive_errors', 0) + 1
             max_errors = getattr(self, '_max_errors_before_fallback', 3)
             logger.warning(
@@ -3169,6 +3246,7 @@ class StandaloneCoach:
         else:
             # Reset counter on successful response
             self._consecutive_errors = 0
+            self._mark_backend_healthy()
 
         return False
 

--- a/src/arenamcp/tui.py
+++ b/src/arenamcp/tui.py
@@ -462,6 +462,7 @@ class Sidebar(Vertical):
             yield Static("Model: Default", id="status-model", classes="status-line")
             yield Static("Style: CONCISE", id="status-style", classes="status-line")
             yield Static("Voice: Initializing...", id="status-voice", classes="status-line")
+            yield Static("Backend: Starting...", id="status-backend", classes="status-line")
 
         with Vertical(id="actions-panel"):
             yield Button("Provider: detecting...", id="btn-provider", variant="primary")
@@ -569,12 +570,16 @@ class ArenaApp(App):
 
     BINDINGS = [
         ("ctrl+q", "quit", "Quit"),
+        ("f1", "autopilot_cancel", "AP Cancel"),
         ("f2", "toggle_style", "Style"),
         ("f3", "analyze_screen", "Screen"),
+        ("f4", "autopilot_abort", "AP Abort"),
         ("f5", "toggle_mute", "Mute"),
         ("f6", "cycle_voice", "Voice"),
         ("f7", "copy_debug", "Debug"),
         ("f8", "cycle_speed", "Speed"),
+        ("f9", "autopilot_toggle_afk", "AP AFK"),
+        ("f10", "autopilot_toggle_land", "AP Land"),
         ("ctrl+0", "read_win_plan", "Win Plan"),
     ]
 
@@ -782,6 +787,7 @@ class ArenaApp(App):
         model_display = f"{current_backend}/{current_model}" if current_model else current_backend
         self.update_status("MODEL", model_display)
         self.update_status("STYLE", self.coach.advice_style.upper())
+        self.update_status("BACKEND", f"OK ({current_backend})")
 
         # Sync voice output
         if self.coach._voice_output:
@@ -914,6 +920,8 @@ class ArenaApp(App):
             self.sub_title = value
         elif key == "SEAT_INFO":
             self.query_one("#status-seat", Static).update(f"Seat: {value}")
+        elif key == "BACKEND":
+            self.query_one("#status-backend", Static).update(f"Backend: {value}")
         elif key == "WIN-PLAN":
             btn = self.query_one("#btn-win-plan", Button)
             if value:
@@ -1100,8 +1108,10 @@ class ArenaApp(App):
                 or "didn't catch that" in advice
                 or (is_query_failure_retriable(advice) and len(advice) < 200)
             ):
+                self.call_from_thread(self.update_status, "BACKEND", f"ERROR ({self.coach.backend_name})")
                 self.call_from_thread(self.write_log, f"[red]Backend error: {advice}[/]")
             else:
+                self.call_from_thread(self.update_status, "BACKEND", f"OK ({self.coach.backend_name})")
                 self.call_from_thread(self.write_advice, advice, "Chat Response")
         except Exception as e:
             self.call_from_thread(self.write_log, f"[red]Chat error: {e}[/]")
@@ -1513,6 +1523,61 @@ class ArenaApp(App):
         """Read pending win plan aloud (Ctrl+0 or click)."""
         if self.coach:
             threading.Thread(target=self.coach._on_read_win_plan, daemon=True).start()
+
+    def _get_autopilot(self):
+        if not self.coach:
+            return None
+        return getattr(self.coach, "_autopilot", None)
+
+    def action_autopilot_cancel(self) -> None:
+        """Cancel pending autopilot countdown/confirmation."""
+        ap = self._get_autopilot()
+        if not ap:
+            self.write_log("[dim]Autopilot not enabled[/]")
+            return
+        try:
+            ap.on_spacebar()
+            self.write_log("[yellow]Autopilot: cancel requested[/]")
+        except Exception as e:
+            self.write_log(f"[red]Autopilot cancel failed: {e}[/]")
+
+    def action_autopilot_abort(self) -> None:
+        """Abort current autopilot plan immediately."""
+        ap = self._get_autopilot()
+        if not ap:
+            self.write_log("[dim]Autopilot not enabled[/]")
+            return
+        try:
+            ap.on_abort()
+            self.write_log("[yellow]Autopilot: abort requested[/]")
+        except Exception as e:
+            self.write_log(f"[red]Autopilot abort failed: {e}[/]")
+
+    def action_autopilot_toggle_afk(self) -> None:
+        """Toggle autopilot AFK mode."""
+        ap = self._get_autopilot()
+        if not ap:
+            self.write_log("[dim]Autopilot not enabled[/]")
+            return
+        try:
+            enabled = ap.toggle_afk()
+            state = "ON" if enabled else "OFF"
+            self.write_log(f"[cyan]Autopilot AFK: {state}[/]")
+        except Exception as e:
+            self.write_log(f"[red]Autopilot AFK toggle failed: {e}[/]")
+
+    def action_autopilot_toggle_land(self) -> None:
+        """Toggle autopilot land-drop-only mode."""
+        ap = self._get_autopilot()
+        if not ap:
+            self.write_log("[dim]Autopilot not enabled[/]")
+            return
+        try:
+            enabled = ap.toggle_land_drop()
+            state = "ON" if enabled else "OFF"
+            self.write_log(f"[cyan]Autopilot Land-drop: {state}[/]")
+        except Exception as e:
+            self.write_log(f"[red]Autopilot land-drop toggle failed: {e}[/]")
 
     def action_quit(self) -> None:
         if self.coach:

--- a/tests/test_action_planner_fallback.py
+++ b/tests/test_action_planner_fallback.py
@@ -1,0 +1,53 @@
+from arenamcp.action_planner import ActionPlanner, ActionType
+
+
+class _StubBackend:
+    def __init__(self, response: str):
+        self._response = response
+
+    def complete(self, system_prompt: str, user_message: str) -> str:
+        return self._response
+
+
+def test_planner_falls_back_from_markdown_text_to_legal_action() -> None:
+    planner = ActionPlanner(_StubBackend("## Coach's Advice: Pass Priority"))
+    plan = planner.plan_actions(
+        game_state={"turn": {"turn_number": 3}},
+        trigger="priority_gained",
+        legal_actions=["Pass", "Cast Shock"],
+    )
+    assert len(plan.actions) == 1
+    assert plan.actions[0].action_type == ActionType.PASS_PRIORITY
+
+
+def test_planner_falls_back_from_backend_error_to_preferred_legal_action() -> None:
+    planner = ActionPlanner(
+        _StubBackend("Error: Codex CLI failed: error: unexpected argument '-q' found")
+    )
+    plan = planner.plan_actions(
+        game_state={"turn": {"turn_number": 4}},
+        trigger="new_turn",
+        legal_actions=["Pass", "Cast Lightning Strike", "Play Land: Mountain"],
+    )
+    assert len(plan.actions) == 1
+    assert plan.actions[0].action_type == ActionType.PLAY_LAND
+    assert plan.actions[0].card_name == "Mountain"
+
+
+def test_planner_keeps_valid_json_response() -> None:
+    planner = ActionPlanner(
+        _StubBackend(
+            """{
+  "actions": [{"action_type":"cast_spell","card_name":"Shock"}],
+  "overall_strategy":"Use mana efficiently"
+}"""
+        )
+    )
+    plan = planner.plan_actions(
+        game_state={"turn": {"turn_number": 2}},
+        trigger="new_turn",
+        legal_actions=["Cast Shock", "Pass"],
+    )
+    assert len(plan.actions) == 1
+    assert plan.actions[0].action_type == ActionType.CAST_SPELL
+    assert plan.actions[0].card_name == "Shock"

--- a/tests/test_snapshot_consistency.py
+++ b/tests/test_snapshot_consistency.py
@@ -1,0 +1,60 @@
+﻿import threading
+import time
+
+from arenamcp.gamestate import GameState
+
+
+def test_published_snapshot_is_frame_consistent_under_concurrency() -> None:
+    """Readers should never observe mixed-frame turn/player data.
+
+    Writer updates turn and life in a single message; readers consume the
+    published immutable snapshot and assert the mapping remains consistent.
+    """
+    gs = GameState()
+    gs.set_local_seat_id(1, source=3)
+
+    mismatches: list[tuple[int, int]] = []
+    stop = threading.Event()
+
+    def writer() -> None:
+        for i in range(1, 300):
+            msg = {
+                "type": "GameStateType_Diff",
+                "turnInfo": {
+                    "turnNumber": i,
+                    "activePlayer": 1,
+                    "priorityPlayer": 1,
+                },
+                "players": [
+                    {"seatId": 1, "lifeTotal": 1000 + i, "landsPlayedThisTurn": 0},
+                ],
+            }
+            gs.update_from_message(msg)
+            # Keep overlap high so readers race with writer publication cadence.
+            time.sleep(0.0005)
+        stop.set()
+
+    def reader() -> None:
+        while not stop.is_set():
+            snap = gs.get_published_snapshot()
+            turn = int(snap.get("turn_info", {}).get("turn_number", 0) or 0)
+            if turn <= 0:
+                continue
+            players = snap.get("players", [])
+            you = next((p for p in players if p.get("seat_id") == 1), None)
+            if not you:
+                continue
+            life = int(you.get("life_total", 0) or 0)
+            expected = 1000 + turn
+            if life != expected:
+                mismatches.append((turn, life))
+                break
+
+    wt = threading.Thread(target=writer, daemon=True)
+    rt = threading.Thread(target=reader, daemon=True)
+    wt.start()
+    rt.start()
+    wt.join(timeout=5)
+    rt.join(timeout=1)
+
+    assert not mismatches, f"Observed mixed-frame snapshot(s): {mismatches[:5]}"

--- a/tests/test_standalone_init.py
+++ b/tests/test_standalone_init.py
@@ -1,0 +1,7 @@
+from arenamcp.standalone import StandaloneCoach
+
+
+def test_standalone_initializes_advice_history():
+    coach = StandaloneCoach(register_hotkeys=False)
+    assert hasattr(coach, "_advice_history")
+    assert isinstance(coach._advice_history, list)


### PR DESCRIPTION
## Summary
- fix autopilot getting stuck after first move by forcing decision_required when pending decisions exist but trigger edges are missed
- prevent quiet-trigger suppression from hiding pending decisions
- skip redundant trailing done actions emitted by some backends
- add backend health status + failure surfacing in TUI
- harden Codex CLI invocation compatibility and legal-action fallback parsing
- move game state reads to published immutable snapshots for safer high-frequency read/write behavior
- fix standalone match-end exception loop by initializing _advice_history
- bump package version to 