### PR TITLE
WP-3: corpus filters, tripwires, splits, manifest

### DIFF
--- a/tests/test_magezero_filters.py
+++ b/tests/test_magezero_filters.py
@@ -1,0 +1,602 @@
+"""Tests for tools/training/magezero_filters.py.
+
+Every function is tested with synthetic fixtures — no external data required.
+Covers normal operation, edge cases, tripwire firing, and split determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from tools.training import magezero_filters as mf
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(overrides: dict | None = None) -> dict:
+    """Build a minimal valid decision row with sensible defaults."""
+    base = {
+        "game_id": "log_a:1:3",
+        "turn": 4,
+        "phase": "PRECOMBAT_MAIN",
+        "active_life": 18,
+        "opp_life": 18,
+        "hand": ["Forest"],
+        "battlefield_self": [{"name": "Elf", "tapped": False}],
+        "battlefield_opp": [{"name": "Mountain", "tapped": True}],
+        "menu": ["Play Forest", "Attack with Elf", "Pass"],
+        "chosen": "Play Forest",
+        "mcts_counts": {"Pass": 30, "Play Forest": 609, "Attack with Elf": 200},
+        "actor": "PlayerA",
+        "outcome": "won",
+        "session": "session21",
+        "decision_kind": "priority",
+    }
+    if overrides:
+        base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# drop_single_option
+# ---------------------------------------------------------------------------
+
+
+class TestDropSingleOption:
+    def test_keeps_multi_option(self):
+        rows = [_make_row(), _make_row({"menu": ["A", "B"]})]
+        kept, dropped = mf.drop_single_option(rows)
+        assert dropped == 0
+        assert len(kept) == 2
+
+    def test_drops_single_option(self):
+        rows = [_make_row({"menu": ["Pass"]}), _make_row({"menu": ["Keep"]})]
+        kept, dropped = mf.drop_single_option(rows)
+        assert dropped == 2
+        assert len(kept) == 0
+
+    def test_mixed(self):
+        rows = [
+            _make_row({"menu": ["Pass"]}),
+            _make_row({"menu": ["A", "B"]}),
+            _make_row({"menu": ["Only"]}),
+            _make_row({"menu": ["X", "Y", "Z"]}),
+        ]
+        kept, dropped = mf.drop_single_option(rows)
+        assert dropped == 2
+        assert len(kept) == 2
+
+    def test_empty_menu_counts_as_single_option(self):
+        rows = [_make_row({"menu": []})]
+        kept, dropped = mf.drop_single_option(rows)
+        assert dropped == 1
+        assert len(kept) == 0
+
+    def test_missing_menu_defaults_empty(self):
+        rows = [{"game_id": "x"}, {"game_id": "y", "menu": ["A", "B"]}]
+        kept, dropped = mf.drop_single_option(rows)
+        assert dropped == 1
+        assert len(kept) == 1
+
+    def test_empty_input(self):
+        kept, dropped = mf.drop_single_option([])
+        assert dropped == 0
+        assert kept == []
+
+
+# ---------------------------------------------------------------------------
+# outcome_filter
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeFilter:
+    def test_won_only_keeps_won(self):
+        rows = [
+            _make_row({"outcome": "won"}),
+            _make_row({"outcome": "lost"}),
+            _make_row({"outcome": "won"}),
+        ]
+        kept, dropped = mf.outcome_filter(rows, "won_only")
+        assert dropped == 1
+        assert len(kept) == 2
+        assert all(r["outcome"] == "won" for r in kept)
+
+    def test_won_only_drops_unknown(self):
+        rows = [
+            _make_row({"outcome": "won"}),
+            _make_row({"outcome": "unknown"}),
+        ]
+        kept, dropped = mf.outcome_filter(rows, "won_only")
+        assert dropped == 1
+        assert len(kept) == 1
+
+    def test_all_preserves_everything(self):
+        rows = [
+            _make_row({"outcome": "won"}),
+            _make_row({"outcome": "lost"}),
+            _make_row({"outcome": "unknown"}),
+        ]
+        kept, dropped = mf.outcome_filter(rows, "all")
+        assert dropped == 0
+        assert len(kept) == 3
+
+    def test_all_returns_copy(self):
+        rows = [_make_row()]
+        kept, dropped = mf.outcome_filter(rows, "all")
+        assert dropped == 0
+        assert kept is not rows  # should be a shallow copy
+
+    def test_empty_input(self):
+        kept, dropped = mf.outcome_filter([], "won_only")
+        assert dropped == 0
+        assert kept == []
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown outcome filter mode"):
+            mf.outcome_filter([_make_row()], "bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# dedupe
+# ---------------------------------------------------------------------------
+
+
+class TestDedupe:
+    def test_identical_rows_deduplicated(self):
+        r = _make_row()
+        rows = [r, r, r]
+        kept, dropped = mf.dedupe(rows)
+        assert dropped == 2
+        assert len(kept) == 1
+
+    def test_different_chosen_is_different(self):
+        r1 = _make_row({"chosen": "Play Forest"})
+        r2 = _make_row({"chosen": "Pass"})
+        kept, dropped = mf.dedupe([r1, r2])
+        assert dropped == 0
+        assert len(kept) == 2
+
+    def test_different_menu_is_different(self):
+        r1 = _make_row({"menu": ["A", "B"]})
+        r2 = _make_row({"menu": ["A", "B", "C"]})
+        kept, dropped = mf.dedupe([r1, r2])
+        assert dropped == 0
+        assert len(kept) == 2
+
+    def test_different_battlefield_tapped_status_is_different(self):
+        r1 = _make_row({"battlefield_self": [{"name": "Elf", "tapped": False}]})
+        r2 = _make_row({"battlefield_self": [{"name": "Elf", "tapped": True}]})
+        kept, dropped = mf.dedupe([r1, r2])
+        assert dropped == 0
+        assert len(kept) == 2
+
+    def test_battlefield_order_independent(self):
+        r1 = _make_row({
+            "battlefield_self": [
+                {"name": "Elf", "tapped": False},
+                {"name": "Goblin", "tapped": True},
+            ],
+        })
+        r2 = _make_row({
+            "battlefield_self": [
+                {"name": "Goblin", "tapped": True},
+                {"name": "Elf", "tapped": False},
+            ],
+        })
+        kept, dropped = mf.dedupe([r1, r2])
+        assert dropped == 1
+        assert len(kept) == 1
+
+    def test_preserves_first_occurrence(self):
+        rows = [
+            _make_row({"chosen": "Pass", "mcts_counts": {"Pass": 100}}),
+            _make_row({"chosen": "Pass", "mcts_counts": {"Pass": 200}}),
+        ]
+        kept, dropped = mf.dedupe(rows)
+        assert dropped == 1
+        assert kept[0]["mcts_counts"]["Pass"] == 100
+
+    def test_empty_input(self):
+        kept, dropped = mf.dedupe([])
+        assert dropped == 0
+        assert kept == []
+
+    def test_hand_order_matters(self):
+        """Hand is a tuple, so order IS significant (as in the MTGA client)."""
+        r1 = _make_row({"hand": ["Forest", "Mountain"]})
+        r2 = _make_row({"hand": ["Mountain", "Forest"]})
+        kept, dropped = mf.dedupe([r1, r2])
+        assert dropped == 0
+        assert len(kept) == 2
+
+
+# ---------------------------------------------------------------------------
+# pass_rate_tripwire
+# ---------------------------------------------------------------------------
+
+
+class TestPassRateTripwire:
+    def test_below_threshold_passes(self):
+        rows = [
+            _make_row({"chosen": "Play Forest"}),
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Attack"}),
+        ]
+        # 1/3 ≈ 33 % < 40 %
+        mf.pass_rate_tripwire(rows, max_frac=0.40)  # should not raise
+
+    def test_at_threshold_passes(self):
+        rows = [
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Play Forest"}),
+            _make_row({"chosen": "Play Forest"}),
+            _make_row({"chosen": "Attack"}),
+        ]
+        mf.pass_rate_tripwire(rows, max_frac=0.40)
+
+    def test_above_threshold_raises_systemexit(self):
+        rows = [
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Pass"}),
+            _make_row({"chosen": "Play Forest"}),
+            _make_row({"chosen": "Attack"}),
+        ]
+        # 3/5 = 60 % > 40 %
+        with pytest.raises(SystemExit) as exc:
+            mf.pass_rate_tripwire(rows, max_frac=0.40)
+        assert exc.value.code == 42
+
+    def test_all_pass_exits(self):
+        rows = [_make_row({"chosen": "Pass"}), _make_row({"chosen": "Pass"})]
+        with pytest.raises(SystemExit) as exc:
+            mf.pass_rate_tripwire(rows, max_frac=0.40)
+        assert exc.value.code == 42
+
+    def test_empty_input_does_not_raise(self):
+        mf.pass_rate_tripwire([], max_frac=0.40)
+
+
+# ---------------------------------------------------------------------------
+# split_by_game
+# ---------------------------------------------------------------------------
+
+
+class TestSplitByGame:
+    def test_two_games_get_separate_splits(self):
+        rows = [
+            _make_row({"game_id": "game_a:1:1", "turn": 1}),
+            _make_row({"game_id": "game_a:1:2", "turn": 2}),
+            _make_row({"game_id": "game_b:1:1", "turn": 1}),
+            _make_row({"game_id": "game_c:1:1", "turn": 1}),
+            _make_row({"game_id": "game_c:1:2", "turn": 2}),
+        ]
+        splits = mf.split_by_game(rows, seed=7)
+        assert sum(len(v) for v in splits.values()) == 5
+        # All rows of each game should be in the same split
+        for group in splits.values():
+            gids = {r["game_id"] for r in group}
+            for gid in gids:
+                # Every other row with the same base game prefix is also here
+                prefix = gid.rsplit(":", 1)[0]
+                siblings = {r["game_id"] for r in group if r["game_id"].startswith(prefix)}
+                assert siblings == {r["game_id"] for r in rows if r["game_id"].startswith(prefix)} & gids
+
+    def test_deterministic_same_seed(self):
+        rows = [_make_row({"game_id": f"g{i}:1:1"}) for i in range(100)]
+        a = mf.split_by_game(rows, seed=7)
+        b = mf.split_by_game(rows, seed=7)
+        for name in ("train", "val", "test"):
+            assert len(a.get(name, [])) == len(b.get(name, []))
+            # Contents should be identical in order
+            assert [r["game_id"] for r in a.get(name, [])] == [
+                r["game_id"] for r in b.get(name, [])
+            ]
+
+    def test_different_seed_different_splits(self):
+        rows = [_make_row({"game_id": f"g{i}:1:1"}) for i in range(100)]
+        a = mf.split_by_game(rows, seed=7)
+        b = mf.split_by_game(rows, seed=42)
+        # Same total count
+        assert sum(len(v) for v in a.values()) == sum(len(v) for v in b.values())
+        # But likely different assignments — at least one split size differs
+        # (the chance two seeds give the exact same sizes for 100 games is negligible)
+        a_counts = tuple(len(a.get(n, [])) for n in ("train", "val", "test"))
+        b_counts = tuple(len(b.get(n, [])) for n in ("train", "val", "test"))
+        # These COULD coincidentally match (rare), so we just check the overall
+        # game->split mapping differs for at least one game
+        def _game_to_split(splits):
+            mapping = {}
+            for name, group in splits.items():
+                for r in group:
+                    mapping[r["game_id"]] = name
+            return mapping
+
+        assert _game_to_split(a) != _game_to_split(b)
+
+    def test_default_fracs_sum_to_one(self):
+        rows = [_make_row({"game_id": f"g{i}:1:1"}) for i in range(100)]
+        splits = mf.split_by_game(rows)
+        total = sum(len(v) for v in splits.values())
+        assert total == 100
+
+    def test_invalid_fracs_raises(self):
+        rows = [_make_row()]
+        with pytest.raises(ValueError, match="fracs must sum to 1.0"):
+            mf.split_by_game(rows, fracs=(0.5, 0.3, 0.3))
+
+    def test_without_val_or_test(self):
+        rows = [_make_row({"game_id": "g:1:1"})]
+        splits = mf.split_by_game(rows, fracs=(1.0, 0.0, 0.0))
+        assert "train" in splits
+        assert "val" not in splits or len(splits["val"]) == 0
+        assert "test" not in splits or len(splits["test"]) == 0
+        assert len(splits["train"]) == 1
+
+    def test_no_leakage(self):
+        """No game_id appears in more than one split."""
+        rows = [_make_row({"game_id": f"g{i}:1:{j}"}) for i in range(10) for j in range(3)]
+        splits = mf.split_by_game(rows, seed=7)
+        seen_games: dict[str, str] = {}
+        for name, group in splits.items():
+            for r in group:
+                gid = mf._game_id(r)
+                if gid in seen_games:
+                    assert seen_games[gid] == name, (
+                        f"Game {gid} leaked from {seen_games[gid]} to {name}"
+                    )
+                seen_games[gid] = name
+
+
+# ---------------------------------------------------------------------------
+# write_manifest
+# ---------------------------------------------------------------------------
+
+
+class TestWriteManifest:
+    def test_manifest_has_required_keys(self):
+        rows = [_make_row() for _ in range(5)]
+        splits = {"train": rows[:3], "val": rows[3:4], "test": rows[4:]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            mf.write_manifest(splits, manifest_path, filter_counts={"drop_single_option": 2})
+
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        assert "version" in manifest
+        assert "git_sha" in manifest
+        assert "total_rows" in manifest
+        assert manifest["total_rows"] == 5
+        assert "splits" in manifest
+        assert set(manifest["splits"].keys()) == {"train", "val", "test"}
+        assert manifest["filter_counts"] == {"drop_single_option": 2}
+
+    def test_manifest_split_counts(self):
+        win_rows = [_make_row({"outcome": "won"}) for _ in range(3)]
+        lost_rows = [_make_row({"outcome": "lost"}) for _ in range(2)]
+        splits = {"train": win_rows + lost_rows}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            mf.write_manifest(splits, manifest_path)
+
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        train_info = manifest["splits"]["train"]
+        assert train_info["rows"] == 5
+        assert train_info["by_outcome"]["won"] == 3
+        assert train_info["by_outcome"]["lost"] == 2
+
+    def test_manifest_sha256_is_hex(self):
+        splits = {"train": [_make_row()]}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            mf.write_manifest(splits, manifest_path)
+
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+
+        sha = manifest["splits"]["train"]["sha256"]
+        assert len(sha) == 64
+        int(sha, 16)  # should not raise
+
+    def test_manifest_git_sha(self):
+        splits = {"train": [_make_row()]}
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            mf.write_manifest(splits, manifest_path)
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+        # Should either be a valid git SHA or "unknown" (CI)
+        sha = manifest["git_sha"]
+        assert sha == "unknown" or (len(sha) == 40 and all(c in "0123456789abcdef" for c in sha))
+
+    def test_writes_jsonl_files(self):
+        splits = {"train": [_make_row({"game_id": "g:1:1"})] * 3}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest_path = Path(tmp) / "manifest.json"
+            mf.write_manifest(splits, manifest_path)
+
+            # Check JSONL was written
+            train_path = Path(tmp) / "train.jsonl"
+            assert train_path.exists()
+            lines = train_path.read_text().strip().split("\n")
+            assert len(lines) == 3
+
+
+# ---------------------------------------------------------------------------
+# Full CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_cli_pipeline_e2e(self):
+        """End-to-end: write a JSONL fixture, run the CLI, check outputs."""
+        rows = []
+        for i in range(50):
+            outcome = "won" if i < 40 else "lost"
+            chosen = "Play Forest"  # never Pass so tripwire doesn't fire
+            rows.append(
+                _make_row({
+                    "game_id": f"game{i:03d}:1:1",
+                    "outcome": outcome,
+                    "chosen": chosen,
+                    "menu": ["Play Forest", "Attack", "Pass"],
+                    "hand": [f"Card_{i}"],  # unique hand to avoid dedupe collapse
+                })
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "input.jsonl"
+            with open(input_path, "w") as f:
+                for r in rows:
+                    f.write(json.dumps(r) + "\n")
+
+            outdir = Path(tmp) / "wp3_out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools/training/magezero_filters.py"),
+                    "--in", str(input_path),
+                    "--outdir", str(outdir),
+                    "--mode", "won_only",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            assert result.returncode == 0, (
+                f"CLI failed:\nstdout:{result.stdout}\nstderr:{result.stderr}"
+            )
+
+            # Check outputs
+            assert (outdir / "manifest.json").exists()
+            assert (outdir / "train.jsonl").exists()
+
+            # Verify manifest is valid JSON
+            with open(outdir / "manifest.json") as f:
+                manifest = json.load(f)
+            assert manifest["total_rows"] > 0
+            assert "filter_counts" in manifest
+            assert "drop_single_option" in manifest["filter_counts"]
+
+    def test_cli_tripwire_rejects_high_pass_rate(self):
+        """Rows where most decisions are Pass should trip the CLI."""
+        rows = []
+        for i in range(20):
+            rows.append(
+                _make_row({
+                    "game_id": f"game{i:03d}:1:1",
+                    "chosen": "Play Forest" if i < 7 else "Pass",
+                    "menu": ["Play Forest", "Attack", "Pass"],
+                    "outcome": "won",
+                })
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "high_pass.jsonl"
+            with open(input_path, "w") as f:
+                for r in rows:
+                    f.write(json.dumps(r) + "\n")
+
+            outdir = Path(tmp) / "wp3_out"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "tools/training/magezero_filters.py"),
+                    "--in", str(input_path),
+                    "--outdir", str(outdir),
+                    "--mode", "won_only",
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            assert result.returncode == 42
+            assert "TRIPWIRE TRIPPED" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Schema / invariants
+# ---------------------------------------------------------------------------
+
+
+class TestInvariants:
+    """Contract tests for the shared decisions JSONL schema."""
+
+    REQUIRED_FIELDS = [
+        "game_id", "turn", "phase", "active_life", "opp_life",
+        "hand", "battlefield_self", "battlefield_opp",
+        "menu", "chosen", "mcts_counts", "actor",
+        "outcome", "session", "decision_kind",
+    ]
+
+    def test_make_row_has_all_required_fields(self):
+        r = _make_row()
+        for field in self.REQUIRED_FIELDS:
+            assert field in r, f"Required field {field!r} missing from _make_row()"
+
+    def test_drop_single_option_preserves_fields(self):
+        r = _make_row({"menu": ["A", "B"]})
+        kept, _ = mf.drop_single_option([r])
+        assert kept[0] == r
+
+    def test_deterministic_split_across_runs(self):
+        """Same seed must produce identical split assignments across two independent calls."""
+        rows = [_make_row({"game_id": f"g{i:04d}:1:1"}) for i in range(50)]
+        a = mf.split_by_game(rows, seed=42)
+        b = mf.split_by_game(rows, seed=42)
+        for name in ("train", "val", "test"):
+            a_ids = [r["game_id"] for r in a.get(name, [])]
+            b_ids = [r["game_id"] for r in b.get(name, [])]
+            assert a_ids == b_ids, f"Split {name} differs between runs"
+
+    def test_filter_composition_pipeline(self):
+        """Pipeline: drop_single_option -> outcome_filter -> dedupe -> split_by_game
+        produces a valid result with no errors."""
+        rows = []
+        for i in range(30):
+            outcome = "won" if i < 24 else "lost"
+            menu = ["Only"] if i == 29 else [f"A{i}", f"B{i}", f"C{i}"]
+            rows.append(
+                _make_row({
+                    "game_id": f"game_{i % 10:03d}:1:1",
+                    "outcome": outcome,
+                    "menu": menu,
+                    "chosen": f"A{i}",
+                    "hand": [f"Card_{i}"],  # unique hand avoids dedupe collapse
+                })
+            )
+
+        # Run full pipeline
+        rows, n1 = mf.drop_single_option(rows)
+        rows, n2 = mf.outcome_filter(rows, "won_only")
+        rows, n3 = mf.dedupe(rows)
+        mf.pass_rate_tripwire(rows, max_frac=0.40)
+        splits = mf.split_by_game(rows, seed=7)
+
+        total = sum(len(v) for v in splits.values())
+        assert total == len(rows)
+        assert n1 >= 0
+        assert n2 >= 0
+        assert n3 >= 0
+        assert set(splits.keys()).issubset({"train", "val", "test"})

--- a/tools/training/magezero_filters.py
+++ b/tools/training/magezero_filters.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Corpus-level filters, tripwires, splits, and manifest for MageZero → gemma distillation.
+
+Every function here is pure (stdlib only). Rows are dicts as parsed from the
+decisions JSONL schema shared by all WP-3 agents.
+
+Functions are designed to be composed in a pipeline:
+
+    rows = load_jsonl(path)
+    rows, n1 = drop_single_option(rows)
+    rows, n2 = outcome_filter(rows, mode)
+    rows, n3 = dedupe(rows)
+    pass_rate_tripwire(rows)        # raises SystemExit if pass rate > 40 %
+    splits = split_by_game(rows)
+    manifest = write_manifest(splits, outdir, filter_counts={...})
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def drop_single_option(rows: list[dict]) -> tuple[list[dict], int]:
+    """Remove rows whose *menu* has fewer than 2 items.
+
+    A single-option decision contributes no signal — the model has nothing
+    to choose, so the row teaches nothing about decision quality.
+    Returns ``(filtered, count_dropped)``.
+    """
+    kept: list[dict] = []
+    dropped = 0
+    for r in rows:
+        menu = r.get("menu", [])
+        if isinstance(menu, list) and len(menu) < 2:
+            dropped += 1
+        else:
+            kept.append(r)
+    return kept, dropped
+
+
+def outcome_filter(rows: list[dict], mode: str) -> tuple[list[dict], int]:
+    """Filter rows by game outcome.
+
+    * ``mode="won_only"`` — keep only rows where ``outcome == "won"``.
+    * ``mode="all"`` — keep everything.
+    Returns ``(filtered, count_dropped)``.
+    """
+    if mode == "all":
+        return rows[:], 0
+    if mode != "won_only":
+        raise ValueError(f"Unknown outcome filter mode: {mode!r}")
+    kept = [r for r in rows if r.get("outcome") == "won"]
+    return kept, len(rows) - len(kept)
+
+
+def _dedupe_key(row: dict) -> tuple:
+    """Build an order-independent deduplication key for one decision row."""
+    menu = tuple(row.get("menu", []))
+    hand = tuple(row.get("hand", []))
+    bf = row.get("battlefield_self", [])
+    # frozenset of (name, tapped) tuples so order & dupes don't matter
+    bf_key = frozenset((p.get("name", ""), bool(p.get("tapped", False))) for p in bf)
+    chosen = row.get("chosen", "")
+    return (menu, hand, bf_key, chosen)
+
+
+def dedupe(rows: list[dict]) -> tuple[list[dict], int]:
+    """Deduplicate rows by decision context key.
+
+    Key = ``(tuple(menu), tuple(hand), frozenset(battlefield name+tapped), chosen)``.
+
+    Uses order-preserving dedup: the **first** occurrence of each key is kept,
+    which matters when rows have the same context but different MCTS counts
+    (the earliest is typically the most useful for training).
+    Returns ``(filtered, count_dropped)``.
+    """
+    seen: set[tuple] = set()
+    kept: list[dict] = []
+    dropped = 0
+    for r in rows:
+        k = _dedupe_key(r)
+        if k in seen:
+            dropped += 1
+        else:
+            seen.add(k)
+            kept.append(r)
+    return kept, dropped
+
+
+# ---------------------------------------------------------------------------
+# Tripwire
+# ---------------------------------------------------------------------------
+
+
+def pass_rate_tripwire(rows: list[dict], max_frac: float = 0.40) -> None:
+    """Raise ``SystemExit`` if the fraction of rows where ``chosen == "Pass"``
+    exceeds *max_frac* **after** all other filters have been applied.
+
+    This guard exists because a prior corpus with a **56 % Pass rate** trained
+    a pass-reflex into the model, wasting a week of training.  The tripwire
+    ensures we detect and reject such corpora before they reach training.
+
+    On violation, prints a detailed stats dump to stderr and exits with
+    code 42 (the project convention for retryable pipeline failures).
+    """
+    total = len(rows)
+    if total == 0:
+        return  # nothing to check
+    n_pass = sum(1 for r in rows if r.get("chosen") == "Pass")
+    frac = n_pass / total
+
+    if frac > max_frac:
+        n_nonpass = total - n_pass
+        print(
+            f"PASS RATE TRIPWIRE TRIPPED\n"
+            f"  Total rows (post-filter): {total}\n"
+            f"  Pass choices:             {n_pass}\n"
+            f"  Non-Pass choices:         {n_nonpass}\n"
+            f"  Pass fraction:            {frac:.4f}  ({frac*100:.1f}%)\n"
+            f"  Max allowed fraction:     {max_frac}  ({max_frac*100:.0f}%)\n"
+            f"\n"
+            f"A prior corpus with a 56 % Pass rate trained a pass-reflex\n"
+            f"into the model, wasting a week of training.  This corpus\n"
+            f"has a {frac*100:.1f} % Pass rate and is being rejected.\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(42)
+
+
+# ---------------------------------------------------------------------------
+# Splitting
+# ---------------------------------------------------------------------------
+
+
+def _game_id(row: dict) -> str:
+    """Extract the game identifier from a row."""
+    gid = row.get("game_id", "")
+    if not gid:
+        # fallback: use session + turn as a pseudo-key
+        session = row.get("session", "")
+        turn = row.get("turn", 0)
+        gid = f"{session}:turn_{turn}"
+    return gid
+
+
+def split_by_game(
+    rows: list[dict],
+    seed: int = 7,
+    fracs: tuple[float, float, float] = (0.90, 0.05, 0.05),
+) -> dict[str, list[dict]]:
+    """Split rows by *game_id* (never row-level) to prevent train/val leakage.
+
+    All rows sharing the same ``game_id`` go to the same split.  The
+    assignment is deterministic given *seed* and stable across runs.
+
+    Parameters
+    ----------
+    rows:
+        Decision records.
+    seed:
+        PRNG seed for deterministic shuffling of game IDs.
+    fracs:
+        (train, val, test) fractions.  Must sum to 1.0.
+
+    Returns
+    -------
+    ``{"train": [...], "val": [...], "test": [...]}``.
+    Any split whose cumulative count rounds to zero is dropped from the result.
+    """
+    if len(fracs) != 3 or abs(sum(fracs) - 1.0) > 1e-9:
+        raise ValueError(f"fracs must sum to 1.0, got {fracs}")
+    train_frac, val_frac, test_frac = fracs
+
+    # Group rows by game_id
+    game_groups: dict[str, list[dict]] = {}
+    for r in rows:
+        gid = _game_id(r)
+        game_groups.setdefault(gid, []).append(r)
+
+    game_ids = sorted(game_groups.keys())
+
+    # Deterministic shuffle
+    rng = __import__("random").Random(seed)
+    rng.shuffle(game_ids)
+
+    n_games = len(game_ids)
+    n_train = max(0, int(n_games * train_frac))
+    n_val = max(0, int(n_games * val_frac))
+    # test gets the remainder to avoid off-by-one due to rounding
+    remainder = n_games - n_train - n_val
+    n_test = max(0, remainder)
+
+    result: dict[str, list[dict]] = {}
+    splits = [("train", n_train), ("val", n_val), ("test", n_test)]
+    pos = 0
+    for name, count in splits:
+        if count == 0:
+            continue
+        batch: list[dict] = []
+        for gid in game_ids[pos : pos + count]:
+            batch.extend(game_groups[gid])
+        result[name] = batch
+        pos += count
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+def _git_sha() -> str:
+    """Return the current git HEAD SHA, or ``"unknown"`` if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the hex SHA-256 digest of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(8192 * 1024)  # 8 MiB
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _counts_by_field(
+    rows: list[dict], field: str
+) -> dict[str, int]:
+    """Count occurrences of each distinct value of *field* in *rows*."""
+    counts: dict[str, int] = {}
+    for r in rows:
+        val = r.get(field, "unknown")
+        if not isinstance(val, str):
+            val = str(val)
+        counts[val] = counts.get(val, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def write_manifest(
+    splits: dict[str, list[dict]],
+    path: str | Path,
+    filter_counts: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    """Write a JSON manifest describing the corpus and return the manifest dict.
+
+    The manifest includes:
+    * Per-split row counts.
+    * Per-split counts by ``decision_kind`` and by ``outcome``.
+    * SHA-256 digest of each emitted JSONL file.
+    * Git SHA of the repository HEAD at manifest time.
+    * Per-filter drop counts (from the upstream pipeline).
+
+    Parameters
+    ----------
+    splits:
+        ``{"train": [...], "val": [...], "test": [...]}`` — each value is a
+        list of decision rows already serialized as JSONL files in the same
+        directory as *path*.
+    path:
+        Path to write the manifest JSON to.  Also used as the base directory
+        for looking up the split .jsonl files.
+    filter_counts:
+        Optional dict of filter names to dropped-count values, e.g.
+        ``{"drop_single_option": 12, "outcome_filter": 45, "dedupe": 8}``.
+    """
+    path = Path(path)
+    parent = path.parent
+
+    manifest: dict[str, Any] = {
+        "version": 1,
+        "git_sha": _git_sha(),
+        "total_rows": sum(len(v) for v in splits.values()),
+        "splits": {},
+        "filter_counts": dict(filter_counts or {}),
+    }
+
+    for name, rows in sorted(splits.items()):
+        # Write JSONL for this split
+        split_path = parent / f"{name}.jsonl"
+        with open(split_path, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r, sort_keys=True, ensure_ascii=False))
+                f.write("\n")
+
+        sha = _sha256_file(split_path)
+
+        manifest["splits"][name] = {
+            "rows": len(rows),
+            "file": split_path.name,
+            "sha256": sha,
+            "by_decision_kind": _counts_by_field(rows, "decision_kind"),
+            "by_outcome": _counts_by_field(rows, "outcome"),
+        }
+
+    with open(path, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True, ensure_ascii=False)
+        f.write("\n")
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def load_jsonl(path: str | Path) -> list[dict]:
+    """Load a decisions JSONL file into a list of dicts."""
+    rows: list[dict] = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Filter, tripwire, split, and manifest MageZero decision records.",
+    )
+    parser.add_argument(
+        "--in",
+        dest="input_path",
+        type=str,
+        required=True,
+        help="Path to input decisions JSONL.",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=str,
+        default="tools/training/data/wp3/",
+        help="Output directory for split JSONL files and manifest.",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="won_only",
+        choices=("won_only", "all"),
+        help="Outcome filter mode (default: won_only).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=7,
+        help="PRNG seed for deterministic splitting (default: 7).",
+    )
+    parser.add_argument(
+        "--max-pass-frac",
+        type=float,
+        default=0.40,
+        help="Maximum allowed Pass fraction (default: 0.40).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # Load
+    rows = load_jsonl(args.input_path)
+    print(f"Loaded {len(rows)} rows from {args.input_path}")
+
+    # Pipeline
+    filter_counts: dict[str, int] = {}
+
+    rows, n = drop_single_option(rows)
+    filter_counts["drop_single_option"] = n
+    print(f"  drop_single_option: {n} dropped ({len(rows)} kept)")
+
+    rows, n = outcome_filter(rows, args.mode)
+    filter_counts["outcome_filter"] = n
+    print(f"  outcome_filter ({args.mode}): {n} dropped ({len(rows)} kept)")
+
+    rows, n = dedupe(rows)
+    filter_counts["dedupe"] = n
+    print(f"  dedupe: {n} dropped ({len(rows)} kept)")
+
+    # Tripwire
+    pass_rate_tripwire(rows, max_frac=args.max_pass_frac)
+
+    # Split
+    splits = split_by_game(rows, seed=args.seed)
+    for name, group in splits.items():
+        print(f"  split '{name}': {len(group)} rows ({len(set(_game_id(r) for r in group))} games)")
+
+    # Manifest + write splits
+    manifest_path = outdir / "manifest.json"
+    manifest = write_manifest(splits, manifest_path, filter_counts=filter_counts)
+    print(f"  Manifest written to {manifest_path}")
+
+    print(f"\nDone.  {sum(len(v) for v in splits.values())} rows across {len(splits)} splits.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/training/wp3/PROGRESS-wp3-b2-filters.md
+++ b/tools/training/wp3/PROGRESS-wp3-b2-filters.md
@@ -1,0 +1,49 @@
+# WP-3 B-2 Filters — PROGRESS
+
+## What was built
+
+### `tools/training/magezero_filters.py`
+
+Pure-function corpus filter pipeline (stdlib only, no arenamcp imports).
+
+| Function | Purpose |
+|---|---|
+| `drop_single_option(rows)` | Remove rows with menu length < 2 |
+| `outcome_filter(rows, mode)` | Keep only "won" rows, or all |
+| `dedupe(rows)` | Order-preserving dedup by (menu, hand, battlefield+tapped, chosen) |
+| `pass_rate_tripwire(rows, max_frac=0.40)` | `SystemExit(42)` if Pass fraction > threshold |
+| `split_by_game(rows, seed=7, fracs=(0.90,0.05,0.05))` | Deterministic split by `game_id` (never row-level) |
+| `write_manifest(splits, path, filter_counts={})` | JSON manifest with counts/sha256/git SHA |
+| CLI entry point | `--in <jsonl> --outdir <path> --mode won_only` |
+
+### `tests/test_magezero_filters.py`
+
+43 tests across 7 test classes:
+- **TestDropSingleOption** (6): multi-option keep, single drop, mixed, empty menu, missing menu, empty input
+- **TestOutcomeFilter** (6): won_only keep, drop unknown, all preserves, returns copy, empty input, invalid mode
+- **TestDedupe** (7): identical, diff chosen, diff menu, diff tapped, order-independent battlefield, first-occ preservation, hand order matters, empty input
+- **TestPassRateTripwire** (5): below threshold, at threshold, above (SystemExit 42), all pass, empty input
+- **TestSplitByGame** (7): game co-location, deterministic same seed, diff seed diff splits, fracs sum to 1, invalid fracs, no val/test, no leakage
+- **TestWriteManifest** (5): required keys, split counts, sha256 hex, git SHA, writes JSONL files
+- **TestCLI** (2): e2e pipeline, tripwire rejects high pass rate
+- **TestInvariants** (4): required fields, field preservation, determinism, pipeline composition
+
+## Test output
+
+```
+43 passed in 0.29s
+```
+
+## Decisions
+
+1. **Duplicate key design**: `frozenset` of `(name, tapped)` tuples for battlefield — order-independent, which matches the MTGA client's non-deterministic battlefield ordering.
+2. **Hand NOT order-independent**: hand is a `tuple`, preserving the MTGA client card order, because a reordered hand is a materially different game state.
+3. **Split remainder**: test split gets the remainder after floor-based train/val allocation, avoiding rounding losses.
+4. **Tripwire exit code 42**: matches project convention for retryable pipeline failures (used elsewhere in the repo).
+5. **Manifest location**: written alongside split `.jsonl` files in `<outdir>/manifest.json`.
+
+## Known gaps
+
+- No test for CLI with `--mode all` (tested indirectly via `outcome_filter` unit tests)
+- No test for very large corpuses (100K+ rows) — would be slow in CI
+- The manifest `by_decision_kind` and `by_outcome` counts sort alphabetically; this is fine for JSON readability


### PR DESCRIPTION
## What

Pure-function corpus filter pipeline for MageZero→gemma distillation:

### `tools/training/magezero_filters.py`

| Function | Purpose |
|---|---|
| `drop_single_option(rows)` | Remove rows with menu length < 2 |
| `outcome_filter(rows, mode)` | Keep only `"won"` rows, or all |
| `dedupe(rows)` | Order-preserving dedup by (menu, hand, battlefield+tapped, chosen) |
| `pass_rate_tripwire(rows, max_frac=0.40)` | `SystemExit(42)` if Pass fraction > 40% — guards against pass-reflex (prior corpus had 56% Pass rate) |
| `split_by_game(rows, seed=7, fracs=(0.90,0.05,0.05))` | Deterministic split by `game_id` (never row-level — prevents train/val leakage) |
| `write_manifest(splits, path, filter_counts)` | JSON manifest with per-split counts, decision_kind/outcome breakdowns, SHA-256, git SHA |
| CLI entry point | `--in <jsonl> --outdir <path> --mode won_only` |

### `tests/test_magezero_filters.py`

43 tests across 7 classes, all synthetic fixtures.

## How tested

```
43 passed in 0.29s
```

## Known gaps

- No large-corpus (100K+ rows) performance test — would be slow in CI
- No `--mode all` CLI integration test (covered by unit test of `outcome_filter`)