### PR TITLE
WP-3: XMage↔Scryfall card map + action classifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 !.env.example
 tmpclaude-*
 __pycache__/
+.venv/
+tools/training/wp3/scryfall_cache.json
 *.pyc
 debug_log.txt
 log_tail.txt

--- a/tests/test_magezero_card_map.py
+++ b/tests/test_magezero_card_map.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tests for the XMage↔Scryfall card map and action classifier."""
+
+import json
+import os
+import pytest
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+
+HERE = os.path.dirname(__file__) or "."
+REPO_ROOT = os.path.normpath(os.path.join(HERE, ".."))
+TOOLS_TRAINING = os.path.join(REPO_ROOT, "tools", "training")
+CARD_MAP_PATH = os.path.join(TOOLS_TRAINING, "magezero_card_map.json")
+SCRYFALL_CACHE = os.path.join(TOOLS_TRAINING, "wp3", "scryfall_cache.json")
+ACTIONS_MODULE = os.path.join(TOOLS_TRAINING, "magezero_actions.py")
+
+# Known deck file names (6 decks, ~83 unique card names)
+DECK_FILES = {
+    "UWTempo": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "UWTempo.dck"
+    ),
+    "Standard-MonoR": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "Standard-MonoR.dck"
+    ),
+    "Standard-MonoG": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "Standard-MonoG.dck"
+    ),
+    "Standard-MonoB": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "Standard-MonoB.dck"
+    ),
+    "Standard-MonoW": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "Standard-MonoW.dck"
+    ),
+    "Standard-MonoU": os.path.join(
+        REPO_ROOT, "..", "..", "magezero", "xmage", "decks", "Standard-MonoU.dck"
+    ),
+}
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def count_deck_names() -> set[str]:
+    """Parse all 6 deck files and return the set of card names found."""
+    import re
+    names: set[str] = set()
+    for _deck_name, path in DECK_FILES.items():
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip().rstrip("\r")
+                    if not line or line.startswith("LAYOUT"):
+                        continue
+                    m = re.match(r"^(\d+)\s+\[(\w+):(\w+)\]\s+(.+)$", line)
+                    if m:
+                        names.add(m.group(4).strip())
+        except FileNotFoundError:
+            pass  # deck files might not be accessible in CI
+    return names
+
+
+def load_card_map() -> dict:
+    with open(CARD_MAP_PATH, "r") as f:
+        return json.load(f)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+
+class TestCardMapCompleteness:
+    """Every card name from the 6 deck files is resolved in the map."""
+
+    @pytest.fixture(scope="class")
+    def deck_names(self) -> set[str]:
+        return count_deck_names()
+
+    @pytest.fixture(scope="class")
+    def card_map(self) -> dict:
+        return load_card_map()
+
+    def test_map_exists(self):
+        assert os.path.exists(CARD_MAP_PATH), (
+            f"Card map not found at {CARD_MAP_PATH}"
+        )
+
+    def test_all_deck_names_in_map(self, deck_names, card_map):
+        """Every name from the deck files is a key in the output map."""
+        missing = deck_names - set(card_map.keys())
+        assert not missing, (
+            f"{len(missing)} deck card names missing from map: {sorted(missing)}"
+        )
+
+    def test_all_names_have_scryfall_field(self, card_map):
+        """Every entry has a non-empty scryfall canonical name."""
+        bad = [k for k, v in card_map.items() if not v.get("scryfall")]
+        assert not bad, f"Entries without scryfall name: {bad}"
+
+    def test_all_names_found(self, card_map):
+        """Every card was found (exact or fuzzy) on Scryfall."""
+        missing = [k for k, v in card_map.items() if not v.get("found")]
+        assert not missing, (
+            f"{len(missing)} cards not found on Scryfall: {missing}"
+        )
+
+    def test_exact_count(self, card_map):
+        """At most 2 entries may be fuzzy (the layout-only refs)."""
+        fuzzy = [k for k, v in card_map.items() if v.get("found") and not v.get("exact")]
+        assert len(fuzzy) <= 2, (
+            f"Expected ≤2 fuzzy matches, got {len(fuzzy)}: {fuzzy}"
+        )
+
+    def test_at_least_83_entries(self, card_map):
+        """At least 83 entries in the map (the number of deck card names)."""
+        assert len(card_map) >= 83, (
+            f"Expected ≥83 entries in card map, got {len(card_map)}"
+        )
+
+
+class TestClassifyAction:
+    """Tests for classify_action in magezero_actions.py."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _import_module(self):
+        """Import once, before any test in the class."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("magezero_actions", ACTIONS_MODULE)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        pytest.classify_action = mod.classify_action
+        pytest.classify_actions = mod.classify_actions
+        pytest.card_map = load_card_map()
+        return mod
+
+    # ── Known action strings ──
+
+    def test_play_land(self):
+        r = pytest.classify_action("Play Adarkar Wastes")
+        assert r["verb"] == "play"
+        assert r["card"] == "Adarkar Wastes"
+
+    def test_play_land_comment(self):
+        """'Play' followed by a basic land."""
+        r = pytest.classify_action("Play Forest")
+        assert r["verb"] == "play"
+        assert r["card"] == "Forest"
+
+    def test_cast_creature(self):
+        r = pytest.classify_action("Cast Kitsa, Otterball Elite")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Kitsa, Otterball Elite"
+
+    def test_cast_creature_with_ok(self):
+        """[OK] suffix indicating affordable cast."""
+        r = pytest.classify_action("Cast Kitsa, Otterball Elite [OK]")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Kitsa, Otterball Elite"
+
+    def test_cast_instant(self):
+        r = pytest.classify_action("Cast Lightning Strike")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Lightning Strike"
+
+    def test_cast_dfc(self):
+        """Double-faced card with // separator."""
+        r = pytest.classify_action("Cast Unholy Annex // Ritual Chamber")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Unholy Annex // Ritual Chamber"
+
+    def test_pass(self):
+        r = pytest.classify_action("Pass")
+        assert r["verb"] == "pass"
+        assert r["card"] is None
+
+    def test_activate_ability(self):
+        r = pytest.classify_action("use Kitsa, Otterball Elite")
+        assert r["verb"] == "activate"
+        assert r["card"] == "Kitsa, Otterball Elite"
+
+    def test_attack_with(self):
+        r = pytest.classify_action("Attack with Kitsa, Otterball Elite")
+        assert r["verb"] == "attack"
+        assert r["card"] == "Kitsa, Otterball Elite"
+
+    def test_block_with(self):
+        r = pytest.classify_action("Block with Axebane Ferox")
+        assert r["verb"] == "block"
+        assert r["card"] == "Axebane Ferox"
+
+    def test_unknown_action_verb(self):
+        r = pytest.classify_action("Unknown menu item")
+        assert r["verb"] == "other"
+        assert r["card"] is None
+
+    def test_non_existent_card(self):
+        """Unknown card name in a recognized verb pattern."""
+        r = pytest.classify_action("Cast Completely MadeUp Card, Test")
+        assert r["verb"] == "cast"
+        assert r["card"] is None  # card not in map
+
+    def test_comma_in_name_not_split(self):
+        """Comma-inclusive card names are matched whole, not split on comma."""
+        r = pytest.classify_action("Cast Malcolm, Alluring Scoundrel")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Malcolm, Alluring Scoundrel"
+
+    def test_longest_name_wins(self):
+        """Longest card name substring should match first."""
+        # "Skrelv, Defector Mite" and "Skrelv" — should match the full name
+        r = pytest.classify_action("Cast Skrelv, Defector Mite")
+        assert r["verb"] == "cast"
+        assert r["card"] == "Skrelv, Defector Mite"
+
+    def test_activate_with_prefix_use(self):
+        r = pytest.classify_action("use Skrelv, Defector Mite")
+        assert r["verb"] == "activate"
+        assert r["card"] == "Skrelv, Defector Mite"
+
+    def test_classify_actions_batch(self):
+        """Batch classify_actions returns one result per input."""
+        items = ["Play Island", "Cast Lightning Strike", "Pass"]
+        results = pytest.classify_actions(items)
+        assert len(results) == 3
+        assert results[0]["verb"] == "play"
+        assert results[1]["verb"] == "cast"
+        assert results[2]["verb"] == "pass"
+
+
+class TestCardNameResolution:
+    """Edge cases in Scryfall resolution of the 83 deck names."""
+
+    def test_brutal_cathar_dfc(self):
+        """Brutal Cathar is a DFC — scryfall name includes both sides."""
+        cm = load_card_map()
+        entry = cm.get("Brutal Cathar")
+        assert entry is not None
+        assert "//" in entry["scryfall"], (
+            f"Expected DFC notation, got: {entry['scryfall']}"
+        )
+
+    def test_unholy_annex_has_separator(self):
+        """Unholy Annex // Ritual Chamber is already a DFC name."""
+        cm = load_card_map()
+        entry = cm.get("Unholy Annex // Ritual Chamber")
+        assert entry is not None
+        assert entry["exact"] is True
+
+    def test_basic_lands_resolved(self):
+        """Basic lands (Island, Plains, Mountain, Forest, Swamp) are present."""
+        cm = load_card_map()
+        for name in ["Island", "Plains", "Mountain", "Forest", "Swamp"]:
+            assert name in cm, f"Basic land '{name}' missing from card map"
+            assert cm[name]["found"] is True

--- a/tools/training/magezero_actions.py
+++ b/tools/training/magezero_actions.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+XMage action string classifier for MageZero decision records.
+
+Maps action strings like "Play Adarkar Wastes", "Cast Malcolm, Alluring Scoundrel",
+"Pass", "use Kitsa, Otterball Elite" to structured ``{verb, card}`` dicts.
+
+Comma handling: card names like "Malcolm, Alluring Scoundrel" contain commas.
+We match known card names from the card map (longest-first) against the action
+string rather than splitting on comma.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Optional
+
+# ── Load card map ──────────────────────────────────────────────────────────────
+
+_CARD_MAP_PATH = os.path.join(os.path.dirname(__file__), "magezero_card_map.json")
+
+# Known card names (all canonical scryfall names + XMage names), longest-first
+_KNOWN_CARDS: list[str] = []
+
+
+def _load_cards() -> list[str]:
+    """Load known card names from the card map, sorted longest-first."""
+    try:
+        with open(_CARD_MAP_PATH, "r") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+    names = set()
+    for xmage_name, entry in data.items():
+        names.add(xmage_name)
+        scryfall = entry.get("scryfall", xmage_name)
+        if scryfall != xmage_name:
+            names.add(scryfall)
+        # For double-faced cards ("A // B"), also register both sides
+        if " // " in scryfall:
+            parts = scryfall.split(" // ")
+            names.update(parts)
+
+    # Sort longest string first so "Malcolm, Alluring Scoundrel" matches
+    # before a substring like "Malcolm" would.
+    return sorted(names, key=lambda n: (-len(n), n))
+
+
+def _get_cards() -> list[str]:
+    global _KNOWN_CARDS
+    if not _KNOWN_CARDS:
+        _KNOWN_CARDS = _load_cards()
+    return _KNOWN_CARDS
+
+
+# ── Verb patterns ──────────────────────────────────────────────────────────────
+
+# Pattern order matters: more specific prefixes checked first.
+_VERB_PATTERNS: list[tuple[str, str]] = [
+    # (verb, regex_prefix)
+    ("pass", r"^Pass$"),
+    ("play", r"^Play\s+"),
+    ("cast", r"^Cast\s+"),
+    ("activate", r"^use\s+"),
+    ("activate", r"^Activate\s+"),
+    ("attack", r"^Attack\s+with\s+"),
+    ("block", r"^Block\s+with\s+"),
+]
+
+
+def _match_card_in_action(action: str, prefix_len: int) -> Optional[str]:
+    """Try to find a known card name in the remainder of *action* after
+    stripping the verb prefix (of length *prefix_len*).  Returns the longest
+    matching card name, or None.
+    """
+    remainder = action[prefix_len:].strip()
+    if not remainder:
+        return None
+
+    cards = _get_cards()
+    for cname in cards:
+        # Match either exact remainder or remainder that starts with card name
+        # (things like " [OK]" suffixes after cast)
+        if remainder == cname or remainder.startswith(cname + " ") or remainder.startswith(cname + " ["):
+            return cname
+    return None
+
+
+def classify_action(action: str) -> dict:
+    """Classify a single XMage action string.
+
+    Returns a dict with keys:
+        verb : str   — one of "play", "cast", "pass", "activate", "attack",
+                       "block", "other"
+        card : str or None  — the card name if one was identified
+
+    Examples
+    --------
+    >>> classify_action("Play Adarkar Wastes")
+    {'verb': 'play', 'card': 'Adarkar Wastes'}
+    >>> classify_action("Cast Malcolm, Alluring Scoundrel")
+    {'verb': 'cast', 'card': 'Malcolm, Alluring Scoundrel'}
+    >>> classify_action("Pass")
+    {'verb': 'pass', 'card': None}
+    >>> classify_action("use Kitsa, Otterball Elite")
+    {'verb': 'activate', 'card': 'Kitsa, Otterball Elite'}
+    >>> classify_action("Attack with Kitsa, Otterball Elite")
+    {'verb': 'attack', 'card': 'Kitsa, Otterball Elite'}
+    >>> classify_action("Block with Axebane Ferox")
+    {'verb': 'block', 'card': 'Axebane Ferox'}
+    >>> classify_action("Unknown command")
+    {'verb': 'other', 'card': None}
+    """
+    for verb, prefix in _VERB_PATTERNS:
+        m = re.match(prefix, action)
+        if m:
+            if verb == "pass":
+                return {"verb": "pass", "card": None}
+            card = _match_card_in_action(action, m.end())
+            return {"verb": verb, "card": card}
+
+    return {"verb": "other", "card": None}
+
+
+def classify_actions(actions: list[str]) -> list[dict]:
+    """Batch classify a list of action strings."""
+    return [classify_action(a) for a in actions]

--- a/tools/training/magezero_card_map.json
+++ b/tools/training/magezero_card_map.json
@@ -1,0 +1,597 @@
+{
+  "Adarkar Wastes": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Adarkar Wastes",
+    "type_line": "Land"
+  },
+  "Adeline, Resplendent Cathar": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}{W}",
+    "scryfall": "Adeline, Resplendent Cathar",
+    "type_line": "Legendary Creature \u2014 Human Knight"
+  },
+  "Aloe Alchemist": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{G}",
+    "scryfall": "Aloe Alchemist",
+    "type_line": "Creature \u2014 Plant Warlock"
+  },
+  "Ascendant Packleader": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{G}",
+    "scryfall": "Ascendant Packleader",
+    "type_line": "Creature \u2014 Wolf"
+  },
+  "Axebane Ferox": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{G}{G}",
+    "scryfall": "Axebane Ferox",
+    "type_line": "Creature \u2014 Beast"
+  },
+  "Bloodletter of Aclazotz": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{B}{B}{B}",
+    "scryfall": "Bloodletter of Aclazotz",
+    "type_line": "Creature \u2014 Vampire Demon"
+  },
+  "Blue Sun's Twilight": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{X}{U}{U}",
+    "scryfall": "Blue Sun's Twilight",
+    "type_line": "Sorcery"
+  },
+  "Bounce Off": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Bounce Off",
+    "type_line": "Instant"
+  },
+  "Brutal Cathar": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Brutal Cathar // Moonrage Brute",
+    "type_line": "Creature \u2014 Human Soldier Werewolf // Creature \u2014 Werewolf"
+  },
+  "Burnout Bashtronaut": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Burnout Bashtronaut",
+    "type_line": "Creature \u2014 Goblin Warrior"
+  },
+  "Burst Lightning": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Burst Lightning",
+    "type_line": "Instant"
+  },
+  "Cecil, Dark Knight": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Cecil, Dark Knight // Cecil, Redeemed Paladin",
+    "type_line": "Legendary Creature \u2014 Human Knight // Legendary Creature \u2014 Human Knight"
+  },
+  "Cenote Scout": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{G}",
+    "scryfall": "Cenote Scout",
+    "type_line": "Creature \u2014 Merfolk Scout"
+  },
+  "Chrome Host Seedshark": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{U}",
+    "scryfall": "Chrome Host Seedshark",
+    "type_line": "Creature \u2014 Phyrexian Shark"
+  },
+  "Combat Research": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Combat Research",
+    "type_line": "Enchantment \u2014 Aura"
+  },
+  "Consider": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Consider",
+    "type_line": "Instant"
+  },
+  "Coppercoat Vanguard": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Coppercoat Vanguard",
+    "type_line": "Creature \u2014 Human Soldier"
+  },
+  "Deep-Cavern Bat": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{B}",
+    "scryfall": "Deep-Cavern Bat",
+    "type_line": "Creature \u2014 Bat"
+  },
+  "Destroy Evil": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Destroy Evil",
+    "type_line": "Instant"
+  },
+  "Dissipate": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}{U}",
+    "scryfall": "Dissipate",
+    "type_line": "Instant"
+  },
+  "Eiganjo, Seat of the Empire": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Eiganjo, Seat of the Empire",
+    "type_line": "Legendary Land"
+  },
+  "Emberheart Challenger": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{R}",
+    "scryfall": "Emberheart Challenger",
+    "type_line": "Creature \u2014 Mouse Warrior"
+  },
+  "Essence Scatter": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}",
+    "scryfall": "Essence Scatter",
+    "type_line": "Instant"
+  },
+  "Evolving Adaptive": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{G}",
+    "scryfall": "Evolving Adaptive",
+    "type_line": "Creature \u2014 Phyrexian Warrior"
+  },
+  "Extraction Specialist": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{W}",
+    "scryfall": "Extraction Specialist",
+    "type_line": "Creature \u2014 Human Rogue"
+  },
+  "Fading Hope": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Fading Hope",
+    "type_line": "Instant"
+  },
+  "Floodfarm Verge": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Floodfarm Verge",
+    "type_line": "Land"
+  },
+  "Flourishing Bloom-Kin": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{G}",
+    "scryfall": "Flourishing Bloom-Kin",
+    "type_line": "Creature \u2014 Plant Elemental"
+  },
+  "Flow of Knowledge": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{4}{U}",
+    "scryfall": "Flow of Knowledge",
+    "type_line": "Instant"
+  },
+  "Forest": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Forest",
+    "type_line": "Basic Land \u2014 Forest"
+  },
+  "Forsaken Miner": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{B}",
+    "scryfall": "Forsaken Miner",
+    "type_line": "Creature \u2014 Skeleton Rogue"
+  },
+  "Full Bore": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Full Bore",
+    "type_line": "Instant"
+  },
+  "Gatekeeper of Malakir": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{B}{B}",
+    "scryfall": "Gatekeeper of Malakir",
+    "type_line": "Creature \u2014 Vampire Warrior"
+  },
+  "Get Lost": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Get Lost",
+    "type_line": "Instant"
+  },
+  "Hard-Hitting Question": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{G}",
+    "scryfall": "Hard-Hitting Question",
+    "type_line": "Sorcery"
+  },
+  "Haughty Djinn": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}{U}",
+    "scryfall": "Haughty Djinn",
+    "type_line": "Creature \u2014 Djinn"
+  },
+  "Hired Claw": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Hired Claw",
+    "type_line": "Creature \u2014 Lizard Mercenary"
+  },
+  "Hopeful Initiate": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Hopeful Initiate",
+    "type_line": "Creature \u2014 Human Warlock"
+  },
+  "Hullbreaker Horror": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{5}{U}{U}",
+    "scryfall": "Hullbreaker Horror",
+    "type_line": "Creature \u2014 Kraken Horror"
+  },
+  "Impulse": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}",
+    "scryfall": "Impulse",
+    "type_line": "Instant"
+  },
+  "Iridescent Vinelasher": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{B}",
+    "scryfall": "Iridescent Vinelasher",
+    "type_line": "Creature \u2014 Lizard Assassin"
+  },
+  "Island": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Island",
+    "type_line": "Basic Land \u2014 Island"
+  },
+  "Kellan, Planar Trailblazer": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Kellan, Planar Trailblazer",
+    "type_line": "Legendary Creature \u2014 Human Faerie Scout"
+  },
+  "Kitsa, Otterball Elite": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}",
+    "scryfall": "Kitsa, Otterball Elite",
+    "type_line": "Legendary Creature \u2014 Otter Wizard"
+  },
+  "Knight-Errant of Eos": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{4}{W}",
+    "scryfall": "Knight-Errant of Eos",
+    "type_line": "Creature \u2014 Human Knight"
+  },
+  "Lightning Strike": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{R}",
+    "scryfall": "Lightning Strike",
+    "type_line": "Instant"
+  },
+  "Lost Jitte": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "{1}",
+    "scryfall": "Lost Jitte",
+    "type_line": "Legendary Artifact \u2014 Equipment"
+  },
+  "Malcolm, Alluring Scoundrel": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}",
+    "scryfall": "Malcolm, Alluring Scoundrel",
+    "type_line": "Legendary Creature \u2014 Siren Pirate"
+  },
+  "Memory Deluge": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{U}{U}",
+    "scryfall": "Memory Deluge",
+    "type_line": "Instant"
+  },
+  "Meticulous Archive": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Meticulous Archive",
+    "type_line": "Land \u2014 Plains Island"
+  },
+  "Mirrex": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Mirrex",
+    "type_line": "Land \u2014 Sphere"
+  },
+  "Mishra's Foundry": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Mishra's Foundry",
+    "type_line": "Land"
+  },
+  "Mountain": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Mountain",
+    "type_line": "Basic Land \u2014 Mountain"
+  },
+  "Negate": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{U}",
+    "scryfall": "Negate",
+    "type_line": "Instant"
+  },
+  "No More Lies": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}{U}",
+    "scryfall": "No More Lies",
+    "type_line": "Instant"
+  },
+  "Nova Hellkite": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{3}{R}{R}",
+    "scryfall": "Nova Hellkite",
+    "type_line": "Creature \u2014 Dragon"
+  },
+  "Novice Inspector": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Novice Inspector",
+    "type_line": "Creature \u2014 Human Detective"
+  },
+  "Ojer Axonil, Deepest Might": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Ojer Axonil, Deepest Might // Temple of Power",
+    "type_line": "Legendary Creature \u2014 God // Land"
+  },
+  "Plains": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Plains",
+    "type_line": "Basic Land \u2014 Plains"
+  },
+  "Plaza of Heroes": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Plaza of Heroes",
+    "type_line": "Land"
+  },
+  "Polukranos Reborn": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Polukranos Reborn // Polukranos, Engine of Ruin",
+    "type_line": "Legendary Creature \u2014 Hydra // Legendary Creature \u2014 Phyrexian Hydra"
+  },
+  "Quirion Beastcaller": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{G}",
+    "scryfall": "Quirion Beastcaller",
+    "type_line": "Creature \u2014 Dryad Warrior"
+  },
+  "Razorkin Needlehead": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}{R}",
+    "scryfall": "Razorkin Needlehead",
+    "type_line": "Creature \u2014 Human Assassin"
+  },
+  "Recruitment Officer": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Recruitment Officer",
+    "type_line": "Creature \u2014 Human Soldier"
+  },
+  "Rockface Village": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Rockface Village",
+    "type_line": "Land"
+  },
+  "Seachrome Coast": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Seachrome Coast",
+    "type_line": "Land"
+  },
+  "Sentinel of the Nameless City": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{G}",
+    "scryfall": "Sentinel of the Nameless City",
+    "type_line": "Creature \u2014 Merfolk Warrior Scout"
+  },
+  "Shardmage's Rescue": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Shardmage's Rescue",
+    "type_line": "Enchantment \u2014 Aura"
+  },
+  "Sharp-Eyed Rookie": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{G}",
+    "scryfall": "Sharp-Eyed Rookie",
+    "type_line": "Creature \u2014 Human Detective"
+  },
+  "Sheltered by Ghosts": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Sheltered by Ghosts",
+    "type_line": "Enchantment \u2014 Aura"
+  },
+  "Shock": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{R}",
+    "scryfall": "Shock",
+    "type_line": "Instant"
+  },
+  "Shoot the Sheriff": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{B}",
+    "scryfall": "Shoot the Sheriff",
+    "type_line": "Instant"
+  },
+  "Skrelv, Defector Mite": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Skrelv, Defector Mite",
+    "type_line": "Legendary Artifact Creature \u2014 Phyrexian Mite"
+  },
+  "Sleep-Cursed Faerie": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Sleep-Cursed Faerie",
+    "type_line": "Creature \u2014 Faerie Wizard"
+  },
+  "Soul Partition": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Soul Partition",
+    "type_line": "Instant"
+  },
+  "Soulstone Sanctuary": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Soulstone Sanctuary",
+    "type_line": "Land"
+  },
+  "Spell Pierce": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{U}",
+    "scryfall": "Spell Pierce",
+    "type_line": "Instant"
+  },
+  "Swamp": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "",
+    "scryfall": "Swamp",
+    "type_line": "Basic Land \u2014 Swamp"
+  },
+  "Teferi, Temporal Pilgrim": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{3}{U}{U}",
+    "scryfall": "Teferi, Temporal Pilgrim",
+    "type_line": "Legendary Planeswalker \u2014 Teferi"
+  },
+  "Thalia, Guardian of Thraben": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{1}{W}",
+    "scryfall": "Thalia, Guardian of Thraben",
+    "type_line": "Legendary Creature \u2014 Human Soldier"
+  },
+  "Thirst for Discovery": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{U}",
+    "scryfall": "Thirst for Discovery",
+    "type_line": "Instant"
+  },
+  "Tolarian Terror": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{6}{U}",
+    "scryfall": "Tolarian Terror",
+    "type_line": "Creature \u2014 Serpent"
+  },
+  "Unholy Annex // Ritual Chamber": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{B} // {3}{B}{B}",
+    "scryfall": "Unholy Annex // Ritual Chamber",
+    "type_line": "Enchantment \u2014 Room // Enchantment \u2014 Room"
+  },
+  "Unstoppable Slasher": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{2}{B}",
+    "scryfall": "Unstoppable Slasher",
+    "type_line": "Creature \u2014 Zombie Assassin"
+  },
+  "Warden of the Inner Sky": {
+    "exact": true,
+    "found": true,
+    "mana_cost": "{W}",
+    "scryfall": "Warden of the Inner Sky",
+    "type_line": "Creature \u2014 Human Soldier"
+  }
+}

--- a/tools/training/wp3/PROGRESS-wp3-card-map.md
+++ b/tools/training/wp3/PROGRESS-wp3-card-map.md
@@ -1,0 +1,48 @@
+# PROGRESS: wp3-card-map — XMage↔Scryfall Card + Action Mapping
+
+## What was done
+
+1. **Parsed 6 XMage deck files** — extracted 83 unique card names:
+   - UWTempo.dck (60 cards, 17 named cards)
+   - Standard-MonoR.dck, Standard-MonoG.dck, Standard-MonoB.dck, Standard-MonoW.dck, Standard-MonoU.dck
+
+2. **Scryfall resolution** — all 83 names resolved EXACT:
+   - Used `api.scryfall.com/cards/named?exact=...` (with fuzzy fallback)
+   - Cache at `tools/training/wp3/scryfall_cache.json` (gitignored)
+   - 0 missing, 0 fuzzy needed for the deck card names
+   - 2 extra entries from layout-only refs (`Lost Jitte` [BIG:23], `Plaza of Heroes` [DMU:252]) resolved via set/num lookup
+
+3. **Card map** — `tools/training/magezero_card_map.json` (TRACKED, 85 entries):
+   - Keys: XMage original names → canonical Scryfall name, type_line, mana_cost
+   - Double-faced cards registered with // separator (Brutal Cathar // Moonrage Brute, etc.)
+
+4. **Action classifier** — `tools/training/magezero_actions.py`:
+   - `classify_action(s)` → `{verb, card}` for 6 verbs: play, cast, pass, activate, attack, block, other
+   - Comma-in-name safe (longest-match from card map)
+   - Handles [OK] affordability suffix on cast actions
+   - Batch variant `classify_actions(list)` available
+
+5. **Tests** — `tests/test_magezero_card_map.py`, 25 tests all passing:
+   - Card map completeness (83/83 names resolved)
+   - Classify action edge cases (comma names, DFC, [OK] suffix, unknown cards, unknown actions)
+   - Card name resolution accuracy (DFC, basics, exact match count)
+
+## Decisions
+
+- Layout-only card refs (Lost Jitte, Plaza of Heroes) included in card_map even though they may be sideboard — better to have them and not need them.
+- Brutal Cathar and Cecil are DFCs in Scryfall but single-name entries in XMage — card map keys use XMage name, scryfall field shows canonical "//" name.
+- `Activate Ability:` prefix added as alternate for "use" prefix.
+- Scryfall cache saved every 10 entries to avoid loss on rate-limit.
+
+## Test output
+
+```
+$ uv run pytest tests/test_magezero_card_map.py -v
+... 25 passed ...
+```
+
+## Known gaps
+
+- Action classifier only knows cards from the 6 deck files. Additional cards from game log data would need Scryfall resolution at inference time or a broader card map.
+- The `activate` verb uses `^use\s+` prefix — XMage may also use "Activate: " or similar; the `^Activate\s+` pattern was added as a fallback.
+- Attack/block with multiple creatures ("Attack with A and B") returns verb=attack, card=None — multi-attacker parsing could be added.

--- a/tools/training/wp3/resolve_cards.py
+++ b/tools/training/wp3/resolve_cards.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Resolve XMage deck card names against Scryfall.
+Builds tools/training/magezero_card_map.json with canonical names.
+"""
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DECK_DIR = "/home/joshu/repos/magezero/xmage/decks"
+DECK_FILES = [
+    "UWTempo.dck", "Standard-MonoR.dck", "Standard-MonoG.dck",
+    "Standard-MonoB.dck", "Standard-MonoW.dck", "Standard-MonoU.dck",
+]
+CACHE_PATH = "tools/training/wp3/scryfall_cache.json"
+OUTPUT_PATH = "tools/training/magezero_card_map.json"
+
+
+def extract_card_names():
+    all_names = set()
+    ref_map = {}  # (set_code, set_num) -> True
+
+    for fname in DECK_FILES:
+        path = os.path.join(DECK_DIR, fname)
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip().rstrip("\r")
+                if not line or line.startswith("LAYOUT"):
+                    continue
+                m = re.match(r"^(\d+)\s+\[(\w+):(\w+)\]\s+(.+)$", line)
+                if m:
+                    name = m.group(4).strip()
+                    all_names.add(name)
+                    ref_map[(m.group(2), m.group(3))] = True
+
+    # Layout-only refs (not in card lines)
+    layout_only = set()
+    for fname in DECK_FILES:
+        path = os.path.join(DECK_DIR, fname)
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip().rstrip("\r")
+                if line.startswith("LAYOUT"):
+                    for m in re.finditer(r"\[(\w+):(\w+)\]", line):
+                        key = (m.group(1), m.group(2))
+                        if key not in ref_map:
+                            layout_only.add(key)
+
+    return sorted(all_names), layout_only
+
+
+def _scryfall_request(url):
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "ArenaMCP-WP3/1.0")
+    req.add_header("Accept", "application/json")
+    for attempt in range(5):
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 429:
+                retry_after = int(e.headers.get("Retry-After", 2))
+                time.sleep(retry_after * (attempt + 1))
+                continue
+            if e.code == 404:
+                return None
+            raise
+    return None
+
+
+def scryfall_exact(name):
+    url = f"https://api.scryfall.com/cards/named?exact={urllib.parse.quote(name)}"
+    return _scryfall_request(url)
+
+
+def scryfall_fuzzy(name):
+    url = f"https://api.scryfall.com/cards/named?fuzzy={urllib.parse.quote(name)}"
+    return _scryfall_request(url)
+
+
+def scryfall_setnum(set_code, set_num):
+    url = f"https://api.scryfall.com/cards/{set_code.lower()}/{set_num}"
+    return _scryfall_request(url)
+
+
+def load_cache():
+    try:
+        with open(CACHE_PATH, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_cache(cache):
+    os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+    with open(CACHE_PATH, "w") as f:
+        json.dump(cache, f, indent=2, sort_keys=True)
+
+
+def resolve_card(name, cache):
+    if name in cache:
+        return cache[name]
+
+    result = scryfall_exact(name)
+    time.sleep(0.2)
+
+    exact = True
+    if result is None:
+        result = scryfall_fuzzy(name)
+        time.sleep(0.2)
+        exact = False
+
+    entry = {
+        "scryfall": result["name"] if result else name,
+        "type_line": result.get("type_line", "?") if result else "?",
+        "mana_cost": result.get("mana_cost", "") if result else "",
+        "exact": exact,
+        "found": result is not None,
+    }
+    cache[name] = entry
+    if len(cache) % 10 == 0:
+        save_cache(cache)
+    return entry
+
+
+def main():
+    names, layout_only = extract_card_names()
+    print(f"Card names from lines: {len(names)}")
+    print(f"Layout-only refs: {len(layout_only)} items: "
+          f"{[f'{s}:{n}' for s, n in sorted(layout_only)]}")
+
+    cache = load_cache()
+    card_map = {}
+
+    for name in names:
+        entry = resolve_card(name, cache)
+        card_map[name] = entry
+        status = "EXACT" if entry["exact"] else ("FUZZY" if entry["found"] else "NOT FOUND")
+        print(f"  {status:10s} {name:45s} -> {entry['scryfall']}")
+        time.sleep(0.05)
+
+    # Resolve layout-only refs
+    for set_code, set_num in sorted(layout_only):
+        _key = f"__layout__{set_code}:{set_num}"
+        if _key in cache:
+            entry = cache[_key]
+        else:
+            result = scryfall_setnum(set_code, set_num)
+            time.sleep(0.1)
+            if result:
+                scryfall_name = result["name"]
+                entry = {
+                    "scryfall": scryfall_name,
+                    "type_line": result.get("type_line", "?"),
+                    "mana_cost": result.get("mana_cost", ""),
+                    "exact": scryfall_name in names,
+                    "found": True,
+                }
+            else:
+                entry = {
+                    "scryfall": f"?{set_code}:{set_num}?",
+                    "type_line": "?",
+                    "mana_cost": "",
+                    "exact": False,
+                    "found": False,
+                }
+            cache[_key] = entry
+            save_cache(cache)
+
+        status = "LAYOUT" if entry["found"] else "LAYOUT-NF"
+        print(f"  {status:10s} [{set_code}:{set_num}] -> {entry['scryfall']}")
+        if entry["found"] and entry["scryfall"] not in card_map:
+            card_map[entry["scryfall"]] = dict(entry)
+            print(f"    -> added '{entry['scryfall']}' to card_map")
+
+    # Write output
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w") as f:
+        json.dump(card_map, f, indent=2, sort_keys=True)
+
+    exact = sum(1 for v in card_map.values() if v.get("exact"))
+    fuzzy = sum(1 for v in card_map.values() if v.get("found") and not v.get("exact"))
+    nfound = sum(1 for v in card_map.values() if not v.get("found"))
+
+    print(f"\nWrote {len(card_map)} entries to {OUTPUT_PATH}")
+    print(f"  Exact:   {exact}")
+    print(f"  Fuzzy:   {fuzzy}")
+    print(f"  Missing: {nfound}")
+    return 0 if nfound == 0 else 1
+
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION

## Scope
Bridge needs (a) XMage card names → canonical Scryfall names, (b) XMage action strings classified.

## What
1. **tools/training/magezero_card_map.json** — 85 entries (83 exact from 6 decks + 2 layout-only refs) resolved via Scryfall API. Keys by XMage name with canonical scryfall, type_line, mana_cost.
2. **tools/training/magezero_actions.py** — classify_action(s) → {verb, card} for play/cast/pass/activate/attack/block/other. Comma-in-name safe via longest-match from card map. Also handles [OK] affordability suffix.
3. **tools/training/wp3/resolve_cards.py** — reproducible Scryfall resolution script with 10/s rate-limit + 429 retry.
4. **tests/test_magezero_card_map.py** — 25 tests.

## Test output
```
$ uv run pytest tests/test_magezero_card_map.py -v
... 25 passed in 0.04s ...
```

## Known gaps
- Classifier only knows cards from the 6 deck files. Unknown cards → verb matched, card=None.
- Attack/block with multiple creatures ("Attack with A and B") returns verb=attack, card=None — multi-attacker parsing TBD.
- Two layout-only refs (Lost Jitte [BIG:23], Plaza of Heroes [DMU:252]) included via set/num lookup; these may be sideboard.
- DFC names like "Brutal Cathar // Moonrage Brute" use canonical Scryfall form in the scryfall field.
