### PR TITLE
WP-3: bridge-x-chooser — submit_x + CastingTimeOption numeric fields (#390)

### DIFF
--- a/bepinex-plugin/MtgaCoachBridge/Plugin.cs
+++ b/bepinex-plugin/MtgaCoachBridge/Plugin.cs
@@ -430,6 +430,10 @@ namespace MtgaCoachBridge
                     HandleSubmitNumeric(cmd);
                     break;
 
+                case "submit_x":
+                    HandleSubmitX(cmd);
+                    break;
+
                 case "submit_targets":
                     HandleSubmitTargets(cmd);
                     break;
@@ -836,6 +840,38 @@ namespace MtgaCoachBridge
                 }
                 resp["actions"] = actionsArr;
                 resp["decision_context"] = BuildCastingTimeOptionDecisionContext(entries);
+                resp["can_pass"] = castingReq.CanCancel;
+
+                // Surface numeric-input child fields for X-cost spells so
+                // Python can reason about the value range directly instead
+                // of relying solely on the enumerated entries.
+                foreach (var child in castingReq.ChildRequests)
+                {
+                    if (child is CastingTimeOption_NumericInputRequest numericChild)
+                    {
+                        resp["numeric_min"] = (int)numericChild.Min;
+                        resp["numeric_max"] = (int)numericChild.Max;
+                        if (numericChild.StepSize > 0)
+                            resp["numeric_step"] = (int)numericChild.StepSize;
+
+                        var disallowedArr = new JArray();
+                        if (numericChild.DisallowedValues != null)
+                            foreach (var v in numericChild.DisallowedValues)
+                                disallowedArr.Add((int)v);
+                        if (disallowedArr.Count > 0)
+                            resp["numeric_disallowed"] = disallowedArr;
+
+                        if (numericChild.DisallowEven)
+                            resp["numeric_disallow_even"] = true;
+                        if (numericChild.DisallowOdd)
+                            resp["numeric_disallow_odd"] = true;
+
+                        if (numericChild.GrpId != 0)
+                            resp["grp_id"] = (int)numericChild.GrpId;
+
+                        break; // At most one numeric child
+                    }
+                }
             }
             else if (request is SelectTargetsRequest targetsReqForCandidates)
             {
@@ -1587,6 +1623,58 @@ namespace MtgaCoachBridge
             else
             {
                 cmd.SetResponse(new JObject { ["ok"] = false, ["error"] = $"Pending is {request?.GetType().Name ?? "null"}, not NumericInputRequest" });
+            }
+        }
+
+        private void HandleSubmitX(PipeCommand cmd)
+        {
+            var request = FindPendingInteraction();
+            if (request is CastingTimeOptionRequest castingReq)
+            {
+                CastingTimeOption_NumericInputRequest numericChild = null;
+                foreach (var child in castingReq.ChildRequests)
+                {
+                    if (child is CastingTimeOption_NumericInputRequest n)
+                    {
+                        numericChild = n;
+                        break;
+                    }
+                }
+
+                if (numericChild == null)
+                {
+                    cmd.SetResponse(new JObject { ["ok"] = false, ["error"] = "CastingTimeOptionRequest has no CastingTimeOption_NumericInputRequest child" });
+                    return;
+                }
+
+                uint value = (uint)cmd.Json.Value<int>("value");
+                _log.LogInfo($"Submitting X value {value} via CastingTimeOption_NumericInputRequest.SubmitX");
+                numericChild.SubmitX(value);
+                lock (_interactionLock) { _lastKnownRequest = null; }
+                cmd.SetResponse(new JObject
+                {
+                    ["ok"] = true,
+                    ["submitted_type"] = "CastingTimeOption_X",
+                    ["value"] = (int)value
+                });
+            }
+            else if (request is NumericInputRequest numericReq)
+            {
+                // Also accept standalone NumericInputRequest for flexibility.
+                uint value = (uint)cmd.Json.Value<int>("value");
+                _log.LogInfo($"Submitting X value {value} via NumericInputRequest.SubmitValue (submit_x fallback)");
+                numericReq.SubmitValue(value);
+                lock (_interactionLock) { _lastKnownRequest = null; }
+                cmd.SetResponse(new JObject
+                {
+                    ["ok"] = true,
+                    ["submitted_type"] = "NumericInput",
+                    ["value"] = (int)value
+                });
+            }
+            else
+            {
+                cmd.SetResponse(new JObject { ["ok"] = false, ["error"] = $"Pending is {request?.GetType().Name ?? "null"}, not CastingTimeOptionRequest" });
             }
         }
 

--- a/src/arenamcp/gre_bridge.py
+++ b/src/arenamcp/gre_bridge.py
@@ -920,6 +920,33 @@ class GREBridge:
             logger.warning(f"GRE bridge submit_numeric error: {e}")
         return False
 
+    def submit_x(self, value: int) -> bool:
+        """Submit an X-cost value via the CastingTimeOption_NumericInputRequest.
+
+        Sends the submit_x pipe command which finds the
+        CastingTimeOption_NumericInputRequest child in the pending
+        CastingTimeOptionRequest and calls SubmitX(value) on it.
+
+        Also accepts standalone NumericInputRequest as a fallback
+        (older plugin paths).
+
+        Fail-closed: returns False if the plugin responds with an
+        error (e.g. no numeric child present), or on communication
+        failure.
+        """
+        try:
+            resp = self._send_safe({"action": "submit_x", "value": value})
+            if resp.get("ok"):
+                logger.info(
+                    f"GRE bridge submitted X value: {value} "
+                    f"(type={resp.get('submitted_type', '?')})"
+                )
+                return True
+            logger.warning(f"GRE bridge submit_x failed: {resp.get('error')}")
+        except GREBridgeError as e:
+            logger.warning(f"GRE bridge submit_x error: {e}")
+        return False
+
     def submit_targets(self, target_instance_id: int | list[int]) -> bool:
         """Submit target selection by instance ID(s).
 

--- a/tests/test_bridge_x_chooser.py
+++ b/tests/test_bridge_x_chooser.py
@@ -1,0 +1,291 @@
+"""Tests for the X-cost chooser bridge (submit_x + CastingTimeOption fields).
+
+Verifies that GREBridge.submit_x sends the correct pipe command and
+handles responses properly, and that get_pending_actions passes through
+the CastingTimeOption_NumericInputRequest fields surfaced by the plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+import pytest
+
+from arenamcp.gre_bridge import GREBridge, GREBridgeError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockPipe:
+    """A pipe mock that records writes and returns canned responses."""
+
+    def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
+        self._writes: list[bytes] = []
+        self._responses: list[bytes] = []
+        self._closed = threading.Event()
+        if responses:
+            for r in responses:
+                self._responses.append(
+                    (json.dumps(r, separators=(",", ":")) + "\n").encode("utf-8")
+                )
+
+    def write(self, data: bytes) -> int:
+        if self._closed.is_set():
+            raise OSError("Mock pipe closed")
+        self._writes.append(data)
+        return len(data)
+
+    def flush(self) -> None:
+        if self._closed.is_set():
+            raise OSError("Mock pipe closed")
+
+    def read(self, n: int) -> bytes:
+        if self._closed.is_set():
+            return b""
+        if self._responses:
+            return self._responses.pop(0)
+        return b""
+
+    def close(self) -> None:
+        self._closed.set()
+
+
+def _bridge_with_pipe(pipe: Any, *, timeout: float = 1.0) -> GREBridge:
+    bridge = GREBridge.__new__(GREBridge)
+    bridge._pipe_lock = threading.Lock()
+    bridge._pipe_file = pipe
+    bridge._connected = True
+    bridge._server_socket = None
+    bridge._client_socket = None
+    bridge._last_ping_at = 0.0
+    bridge._DEFAULT_READ_TIMEOUT_S = timeout
+    return bridge
+
+
+# ---------------------------------------------------------------------------
+# submit_x — command shape
+# ---------------------------------------------------------------------------
+
+
+def test_submit_x_sends_correct_action():
+    """submit_x must send {"action": "submit_x", "value": <int>}."""
+    pipe = _MockPipe([{"ok": True, "submitted_type": "CastingTimeOption_X", "value": 3}])
+    bridge = _bridge_with_pipe(pipe)
+    result = bridge.submit_x(3)
+    assert result is True
+    # Decode the write buffer to check command shape
+    written = json.loads(pipe._writes[0].decode("utf-8").strip())
+    assert written == {"action": "submit_x", "value": 3}
+
+
+def test_submit_x_returns_true_on_success():
+    """submit_x returns True when the plugin responds ok."""
+    pipe = _MockPipe([{"ok": True, "submitted_type": "CastingTimeOption_X", "value": 5}])
+    bridge = _bridge_with_pipe(pipe)
+    assert bridge.submit_x(5) is True
+
+
+def test_submit_x_returns_false_on_plugin_error():
+    """submit_x returns False when the plugin returns ok=False."""
+    pipe = _MockPipe([{"ok": False, "error": "CastingTimeOptionRequest has no CastingTimeOption_NumericInputRequest child"}])
+    bridge = _bridge_with_pipe(pipe)
+    assert bridge.submit_x(3) is False
+
+
+def test_submit_x_returns_false_on_disconnect():
+    """submit_x returns False when the pipe is disconnected."""
+    pipe = _MockPipe()
+    pipe.close()
+    bridge = _bridge_with_pipe(pipe)
+    with pytest.raises(GREBridgeError):
+        bridge._send_command({"action": "submit_x", "value": 0})
+
+
+def test_submit_x_value_zero():
+    """submit_x must handle X=0 (valid for e.g. Silkguard with no spare mana)."""
+    pipe = _MockPipe([{"ok": True, "submitted_type": "CastingTimeOption_X", "value": 0}])
+    bridge = _bridge_with_pipe(pipe)
+    assert bridge.submit_x(0) is True
+    written = json.loads(pipe._writes[0].decode("utf-8").strip())
+    assert written["value"] == 0
+
+
+def test_submit_x_value_max():
+    """submit_x must handle large X values (e.g. X=20 with lots of mana)."""
+    pipe = _MockPipe([{"ok": True, "submitted_type": "CastingTimeOption_X", "value": 20}])
+    bridge = _bridge_with_pipe(pipe)
+    assert bridge.submit_x(20) is True
+    written = json.loads(pipe._writes[0].decode("utf-8").strip())
+    assert written["value"] == 20
+
+
+# ---------------------------------------------------------------------------
+# CastingTimeOptionRequest numeric fields — get_pending_actions pass-through
+# ---------------------------------------------------------------------------
+
+
+def _casting_option_response(
+    *,
+    numeric_min: int = 0,
+    numeric_max: int = 10,
+    numeric_step: int = 1,
+    numeric_disallowed: list[int] | None = None,
+    numeric_disallow_even: bool = False,
+    numeric_disallow_odd: bool = False,
+    grp_id: int = 0,
+) -> dict[str, Any]:
+    """Build a plausible CastingTimeOptionRequest response with numeric fields."""
+    resp: dict[str, Any] = {
+        "ok": True,
+        "has_pending": True,
+        "request_type": "CastingTimeOptions",
+        "request_class": "CastingTimeOptionRequest",
+        "can_cancel": True,
+        "decision_context": {
+            "type": "casting_time_options",
+            "num_options": 4,
+            "options": [
+                {"actionType": "CastingTimeOption", "choiceKind": "done", "childIndex": 0, "label": "Done"},
+            ],
+        },
+        "actions": [
+            {"actionType": "CastingTimeOption", "choiceKind": "numeric_input", "label": "X = 0", "numericValue": 0},
+            {"actionType": "CastingTimeOption", "choiceKind": "numeric_input", "label": "X = 2", "numericValue": 2},
+            {"actionType": "CastingTimeOption", "choiceKind": "numeric_input", "label": "X = 4", "numericValue": 4},
+            {"actionType": "CastingTimeOption", "choiceKind": "done", "label": "Done"},
+        ],
+        "numeric_min": numeric_min,
+        "numeric_max": numeric_max,
+        "numeric_step": numeric_step,
+        "can_pass": True,
+    }
+    if numeric_disallowed:
+        resp["numeric_disallowed"] = numeric_disallowed
+    if numeric_disallow_even:
+        resp["numeric_disallow_even"] = True
+    if numeric_disallow_odd:
+        resp["numeric_disallow_odd"] = True
+    if grp_id:
+        resp["grp_id"] = grp_id
+    return resp
+
+
+def test_get_pending_actions_passes_numeric_fields():
+    """get_pending_actions for CastingTimeOptionRequest must include numeric fields."""
+    response = _casting_option_response(
+        numeric_min=0, numeric_max=7, numeric_step=1,
+        numeric_disallowed=[1, 3, 5],
+        grp_id=12345,
+    )
+    pipe = _MockPipe([response])
+    bridge = _bridge_with_pipe(pipe)
+
+    pending = bridge.get_pending_actions()
+    assert pending is not None
+    assert pending["has_pending"] is True
+    assert pending["numeric_min"] == 0
+    assert pending["numeric_max"] == 7
+    assert pending["numeric_step"] == 1
+    assert pending["numeric_disallowed"] == [1, 3, 5]
+    assert pending["grp_id"] == 12345
+
+
+def test_get_pending_actions_numeric_fields_absent_older_plugin():
+    """Older plugin builds without numeric fields must not break get_pending_actions."""
+    response: dict[str, Any] = {
+        "ok": True,
+        "has_pending": True,
+        "request_type": "CastingTimeOptions",
+        "request_class": "CastingTimeOptionRequest",
+        "can_cancel": True,
+        "decision_context": {
+            "type": "casting_time_options",
+            "num_options": 1,
+            "options": [
+                {"actionType": "CastingTimeOption", "choiceKind": "done", "childIndex": 0, "label": "Done"},
+            ],
+        },
+        "actions": [
+            {"actionType": "CastingTimeOption", "choiceKind": "done", "label": "Done"},
+        ],
+        "can_pass": True,
+    }
+    pipe = _MockPipe([response])
+    bridge = _bridge_with_pipe(pipe)
+
+    pending = bridge.get_pending_actions()
+    assert pending is not None
+    assert pending["has_pending"] is True
+    # Numeric fields should be absent without error
+    assert "numeric_min" not in pending
+    assert "numeric_max" not in pending
+    assert "numeric_step" not in pending
+
+
+def test_get_pending_actions_disallow_even():
+    """Numeric fields must include disallow_even flag when set."""
+    response = _casting_option_response(
+        numeric_min=0, numeric_max=10,
+        numeric_disallow_even=True,
+    )
+    pipe = _MockPipe([response])
+    bridge = _bridge_with_pipe(pipe)
+
+    pending = bridge.get_pending_actions()
+    assert pending is not None
+    assert pending.get("numeric_disallow_even") is True
+
+
+def test_get_pending_actions_disallow_odd():
+    """Numeric fields must include disallow_odd flag when set."""
+    response = _casting_option_response(
+        numeric_min=1, numeric_max=9,
+        numeric_disallow_odd=True,
+    )
+    pipe = _MockPipe([response])
+    bridge = _bridge_with_pipe(pipe)
+
+    pending = bridge.get_pending_actions()
+    assert pending is not None
+    assert pending.get("numeric_disallow_odd") is True
+
+
+# ---------------------------------------------------------------------------
+# Pipe protocol boundary tests
+# ---------------------------------------------------------------------------
+
+
+def test_submit_x_via_send_safe():
+    """submit_x sent through _send_safe must round-trip correctly."""
+    pipe = _MockPipe([{"ok": True, "submitted_type": "CastingTimeOption_X", "value": 7}])
+    bridge = _bridge_with_pipe(pipe)
+
+    resp = bridge._send_safe({"action": "submit_x", "value": 7})
+    assert resp["ok"] is True
+    assert resp["submitted_type"] == "CastingTimeOption_X"
+    assert resp["value"] == 7
+
+    # Verify the command that was written
+    written = json.loads(pipe._writes[0].decode("utf-8").strip())
+    assert written["action"] == "submit_x"
+    assert written["value"] == 7
+
+
+def test_get_pending_actions_casting_option_has_actions():
+    """CastingTimeOptionRequest response must include the 'actions' list."""
+    response = _casting_option_response()
+    pipe = _MockPipe([response])
+    bridge = _bridge_with_pipe(pipe)
+
+    pending = bridge.get_pending_actions()
+    assert pending is not None
+    assert "actions" in pending
+    assert len(pending["actions"]) > 0
+    # Each action should have the CastingTimeOption actionType
+    for action in pending["actions"]:
+        assert action.get("actionType") == "CastingTimeOption"

--- a/tools/training/wp3/PROGRESS-wt-bridge-x-chooser.md
+++ b/tools/training/wp3/PROGRESS-wt-bridge-x-chooser.md
@@ -1,0 +1,54 @@
+# WP-3: bridge-x-chooser — PROGRESS
+
+## Scope
+Fix GitHub issue #390: autopilot blind to the X-cost chooser (CastingTimeOption_NumericInputRequest invisible to FindPendingInteraction).
+
+## What was done
+
+### C# Plugin (bepinex-plugin/MtgaCoachBridge/Plugin.cs) — uncommitted changes
+1. Added `submit_x` case in ProcessCommand switch (line 433)
+2. Added `HandleSubmitX` method (line 1597):
+   - Finds CastingTimeOption_NumericInputRequest child in pending CastingTimeOptionRequest
+   - Calls `SubmitX(value)` on the child
+   - Falls back to NumericInputRequest for standalone numeric inputs
+3. Surfaces CastingTimeOption_NumericInputRequest fields in HandleGetPendingActions (line 845):
+   - `numeric_min`, `numeric_max`, `numeric_step`
+   - `numeric_disallowed` (array)
+   - `numeric_disallow_even`, `numeric_disallow_odd` (bool flags)
+   - `grp_id` from the child request
+
+### Python (src/arenamcp/gre_bridge.py)
+1. Added `GREBridge.submit_x(value: int) -> bool` method:
+   - Sends `{"action": "submit_x", "value": <int>}`
+   - Fail-closed: returns False on plugin error or communication failure
+   - Logs the submitted value and response type
+
+### Tests (tests/test_bridge_x_chooser.py)
+12 pure-Python tests covering:
+- submit_x sends correct JSON command shape
+- submit_x returns True on success
+- submit_x returns False on plugin error (ok=false)
+- submit_x raises GREBridgeError on disconnect
+- submit_x handles X=0 (valid for e.g. Silkguard)
+- submit_x handles large X values (e.g. X=20)
+- get_pending_actions passes through numeric fields (min/max/step/disallowed/grp_id)
+- get_pending_actions works with older plugin builds (fields absent)
+- get_pending_actions includes disallow_even flag
+- get_pending_actions includes disallow_odd flag
+- submit_x via _send_safe round-trips correctly
+- CastingTimeOptionRequest response always has actions list
+
+### Build status
+- `dotnet build -c Release` fails on this Linux machine (missing MTGA assemblies like Assembly-CSharp.dll, Core.dll — expected)
+- Python tests: `uv run pytest tests/test_bridge_x_chooser.py -v` — 12/12 passed
+
+## C# review-readiness
+The C# code follows existing patterns:
+- `HandleSubmitX` mirrors `HandleSubmitNumeric`'s structure
+- Numeric-field surfacing mirrors the standalone `NumericInputRequest` handler (lines 1049-1065)
+- Uses the same `FindPendingInteraction` → child-iteration pattern used elsewhere (e.g. CastingTimeOption_ManaTypeRequest child walk at line 2480)
+- Backward compatible: older plugins without submit_x just get `ok=false` error; the CastingTimeOptionRequest handler still works with the entry-index protocol
+
+## Known gaps
+- C# could not be compiled on this Linux dev machine; structural review needed
+- X casts are NOT re-enabled in the planner — that's a separate owner decision (per task spec)


### PR DESCRIPTION
## What

Fixes GitHub issue #390: the CastingTimeOption numeric-input window ("Select a value for X") is now fully visible to the autopilot. The BepInEx plugin surfaces the CastingTimeOption_NumericInputRequest child fields in `get_pending_actions`, and the Python bridge can submit any X value via `submit_x`.

## Changes

### C# Plugin (`bepinex-plugin/MtgaCoachBridge/Plugin.cs`)
- **HandleSubmitX** (new): walks `CastingTimeOptionRequest.ChildRequests` to find the `CastingTimeOption_NumericInputRequest` child and calls `SubmitX(value)`. Falls back to standalone `NumericInputRequest.SubmitValue()` for older paths.
- **Numeric field surfacing** in `HandleGetPendingActions`: when a CastingTimeOptionRequest has a CastingTimeOption_NumericInputRequest child, exposes numeric_min, numeric_max, numeric_step, numeric_disallowed, numeric_disallow_even, numeric_disallow_odd, grp_id.
- Follows existing patterns in the codebase.

### Python (`src/arenamcp/gre_bridge.py`)
- **GREBridge.submit_x(value: int) -> bool**: sends submit_x pipe command. Fail-closed on older plugin builds.

### Tests (`tests/test_bridge_x_chooser.py`)
- 12 pure-Python tests (no MTGA, no Windows): command shape, success/error/disconnect paths, X=0/X=max edge cases, numeric-field pass-through, backward compatibility.

## How tested

```
$ uv run pytest tests/test_bridge_x_chooser.py -v
============================= 12 passed in 0.37s ==============================
```

## Known gaps
- dotnet build -c Release fails on this Linux machine (no MTGA assemblies — all CS0246). C# is structurally review-ready but cannot compile here.
- X casts are NOT re-enabled in the planner — separate owner decision per #390.