### PR TITLE
WP-3: run_wp3_pipeline — chain all WP-3 modules end-to-end (3 silent failures fixed, real numbers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmpclaude-*
 __pycache__/
 .venv/
 tools/training/wp3/scryfall_cache.json
+tools/training/data/wp3/
 *.pyc
 debug_log.txt
 log_tail.txt

--- a/tests/test_run_wp3_pipeline.py
+++ b/tests/test_run_wp3_pipeline.py
@@ -1,0 +1,132 @@
+"""Regression tests for the three silent failures in run_wp3_pipeline.py.
+
+All three shared a shape: the pipeline reported success while doing the wrong
+thing, which is the worst failure mode for a training pipeline because a broken
+run is indistinguishable from a good one.
+
+1. The leak scan integer-hunted the whole prompt, so the rendered menu's own
+   numbering ("  31. Pass") collided with MCTS counts and the scan rejected the
+   entire corpus. The menu numbering is the ANSWER MECHANISM — the model must see
+   it to emit {"pick": N} — so it cannot be a leak.
+2. ``--seed`` was parsed and never plumbed; ``split_by_game`` was called with a
+   hardcoded ``seed=7``, so every seed produced a byte-identical split.
+3. A typo'd ``--log`` was silently discarded and the run printed
+   "=== PIPELINE COMPLETE ===" with 0 decisions and empty split files.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "tools" / "training" / "run_wp3_pipeline.py"
+
+pytest.importorskip("tools.training.run_wp3_pipeline", reason="pipeline module unavailable")
+
+from tools.training import run_wp3_pipeline as P  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# 1. Leak scan must not flag the rendered menu numbering
+# ---------------------------------------------------------------------------
+
+
+def _record(user: str) -> dict:
+    return {"user": user, "system": "SYS", "response": '{"actions":[{"pick":1}]}'}
+
+
+def test_leak_scan_ignores_menu_numbering():
+    """THE regression: a menu index equal to an MCTS count is not a leak."""
+    # MCTS count 31 exists, and the menu happens to have 31 entries.
+    raw = [{"mcts_counts": {"Pass": 31, "Play Island": 700}}]
+    menu_lines = "\n".join(f"  {i}. Option {i}" for i in range(1, 32))
+    rendered = {"test": [_record(f"Legal actions:\n{menu_lines}\n")]}
+    P.stage_leak_scan(rendered, raw)  # must not raise
+
+
+def test_leak_scan_still_catches_a_real_mcts_leak():
+    """A high MCTS count OUTSIDE the menu must still fail the scan."""
+    raw = [{"mcts_counts": {"Play Island": 700}}]
+    rendered = {"test": [_record("Board state: the search visited this line 700 times.\n")]}
+    with pytest.raises(SystemExit) as exc:
+        P.stage_leak_scan(rendered, raw)
+    assert exc.value.code == 42
+
+
+@pytest.mark.parametrize("word", ["score:", "count:"])
+def test_leak_scan_still_catches_forbidden_words(word):
+    raw = [{"mcts_counts": {"Pass": 50}}]
+    rendered = {"test": [_record(f"Pass {word} 50\n")]}
+    with pytest.raises(SystemExit) as exc:
+        P.stage_leak_scan(rendered, raw)
+    assert exc.value.code == 42
+
+
+# ---------------------------------------------------------------------------
+# 2. --seed must reach split_by_game
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipeline_accepts_and_forwards_seed():
+    """Signature-level guard: the seed parameter must exist to be forwardable."""
+    import inspect
+
+    params = inspect.signature(P.run_pipeline).parameters
+    assert "seed" in params, "run_pipeline must take a seed; a hardcoded 7 made --seed a no-op"
+    assert "balance" in params
+
+
+def test_split_by_game_call_is_not_hardcoded():
+    """AST guard: no literal seed= on the split call inside run_pipeline."""
+    import ast
+
+    tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+    bad: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name != "split_by_game":
+            continue
+        for kw in node.keywords:
+            if kw.arg == "seed" and isinstance(kw.value, ast.Constant):
+                bad.append(f"seed={kw.value.value!r} hardcoded at line {node.lineno}")
+    assert not bad, "; ".join(bad)
+
+
+# ---------------------------------------------------------------------------
+# 3. An unmatched --log must fail, not yield a silently empty corpus
+# ---------------------------------------------------------------------------
+
+
+def test_expand_globs_reports_unmatched(tmp_path):
+    real = tmp_path / "real.log"
+    real.write_text("x", encoding="utf-8")
+    paths, unmatched = P.expand_globs([str(real), str(tmp_path / "typo.log")])
+    assert [p.name for p in paths] == ["real.log"]
+    assert unmatched == [str(tmp_path / "typo.log")]
+
+
+def test_cli_refuses_a_typod_log_path(tmp_path):
+    """THE regression: this used to print PIPELINE COMPLETE with 0 records."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--log",
+            str(tmp_path / "definitely-not-here.log"),
+            "--outdir",
+            str(tmp_path / "out"),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    combined = proc.stdout + proc.stderr
+    assert proc.returncode == 2, f"expected rc=2, got {proc.returncode}\n{combined[-600:]}"
+    assert "matched nothing" in combined
+    assert "PIPELINE COMPLETE" not in combined, "a failed run must not report completion"

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -49,9 +49,9 @@ for p in [str(SRC), str(REPO)]:
         sys.path.insert(0, p)
 
 # ── WP-3 module imports ───────────────────────────────────────────────────
-from tools.training import parse_magezero_log as PARSER
-from tools.training import magezero_filters as FILTERS
 from tools.training import build_magezero_bridge as BRIDGE
+from tools.training import magezero_filters as FILTERS
+from tools.training import parse_magezero_log as PARSER
 
 # ---------------------------------------------------------------------------
 # Output paths
@@ -90,6 +90,7 @@ def _git_sha() -> str:
 # Stage 1: Parse
 # ---------------------------------------------------------------------------
 
+
 def stage_parse(log_paths: list[Path]) -> list[dict]:
     """Parse log files, returning combined decisions list."""
     all_decisions: list[dict] = []
@@ -109,8 +110,19 @@ def stage_parse(log_paths: list[Path]) -> list[dict]:
 # Stage 2: Filter
 # ---------------------------------------------------------------------------
 
-def stage_filter(rows: list[dict]) -> tuple[list[dict], dict[str, int]]:
+
+def stage_filter(
+    rows: list[dict],
+    *,
+    balance: str | None = None,
+    max_pass_frac: float = 0.40,
+    seed: int = 7,
+) -> tuple[list[dict], dict[str, int]]:
     """Apply filters in order: drop_single_option → outcome_filter → dedupe.
+
+    With ``balance="downsample-pass"``, surplus PRIORITY passes are then dropped
+    to meet ``max_pass_frac`` before the tripwire runs. Combat declines are never
+    dropped — see magezero_filters.downsample_passes for why.
 
     Returns (filtered, filter_counts).
     """
@@ -128,12 +140,35 @@ def stage_filter(rows: list[dict]) -> tuple[list[dict], dict[str, int]]:
     counts["dedupe"] = n
     print(f"  dedupe: {n} dropped ({len(rows)} kept)")
 
+    # Pass-rate visibility per decision_kind, before any balancing, so the raw
+    # corpus shape is on the record. The literal-"Pass" gate misses binary
+    # CHOOSE_USE declines ("false"), which are also do-nothing decisions.
+    for kind, st in FILTERS.pass_rate_report(rows).items():
+        print(
+            f"    pass rate {kind:<12s} rows={int(st['rows']):6d}  "
+            f"literal={st['literal_frac'] * 100:5.1f}%  pass-like={st['pass_like_frac'] * 100:5.1f}%"
+        )
+
+    if balance == "downsample-pass":
+        rows, bstats = FILTERS.downsample_passes(rows, max_frac=max_pass_frac, seed=seed)
+        counts["downsample_pass"] = bstats["dropped"]
+        print(
+            f"  downsample_pass: {bstats['dropped']} dropped ({len(rows)} kept; "
+            f"{bstats['eligible']} priority passes eligible)"
+        )
+        if bstats.get("shortfall"):
+            print(
+                f"  ** {bstats['shortfall']} more drops needed than eligible priority "
+                f"passes; the tripwire will reject this corpus **"
+            )
+
     return rows, counts
 
 
 # ---------------------------------------------------------------------------
 # Stage 3: Tripwire
 # ---------------------------------------------------------------------------
+
 
 def stage_tripwire(rows: list[dict], max_frac: float = 0.40) -> float:
     """Check pass rate. Returns the pass fraction (exits on violation)."""
@@ -142,7 +177,7 @@ def stage_tripwire(rows: list[dict], max_frac: float = 0.40) -> float:
         return 0.0
     n_pass = sum(1 for r in rows if r.get("chosen") == "Pass")
     frac = n_pass / total
-    print(f"  Pass rate: {n_pass}/{total} = {frac:.4f} ({frac*100:.1f}%)")
+    print(f"  Pass rate: {n_pass}/{total} = {frac:.4f} ({frac * 100:.1f}%)")
     FILTERS.pass_rate_tripwire(rows, max_frac)
     return frac
 
@@ -150,6 +185,7 @@ def stage_tripwire(rows: list[dict], max_frac: float = 0.40) -> float:
 # ---------------------------------------------------------------------------
 # Stage 4: Count attackers/blockers
 # ---------------------------------------------------------------------------
+
 
 def count_attackers_blockers(splits: dict[str, list[dict]]) -> dict[str, int]:
     """Count how many rows per split are attackers/blockers."""
@@ -167,6 +203,7 @@ def count_attackers_blockers(splits: dict[str, list[dict]]) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 # Stage 5: Render (via build_magezero_bridge.build_record)
 # ---------------------------------------------------------------------------
+
 
 def stage_render(
     splits: dict[str, list[dict]],
@@ -210,6 +247,7 @@ def stage_render(
 # Stage 6: Leak scan
 # ---------------------------------------------------------------------------
 
+
 def stage_leak_scan(
     rendered: dict[str, list[dict]],
     raw_decisions: list[dict],
@@ -249,6 +287,18 @@ def stage_leak_scan(
     errors: list[str] = []
 
     re_bare_int = re.compile(r"\b(\d{2,})\b")
+    # The rendered menu is NUMBERED ("  31. Pass") and that numbering is the
+    # answer mechanism, not a leak — the model must see it to emit {"pick": N}.
+    # Scanning it for bare integers made the scan reject the whole corpus the
+    # moment a menu grew past the smallest MCTS count (reproduced: 31 options
+    # with an MCTS count of 31). Strip menu lines before the integer scan; the
+    # word-level checks above still cover the whole prompt.
+    re_menu_line = re.compile(r"^\s*\d+\.\s", re.MULTILINE)
+
+    def _strip_menu_lines(text: str) -> str:
+        return "\n".join(
+            "" if re_menu_line.match(line) else line for line in text.splitlines()
+        )
 
     for split_name, records in rendered.items():
         for i, rec in enumerate(records):
@@ -257,19 +307,17 @@ def stage_leak_scan(
 
             # 1. "score:" leak
             if "score:" in user or "score:" in system:
-                errors.append(
-                    f"[{split_name} record {i}] 'score:' found in prompt"
-                )
+                errors.append(f"[{split_name} record {i}] 'score:' found in prompt")
 
             # 2. "count:" leak
             if "count:" in user or "count:" in system:
-                errors.append(
-                    f"[{split_name} record {i}] 'count:' found in prompt"
-                )
+                errors.append(f"[{split_name} record {i}] 'count:' found in prompt")
 
             # 3. MCTS integer ≥30 leak: find all bare integers in the prompt
-            # and check if any are in our high MCTS set
-            combined = user + " " + system
+            # and check if any are in our high MCTS set. Menu numbering is
+            # excluded (see _strip_menu_lines) because it is the input
+            # mechanism, not model-invisible search data.
+            combined = _strip_menu_lines(user) + " " + _strip_menu_lines(system)
             for match in re_bare_int.finditer(combined):
                 val = int(match.group(1))
                 if val in mcts_values_high:
@@ -291,18 +339,18 @@ def stage_leak_scan(
         for e in errors:
             print(f"  LEAK: {e}", file=sys.stderr)
         print(
-            f"\nLEAK SCAN FAILED: {len(errors)} violation(s) found. "
-            f"Corpus REJECTED.\n",
+            f"\nLEAK SCAN FAILED: {len(errors)} violation(s) found. Corpus REJECTED.\n",
             file=sys.stderr,
         )
         raise SystemExit(42)
     else:
-        print(f"  Leak scan passed: 0 violations.")
+        print("  Leak scan passed: 0 violations.")
 
 
 # ---------------------------------------------------------------------------
 # Stage 7: Write output
 # ---------------------------------------------------------------------------
+
 
 def stage_write(
     rendered: dict[str, list[dict]],
@@ -379,6 +427,7 @@ def stage_write(
 # Stage 8: REPORT.md
 # ---------------------------------------------------------------------------
 
+
 def stage_report(
     manifest: dict,
     filter_counts: dict[str, int],
@@ -406,8 +455,8 @@ def stage_report(
     lines.append("")
     lines.append("## Per-Stage Drop Counts")
     lines.append("")
-    lines.append(f"| Stage | In | Out | Drop |")
-    lines.append(f"|-------|----|-----|------|")
+    lines.append("| Stage | In | Out | Drop |")
+    lines.append("|-------|----|-----|------|")
     total_in = len(raw_decisions)
     n1 = filter_counts.get("drop_single_option", 0)
     after_1 = total_in - n1
@@ -419,18 +468,17 @@ def stage_report(
     after_3 = after_2 - n3
     lines.append(f"| outcome_filter → dedupe | {after_2} | {after_3} | {n3} |")
     lines.append("")
-    lines.append(f"## Pass Rate")
+    lines.append("## Pass Rate")
     lines.append("")
-    lines.append(f"Pass fraction (post-filter): {pass_rate:.4f} ({pass_rate*100:.1f}%)")
+    lines.append(f"Pass fraction (post-filter): {pass_rate:.4f} ({pass_rate * 100:.1f}%)")
     lines.append(f"Pass rate tripwire: {pass_rate <= 0.40} ({'PASS' if pass_rate <= 0.40 else 'FAIL'})")
     lines.append("")
-    lines.append(f"## Attackers/Blockers Excluded")
+    lines.append("## Attackers/Blockers Excluded")
     lines.append("")
     lines.append(f"Total attackers/blockers rows: {attackers_blockers_total}")
     for split_name, records in rendered.items():
         ab_in_split = sum(
-            1 for rec in records
-            if rec.get("meta", {}).get("decision_kind") in ("attackers", "blockers")
+            1 for rec in records if rec.get("meta", {}).get("decision_kind") in ("attackers", "blockers")
         )
         # Actually attackers/blockers were excluded before rendering, so this
         # should be 0 for all splits.
@@ -478,10 +526,13 @@ def stage_report(
 # Pipeline runner
 # ---------------------------------------------------------------------------
 
+
 def run_pipeline(
     log_paths: list[Path],
     outdir: Path,
     max_pass_frac: float = 0.40,
+    seed: int = 7,
+    balance: str | None = None,
 ) -> dict[str, Any]:
     """Run the full WP-3 pipeline.
 
@@ -504,7 +555,9 @@ def run_pipeline(
 
     # ── Stage 2: Filter ────────────────────────────────────────────────────
     print("Stage 2/5 — Filter decisions")
-    filtered, filter_counts = stage_filter(raw_decisions)
+    filtered, filter_counts = stage_filter(
+        raw_decisions, balance=balance, max_pass_frac=max_pass_frac, seed=seed
+    )
     filtered_count = len(filtered)
 
     # Save intermediate: filtered
@@ -520,21 +573,35 @@ def run_pipeline(
 
     # ── Stage 4: Split ─────────────────────────────────────────────────────
     print("Stage 4/5 — Split by game")
-    splits = FILTERS.split_by_game(filtered, seed=7)
+    splits = FILTERS.split_by_game(filtered, seed=seed)
     for name, group in splits.items():
         unique_games = len(set(FILTERS._game_id(r) for r in group))
         print(f"  split '{name}': {len(group)} rows ({unique_games} games)")
 
     # Count attackers/blockers before rendering
-    attackers_blockers_total = sum(
-        1 for d in filtered if d.get("decision_kind") in ("attackers", "blockers")
-    )
+    attackers_blockers_total = sum(1 for d in filtered if d.get("decision_kind") in ("attackers", "blockers"))
     print(f"  Attackers/blockers rows (pre-render): {attackers_blockers_total}")
 
     # ── Stage 5: Render ────────────────────────────────────────────────────
     print("Stage 5/5 — Render training records via build_magezero_bridge")
     split_drops: dict[str, Counter] = {}
     rendered = stage_render(splits, split_drops, {})
+
+    # Surface the per-reason drop tally. It was computed into split_drops and
+    # then never read, so the PR body's claim about WHY rows were dropped could
+    # not have come from this code. An unexplained drop count is how a silently
+    # broken adapter looks exactly like a working one.
+    render_drops: dict[str, dict[str, int]] = {
+        split: dict(counter) for split, counter in split_drops.items() if counter
+    }
+    total_dropped = sum(sum(c.values()) for c in split_drops.values())
+    if total_dropped:
+        print(f"  render drops: {total_dropped} row(s) not rendered, by reason:")
+        agg: Counter = Counter()
+        for counter in split_drops.values():
+            agg.update(counter)
+        for reason, n in agg.most_common():
+            print(f"    {reason}: {n}")
 
     # ── Leak scan ──────────────────────────────────────────────────────────
     print("Leak scan — checking rendered prompts for training-set artifacts...")
@@ -543,24 +610,37 @@ def run_pipeline(
     # ── Write output ────────────────────────────────────────────────────────
     elapsed = time.time() - t0
     manifest = stage_write(
-        rendered, outdir, filter_counts, splits, raw_count,
-        pass_rate, attackers_blockers_total, elapsed,
+        rendered,
+        outdir,
+        filter_counts,
+        splits,
+        raw_count,
+        pass_rate,
+        attackers_blockers_total,
+        elapsed,
     )
 
     # ── Report ──────────────────────────────────────────────────────────────
     stage_report(
-        manifest, filter_counts, rendered, raw_decisions, filtered,
-        pass_rate, attackers_blockers_total, outdir, log_paths,
+        manifest,
+        filter_counts,
+        rendered,
+        raw_decisions,
+        filtered,
+        pass_rate,
+        attackers_blockers_total,
+        outdir,
+        log_paths,
     )
 
     # Summary
     total_records = sum(len(v) for v in rendered.values())
-    print(f"\n=== PIPELINE COMPLETE ===")
+    print("\n=== PIPELINE COMPLETE ===")
     print(f"  Input decisions:   {raw_count}")
     print(f"  Post-filter:       {filtered_count}")
     print(f"  Training records:  {total_records}")
     print(f"  Attackers/blockers excluded: {attackers_blockers_total}")
-    print(f"  Pass rate:         {pass_rate:.4f} ({pass_rate*100:.1f}%)")
+    print(f"  Pass rate:         {pass_rate:.4f} ({pass_rate * 100:.1f}%)")
     print(f"  Elapsed:           {elapsed:.1f}s")
     print(f"  Output:            {outdir}")
 
@@ -571,47 +651,81 @@ def run_pipeline(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="WP-3 end-to-end pipeline: MageZero logs → training records",
     )
     parser.add_argument(
-        "--log", dest="log_paths", type=str, action="append", required=True,
+        "--log",
+        dest="log_paths",
+        type=str,
+        action="append",
+        required=True,
         help="Path to MageZero XMage log file (can be specified multiple times or as glob)",
     )
     parser.add_argument(
-        "--outdir", type=str, default=str(DEFAULT_OUTDIR),
+        "--outdir",
+        type=str,
+        default=str(DEFAULT_OUTDIR),
         help="Output directory (default: tools/training/data/wp3/)",
     )
     parser.add_argument(
-        "--max-pass-frac", type=float, default=0.40,
+        "--max-pass-frac",
+        type=float,
+        default=0.40,
         help="Maximum allowed Pass fraction (default: 0.40). Trips pipeline if exceeded.",
     )
     parser.add_argument(
-        "--seed", type=int, default=7,
+        "--seed",
+        type=int,
+        default=7,
         help="PRNG seed for deterministic splitting (default: 7).",
+    )
+    parser.add_argument(
+        "--balance",
+        choices=("downsample-pass",),
+        default=None,
+        help="Drop surplus PRIORITY passes to meet --max-pass-frac before the "
+        "tripwire (see magezero_filters.downsample_passes). Combat declines are "
+        "never dropped. Off by default so the raw corpus shape is not altered.",
     )
     return parser
 
 
-def expand_globs(paths: list[str]) -> list[Path]:
-    """Expand glob patterns and deduplicate, preserving order."""
+def expand_globs(paths: list[str]) -> tuple[list[Path], list[str]]:
+    """Expand globs and deduplicate, preserving order.
+
+    Returns ``(resolved_paths, unmatched_patterns)``. Unmatched patterns are
+    RETURNED rather than swallowed: a typo'd --log used to be discarded here, and
+    the pipeline then printed "=== PIPELINE COMPLETE ===" with 0 decisions and
+    wrote empty split files. A run that silently produces an empty corpus is
+    indistinguishable from a run that succeeded, which is the worst possible
+    failure for a training pipeline.
+    """
     import glob as _glob
+
     seen: set[str] = set()
     result: list[Path] = []
+    unmatched: list[str] = []
     for p in paths:
-        for match in sorted(_glob.glob(os.path.expanduser(p), recursive=False)):
-            resolved = os.path.realpath(match)
+        expanded = os.path.expanduser(p)
+        matches = sorted(_glob.glob(expanded, recursive=False))
+        if matches:
+            for match in matches:
+                resolved = os.path.realpath(match)
+                if resolved not in seen:
+                    seen.add(resolved)
+                    result.append(Path(resolved))
+            continue
+        resolved = os.path.realpath(expanded)
+        if os.path.exists(resolved):
             if resolved not in seen:
                 seen.add(resolved)
                 result.append(Path(resolved))
-        # If no glob matches, treat as literal path
-        if not _glob.glob(os.path.expanduser(p)):
-            resolved = os.path.realpath(os.path.expanduser(p))
-            if resolved not in seen and os.path.exists(resolved):
-                seen.add(resolved)
-                result.append(Path(resolved))
-    return result
+        else:
+            unmatched.append(p)
+    return result, unmatched
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -619,7 +733,21 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     # Expand globs in log paths
-    log_paths = expand_globs(args.log_paths)
+    log_paths, unmatched = expand_globs(args.log_paths)
+
+    if unmatched:
+        for pat in unmatched:
+            print(f"ERROR: --log matched nothing: {pat}", file=sys.stderr)
+        print(
+            "\nRefusing to run: every --log must resolve to at least one file. "
+            "Silently skipping a typo'd path yields an empty corpus that looks "
+            "like a successful run.",
+            file=sys.stderr,
+        )
+        return 2
+    if not log_paths:
+        print("ERROR: no input logs resolved.", file=sys.stderr)
+        return 2
 
     print(f"WP-3 Pipeline — {len(log_paths)} log file(s)")
     for lp in log_paths:
@@ -634,10 +762,12 @@ def main(argv: list[str] | None = None) -> int:
             log_paths=log_paths,
             outdir=outdir,
             max_pass_frac=args.max_pass_frac,
+            seed=args.seed,
+            balance=args.balance,
         )
     except SystemExit as e:
         if e.code == 42:
-            print(f"\nPipeline aborted: pass rate tripwire or leak scan failed.", file=sys.stderr)
+            print("\nPipeline aborted: pass rate tripwire or leak scan failed.", file=sys.stderr)
             return 42
         raise
 

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""WP-3 end-to-end pipeline: MageZero logs → production-shaped gemma training records.
+
+Chains the four WP-3 merged modules:
+
+  1. parse_magezero_log  — XMage text logs → decisions JSONL
+  2. magezero_filters     — drop_single_option → outcome_filter(won_only) → dedupe →
+                            pass_rate_tripwire → split_by_game
+  3. build_magezero_bridge — decisions JSONL row → training record via the
+                             production gate_play_decisions.build_user_message
+  4. Leak scan            — reject corpus containing training-set artifacts
+
+Usage
+-----
+    python3 tools/training/run_wp3_pipeline.py \
+        --log /home/joshu/mz_train_smoke.log \
+        --log /home/joshu/mz_logs/*.log
+
+Output
+------
+    tools/training/data/wp3/decisions.jsonl     — unfiltered decisions (intermediate)
+    tools/training/data/wp3/filtered.jsonl      — post-filter decisions (intermediate)
+    tools/training/data/wp3/train.jsonl          — training records (split)
+    tools/training/data/wp3/val.jsonl            — validation records (split)
+    tools/training/data/wp3/test.jsonl           — test records (split)
+    tools/training/data/wp3/manifest.json        — corpus manifest (committed)
+    tools/training/data/wp3/REPORT.md            — pipeline report (committed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+# ── Ensure repo src is on sys.path for module imports ──────────────────────
+REPO = Path(__file__).resolve().parent.parent.parent
+SRC = REPO / "src"
+for p in [str(SRC), str(REPO)]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# ── WP-3 module imports ───────────────────────────────────────────────────
+from tools.training import parse_magezero_log as PARSER
+from tools.training import magezero_filters as FILTERS
+from tools.training import build_magezero_bridge as BRIDGE
+
+# ---------------------------------------------------------------------------
+# Output paths
+# ---------------------------------------------------------------------------
+
+DEFAULT_OUTDIR = REPO / "tools" / "training" / "data" / "wp3"
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(8192 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _git_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: Parse
+# ---------------------------------------------------------------------------
+
+def stage_parse(log_paths: list[Path]) -> list[dict]:
+    """Parse log files, returning combined decisions list."""
+    all_decisions: list[dict] = []
+    per_log_counts: dict[str, int] = {}
+
+    for lp in log_paths:
+        print(f"  Parsing {lp} ...", end=" ", flush=True)
+        decisions, sessions = PARSER.parse_log(str(lp))
+        all_decisions.extend(decisions)
+        per_log_counts[str(lp)] = len(decisions)
+        print(f"{len(decisions)} decisions, {len(sessions)} sessions")
+
+    return all_decisions
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: Filter
+# ---------------------------------------------------------------------------
+
+def stage_filter(rows: list[dict]) -> tuple[list[dict], dict[str, int]]:
+    """Apply filters in order: drop_single_option → outcome_filter → dedupe.
+
+    Returns (filtered, filter_counts).
+    """
+    counts: dict[str, int] = {}
+
+    rows, n = FILTERS.drop_single_option(rows)
+    counts["drop_single_option"] = n
+    print(f"  drop_single_option: {n} dropped ({len(rows)} kept)")
+
+    rows, n = FILTERS.outcome_filter(rows, "won_only")
+    counts["outcome_filter"] = n
+    print(f"  outcome_filter (won_only): {n} dropped ({len(rows)} kept)")
+
+    rows, n = FILTERS.dedupe(rows)
+    counts["dedupe"] = n
+    print(f"  dedupe: {n} dropped ({len(rows)} kept)")
+
+    return rows, counts
+
+
+# ---------------------------------------------------------------------------
+# Stage 3: Tripwire
+# ---------------------------------------------------------------------------
+
+def stage_tripwire(rows: list[dict], max_frac: float = 0.40) -> float:
+    """Check pass rate. Returns the pass fraction (exits on violation)."""
+    total = len(rows)
+    if total == 0:
+        return 0.0
+    n_pass = sum(1 for r in rows if r.get("chosen") == "Pass")
+    frac = n_pass / total
+    print(f"  Pass rate: {n_pass}/{total} = {frac:.4f} ({frac*100:.1f}%)")
+    FILTERS.pass_rate_tripwire(rows, max_frac)
+    return frac
+
+
+# ---------------------------------------------------------------------------
+# Stage 4: Count attackers/blockers
+# ---------------------------------------------------------------------------
+
+def count_attackers_blockers(splits: dict[str, list[dict]]) -> dict[str, int]:
+    """Count how many rows per split are attackers/blockers."""
+    counts: dict[str, Counter] = {}
+    for split_name, rows in splits.items():
+        c: Counter = Counter()
+        for r in rows:
+            kind = r.get("decision_kind", "priority")
+            if kind in ("attackers", "blockers"):
+                c[kind] += 1
+        counts[split_name] = c
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Stage 5: Render (via build_magezero_bridge.build_record)
+# ---------------------------------------------------------------------------
+
+def stage_render(
+    splits: dict[str, list[dict]],
+    split_filter_counts: dict[str, Counter],
+    attackers_blockers_counts: dict[str, int],
+) -> dict[str, list[dict]]:
+    """Render priority rows in each split via build_record.
+
+    Attackers/blockers rows are skipped and counted per split.
+    Returns {split_name: [training_records]}.
+    """
+    result: dict[str, list[dict]] = {}
+    for split_name, rows in splits.items():
+        records: list[dict] = []
+        drops: Counter = Counter()
+        for row in rows:
+            # Pre-count attackers/blockers that bypass drop_single_option
+            kind = row.get("decision_kind", "priority")
+            if kind in ("attackers", "blockers"):
+                drops[f"dk_{kind}"] += 1
+                continue
+            record, reason = BRIDGE.build_record(row)
+            if record is None:
+                drops[reason] += 1
+                continue
+            records.append(record)
+        result[split_name] = records
+        split_filter_counts[split_name] = drops
+        n_ab = sum(drops.get(f"dk_{k}", 0) for k in ("attackers", "blockers"))
+        print(
+            f"  split '{split_name}': {len(rows)} input rows → "
+            f"{len(records)} records, "
+            f"{drops.total()} drops "
+            f"({n_ab} attackers/blockers, "
+            f"{drops.total() - n_ab} other)"
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stage 6: Leak scan
+# ---------------------------------------------------------------------------
+
+def stage_leak_scan(
+    rendered: dict[str, list[dict]],
+    raw_decisions: list[dict],
+) -> None:
+    """Scan every rendered prompt for training-set artifacts.
+
+    Aborts (SystemExit) on ANY hit — the corpus is not safe for training.
+
+    Checks:
+      1. No "score:" substring in any prompt text — this is a definitive
+         marker of MCTS raw data leaking into the prompt.
+      2. No "count:" substring in any prompt text — same.
+      3. No integer that appears in the MCTS counts (≥10) appears as a
+         bare integer token in the rendered prompt, after excluding
+         values that also appear as life totals (10-20 are common in
+         "Life: You=N Opp=N").
+
+    Why not check every possible MCTS integer against every action name?
+    The production prompt builder (gate_play_decisions.build_user_message)
+    receives only game_state and menu — it has no access to mcts_counts.
+    MCTS data can only leak through a bug in the formatter, and such a
+    bug would surface via "score:" / "count:" markers. The integer-check
+    here is a secondary defense against subtle leaks.
+    """
+    # Collect all distinct MCTS integer values ≥ 10
+    mcts_values: set[int] = set()
+    for d in raw_decisions:
+        mcts = d.get("mcts_counts", {})
+        for count in mcts.values():
+            if isinstance(count, (int, float)) and count >= 10:
+                mcts_values.add(int(count))
+
+    # Values 10-20 are common in life totals ("Life: You=13 Opp=20") —
+    # only flag values > 30 that are unlikely to be legitimate game state
+    mcts_values_high = {v for v in mcts_values if v > 30}
+
+    errors: list[str] = []
+
+    re_bare_int = re.compile(r"\b(\d{2,})\b")
+
+    for split_name, records in rendered.items():
+        for i, rec in enumerate(records):
+            user = rec.get("user", "")
+            system = rec.get("system", "")
+
+            # 1. "score:" leak
+            if "score:" in user or "score:" in system:
+                errors.append(
+                    f"[{split_name} record {i}] 'score:' found in prompt"
+                )
+
+            # 2. "count:" leak
+            if "count:" in user or "count:" in system:
+                errors.append(
+                    f"[{split_name} record {i}] 'count:' found in prompt"
+                )
+
+            # 3. MCTS integer ≥30 leak: find all bare integers in the prompt
+            # and check if any are in our high MCTS set
+            combined = user + " " + system
+            for match in re_bare_int.finditer(combined):
+                val = int(match.group(1))
+                if val in mcts_values_high:
+                    # Check context: is this a life total (preceded by =)?
+                    pos = match.start()
+                    prev_char = combined[pos - 1] if pos > 0 else " "
+                    # Menu numbers like "1. " start at position 0 or after \n
+                    # Life totals: "You=NN" or "Opp=NN"
+                    # Turn: "TNN"
+                    # We flag if not preceded by =, :, >, <, or T
+                    if prev_char not in ("=", ":", ">", "<"):
+                        errors.append(
+                            f"[{split_name} record {i}] MCTS count {val} "
+                            f"found as bare integer in prompt (preceded by "
+                            f"'{prev_char}')"
+                        )
+
+    if errors:
+        for e in errors:
+            print(f"  LEAK: {e}", file=sys.stderr)
+        print(
+            f"\nLEAK SCAN FAILED: {len(errors)} violation(s) found. "
+            f"Corpus REJECTED.\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(42)
+    else:
+        print(f"  Leak scan passed: 0 violations.")
+
+
+# ---------------------------------------------------------------------------
+# Stage 7: Write output
+# ---------------------------------------------------------------------------
+
+def stage_write(
+    rendered: dict[str, list[dict]],
+    outdir: Path,
+    filter_counts: dict[str, int],
+    splits: dict[str, list[dict]],
+    raw_count: int,
+    pass_rate: float,
+    attackers_blockers_total: int,
+    elapsed: float,
+) -> dict:
+    """Write per-split JSONL files and manifest. Returns manifest dict."""
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict[str, Any] = {
+        "version": 2,
+        "pipeline": "run_wp3_pipeline.py",
+        "git_sha": _git_sha(),
+        "built_ts": time.time(),
+        "elapsed_seconds": round(elapsed, 2),
+        "input_raw_decisions": raw_count,
+        "pass_rate": round(pass_rate, 6),
+        "attackers_blockers_excluded_total": attackers_blockers_total,
+        "filter_counts": dict(filter_counts),
+        "splits": {},
+    }
+
+    for split_name in sorted(rendered.keys()):
+        records = rendered[split_name]
+        split_path = outdir / f"{split_name}.jsonl"
+        with open(split_path, "w", encoding="utf-8") as f:
+            for rec in records:
+                f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+        sha = _sha256_file(split_path)
+
+        # Count outcome, decision_kind, sessions
+        by_outcome: Counter = Counter()
+        by_kind: Counter = Counter()
+        by_session: Counter = Counter()
+        menu_sizes: list[int] = []
+        for rec in records:
+            meta = rec.get("meta", {})
+            by_outcome[meta.get("outcome", "?")] += 1
+            by_kind[meta.get("decision_kind", "?")] += 1
+            by_session[meta.get("session", "?")] += 1
+            menu_sizes.append(meta.get("menu_size", 0))
+
+        manifest["splits"][split_name] = {
+            "records": len(records),
+            "file": split_path.name,
+            "sha256": sha,
+            "by_outcome": dict(by_outcome),
+            "by_decision_kind": dict(by_kind),
+            "by_session": dict(by_session),
+            "menu_size": {
+                "min": min(menu_sizes) if menu_sizes else 0,
+                "median": sorted(menu_sizes)[len(menu_sizes) // 2] if menu_sizes else 0,
+                "max": max(menu_sizes) if menu_sizes else 0,
+                "mean": round(sum(menu_sizes) / len(menu_sizes), 2) if menu_sizes else 0,
+            },
+        }
+
+    manifest_path = outdir / "manifest.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"  Manifest written to {manifest_path}")
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Stage 8: REPORT.md
+# ---------------------------------------------------------------------------
+
+def stage_report(
+    manifest: dict,
+    filter_counts: dict[str, int],
+    rendered: dict[str, list[dict]],
+    raw_decisions: list[dict],
+    filtered_decisions: list[dict],
+    pass_rate: float,
+    attackers_blockers_total: int,
+    outdir: Path,
+    log_paths: list[Path],
+) -> str:
+    """Write REPORT.md to the output directory. Returns the path."""
+    lines: list[str] = []
+    lines.append("# WP-3 Pipeline Report — wp3-integration")
+    lines.append("")
+    lines.append(f"Built: {time.strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"Git SHA: {manifest.get('git_sha', 'unknown')}")
+    lines.append(f"Elapsed: {manifest.get('elapsed_seconds', 0)}s")
+    lines.append("")
+    lines.append("## Input")
+    lines.append("")
+    for lp in log_paths:
+        lines.append(f"- `{lp}`")
+    lines.append(f"- Raw decisions parsed: {len(raw_decisions)}")
+    lines.append("")
+    lines.append("## Per-Stage Drop Counts")
+    lines.append("")
+    lines.append(f"| Stage | In | Out | Drop |")
+    lines.append(f"|-------|----|-----|------|")
+    total_in = len(raw_decisions)
+    n1 = filter_counts.get("drop_single_option", 0)
+    after_1 = total_in - n1
+    lines.append(f"| parse → drop_single_option | {total_in} | {after_1} | {n1} |")
+    n2 = filter_counts.get("outcome_filter", 0)
+    after_2 = after_1 - n2
+    lines.append(f"| drop_single_option → outcome_filter | {after_1} | {after_2} | {n2} |")
+    n3 = filter_counts.get("dedupe", 0)
+    after_3 = after_2 - n3
+    lines.append(f"| outcome_filter → dedupe | {after_2} | {after_3} | {n3} |")
+    lines.append("")
+    lines.append(f"## Pass Rate")
+    lines.append("")
+    lines.append(f"Pass fraction (post-filter): {pass_rate:.4f} ({pass_rate*100:.1f}%)")
+    lines.append(f"Pass rate tripwire: {pass_rate <= 0.40} ({'PASS' if pass_rate <= 0.40 else 'FAIL'})")
+    lines.append("")
+    lines.append(f"## Attackers/Blockers Excluded")
+    lines.append("")
+    lines.append(f"Total attackers/blockers rows: {attackers_blockers_total}")
+    for split_name, records in rendered.items():
+        ab_in_split = sum(
+            1 for rec in records
+            if rec.get("meta", {}).get("decision_kind") in ("attackers", "blockers")
+        )
+        # Actually attackers/blockers were excluded before rendering, so this
+        # should be 0 for all splits.
+        pass
+    lines.append("(Counted and excluded before split rendering — no attackers/blockers appear in any split.)")
+    lines.append("")
+    lines.append("## Split Sizes")
+    lines.append("")
+    lines.append("| Split | Records |")
+    lines.append("|-------|---------|")
+    for split_name in sorted(rendered.keys()):
+        lines.append(f"| {split_name} | {len(rendered[split_name])} |")
+    total = sum(len(v) for v in rendered.values())
+    lines.append(f"| **Total** | **{total}** |")
+    lines.append("")
+    lines.append("## Sample Records (first 2 per split)")
+    lines.append("")
+    for split_name in sorted(rendered.keys()):
+        records = rendered[split_name]
+        lines.append(f"### Split: {split_name} ({len(records)} records)")
+        lines.append("")
+        for idx, rec in enumerate(records[:2]):
+            lines.append(f"**Record {idx + 1}**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(json.dumps(rec, indent=2, ensure_ascii=False))
+            lines.append("```")
+            lines.append("")
+    lines.append("## Manifest")
+    lines.append("")
+    lines.append("```json")
+    lines.append(json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False))
+    lines.append("```")
+    lines.append("")
+
+    report = "\n".join(lines)
+    report_path = outdir / "REPORT.md"
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write(report)
+    print(f"  Report written to {report_path}")
+    return str(report_path)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline runner
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    log_paths: list[Path],
+    outdir: Path,
+    max_pass_frac: float = 0.40,
+) -> dict[str, Any]:
+    """Run the full WP-3 pipeline.
+
+    Returns the manifest dict.
+    """
+    t0 = time.time()
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    # ── Stage 1: Parse ────────────────────────────────────────────────────
+    print("Stage 1/5 — Parse logs")
+    raw_decisions = stage_parse(log_paths)
+    raw_count = len(raw_decisions)
+
+    # Save intermediate: decisions
+    decisions_path = outdir / "decisions.jsonl"
+    with open(decisions_path, "w", encoding="utf-8") as f:
+        for d in raw_decisions:
+            f.write(json.dumps(d, sort_keys=True, ensure_ascii=False) + "\n")
+    print(f"  Wrote {raw_count} decisions -> {decisions_path}")
+
+    # ── Stage 2: Filter ────────────────────────────────────────────────────
+    print("Stage 2/5 — Filter decisions")
+    filtered, filter_counts = stage_filter(raw_decisions)
+    filtered_count = len(filtered)
+
+    # Save intermediate: filtered
+    filtered_path = outdir / "filtered.jsonl"
+    with open(filtered_path, "w", encoding="utf-8") as f:
+        for d in filtered:
+            f.write(json.dumps(d, sort_keys=True, ensure_ascii=False) + "\n")
+    print(f"  Wrote {filtered_count} filtered -> {filtered_path}")
+
+    # ── Stage 3: Tripwire ──────────────────────────────────────────────────
+    print("Stage 3/5 — Pass rate tripwire")
+    pass_rate = stage_tripwire(filtered, max_pass_frac)
+
+    # ── Stage 4: Split ─────────────────────────────────────────────────────
+    print("Stage 4/5 — Split by game")
+    splits = FILTERS.split_by_game(filtered, seed=7)
+    for name, group in splits.items():
+        unique_games = len(set(FILTERS._game_id(r) for r in group))
+        print(f"  split '{name}': {len(group)} rows ({unique_games} games)")
+
+    # Count attackers/blockers before rendering
+    attackers_blockers_total = sum(
+        1 for d in filtered if d.get("decision_kind") in ("attackers", "blockers")
+    )
+    print(f"  Attackers/blockers rows (pre-render): {attackers_blockers_total}")
+
+    # ── Stage 5: Render ────────────────────────────────────────────────────
+    print("Stage 5/5 — Render training records via build_magezero_bridge")
+    split_drops: dict[str, Counter] = {}
+    rendered = stage_render(splits, split_drops, {})
+
+    # ── Leak scan ──────────────────────────────────────────────────────────
+    print("Leak scan — checking rendered prompts for training-set artifacts...")
+    stage_leak_scan(rendered, raw_decisions)
+
+    # ── Write output ────────────────────────────────────────────────────────
+    elapsed = time.time() - t0
+    manifest = stage_write(
+        rendered, outdir, filter_counts, splits, raw_count,
+        pass_rate, attackers_blockers_total, elapsed,
+    )
+
+    # ── Report ──────────────────────────────────────────────────────────────
+    stage_report(
+        manifest, filter_counts, rendered, raw_decisions, filtered,
+        pass_rate, attackers_blockers_total, outdir, log_paths,
+    )
+
+    # Summary
+    total_records = sum(len(v) for v in rendered.values())
+    print(f"\n=== PIPELINE COMPLETE ===")
+    print(f"  Input decisions:   {raw_count}")
+    print(f"  Post-filter:       {filtered_count}")
+    print(f"  Training records:  {total_records}")
+    print(f"  Attackers/blockers excluded: {attackers_blockers_total}")
+    print(f"  Pass rate:         {pass_rate:.4f} ({pass_rate*100:.1f}%)")
+    print(f"  Elapsed:           {elapsed:.1f}s")
+    print(f"  Output:            {outdir}")
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="WP-3 end-to-end pipeline: MageZero logs → training records",
+    )
+    parser.add_argument(
+        "--log", dest="log_paths", type=str, action="append", required=True,
+        help="Path to MageZero XMage log file (can be specified multiple times or as glob)",
+    )
+    parser.add_argument(
+        "--outdir", type=str, default=str(DEFAULT_OUTDIR),
+        help="Output directory (default: tools/training/data/wp3/)",
+    )
+    parser.add_argument(
+        "--max-pass-frac", type=float, default=0.40,
+        help="Maximum allowed Pass fraction (default: 0.40). Trips pipeline if exceeded.",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=7,
+        help="PRNG seed for deterministic splitting (default: 7).",
+    )
+    return parser
+
+
+def expand_globs(paths: list[str]) -> list[Path]:
+    """Expand glob patterns and deduplicate, preserving order."""
+    import glob as _glob
+    seen: set[str] = set()
+    result: list[Path] = []
+    for p in paths:
+        for match in sorted(_glob.glob(os.path.expanduser(p), recursive=False)):
+            resolved = os.path.realpath(match)
+            if resolved not in seen:
+                seen.add(resolved)
+                result.append(Path(resolved))
+        # If no glob matches, treat as literal path
+        if not _glob.glob(os.path.expanduser(p)):
+            resolved = os.path.realpath(os.path.expanduser(p))
+            if resolved not in seen and os.path.exists(resolved):
+                seen.add(resolved)
+                result.append(Path(resolved))
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    # Expand globs in log paths
+    log_paths = expand_globs(args.log_paths)
+
+    print(f"WP-3 Pipeline — {len(log_paths)} log file(s)")
+    for lp in log_paths:
+        size_mb = os.path.getsize(lp) / (1024 * 1024)
+        print(f"  {lp} ({size_mb:.0f} MB)")
+    print()
+
+    outdir = Path(args.outdir).resolve()
+
+    try:
+        run_pipeline(
+            log_paths=log_paths,
+            outdir=outdir,
+            max_pass_frac=args.max_pass_frac,
+        )
+    except SystemExit as e:
+        if e.code == 42:
+            print(f"\nPipeline aborted: pass rate tripwire or leak scan failed.", file=sys.stderr)
+            return 42
+        raise
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/training/wp3/PROGRESS-wp3-integration.md
+++ b/tools/training/wp3/PROGRESS-wp3-integration.md
@@ -1,0 +1,69 @@
+# PROGRESS: wp3-integration
+
+## Pipeline: run_wp3_pipeline.py — chain all WP-3 modules end-to-end
+
+### What was done
+Created `tools/training/run_wp3_pipeline.py` that:
+  1. Parses MageZero XMage logs → decisions JSONL (via `parse_magezero_log`)
+  2. Filters: drop_single_option → outcome_filter(won_only) → dedupe (via `magezero_filters`)
+  3. Pass rate tripwire (0.40) — PASS (0.0% pass rate)
+  4. Split by game (seed=7) — game-level split to prevent train/val leakage
+  5. Renders priority rows per split via `build_magezero_bridge.build_record`
+  6. Attackers/blockers excluded and counted (621 total)
+  7. Leak scan: 0 violations (checks for "score:", "count:", and MCTS integers ≥30)
+  8. Writes corpus to `tools/training/data/wp3/`
+  9. Writes manifest.json and REPORT.md
+
+### Test output (real corpus — 2 logs)
+```
+Input: /home/joshu/mz_train_smoke.log (201 MB, 9789 decisions)
+       /home/joshu/mz_logs/mz_train.manual-20260729-160933.log (806 MB, 30439 decisions)
+
+Stage        | In     | Out    | Drop
+-------------|--------|--------|------
+parse        | 0      | 40228  | 0
+drop_single  | 40228  | 40228  | 0
+outcome_filt | 40228  | 14591  | 25637
+dedupe       | 14591  | 11265  | 3326
+render(train)| 10167  | 7202   | 2965 (561 AB + 2404 other)
+render(val)  | 519    | 370    | 149 (31 AB + 118 other)
+render(test) | 579    | 419    | 160 (29 AB + 131 other)
+
+Pass rate: 0.0% (tripwire PASS)
+Attackers/blockers excluded: 621
+Total training records: 7991 (7202 train, 370 val, 419 test)
+Leak scan: 0 violations
+Elapsed: 58.8s
+```
+
+### Decisions made
+- Leak scan uses two-tier approach: (1) "score:" and "count:" substring checks (definitive MCTS markers), (2) bare integer check for MCTS values > 30 with context validation (not preceded by =, :, >, < to exclude life totals/turn numbers/menu indices). The full adjacency check (action_name × count pairs) was rejected due to combinatorial explosion (115K pairs → 230K regex patterns).
+- `drop_single_option` filtered 0 rows — MageZero's MCTS pool always has multiple options at priority decisions.
+- Rendering drops 3274 rows: 621 attackers/blockers and 2653 from menu parity issues (chosen action not in menu due to action string normalisation differences between XMage and MTGA naming).
+
+### Known gaps
+- Card facts: only basic land type lines are resolved; non-basic permanents render without full type/oracle info. Mana computation for non-basic lands without basic-land-name-in-name contributes 0 mana.
+- Attackers/blockers rows: excluded and counted only — a parallel agent builds the combat corpus.
+- Session labels from the manual log use "sessionN" fallback naming (no opponent detection for non-smoke logs).
+- Leak scan's MCTS integer check only flags values > 30 to avoid false positives from life totals (10-20).
+
+### Verified
+- [x] Parse: both logs parsed successfully (40228 decisions)
+- [x] Filter: single-option, outcome, dedupe all pass
+- [x] Tripwire: 0.0% pass rate (PASS)
+- [x] Split: game-level split, 3 splits
+- [x] Render: production-shaped prompts via gate_play_decisions.build_user_message
+- [x] R1: system prompt identity (AUTOPILOT_SYSTEM_PROMPT)
+- [x] R2: attackers/blockers excluded and counted
+- [x] R3: unknown-outcome rows excluded by pre-filter
+- [x] R4: answer index from menu match
+- [x] Leak scan: 0 violations
+- [x] Manifest: per-split counts, sha256, filter_counts
+- [x] REPORT.md: full pipeline report with sample records
+
+### File sizes
+- decisions.jsonl: 49 MB (40228 rows)
+- filtered.jsonl: 14 MB (11265 rows)
+- train.jsonl: 567 MB (7202 records)
+- val.jsonl: 30 MB (370 records)
+- test.jsonl: 33 MB (419 records)


### PR DESCRIPTION
Chains parse → filter → tripwire → split → render → leak scan → manifest + REPORT.md.

A review found this had **three silent failures** plus an unverifiable set of corpus counts, and it was held on #430. #430 is now fixed and merged (#452), and all three failures are fixed here. **The corpus numbers in the original body could not be reproduced and have been replaced with a measured run.**

## The three silent failures

All shared one shape — the pipeline reported success while doing the wrong thing. For a training pipeline that's the worst failure mode, because a broken run is indistinguishable from a good one.

**1. The leak scan rejected the entire corpus on a false positive.** `re_bare_int` matched the rendered menu's *own numbering* (`  31. Pass`), so any menu longer than the smallest MCTS count tripped it — reproduced with 31 options and an MCTS count of 31. The menu numbering is the **answer mechanism**: the model must see it to emit `{"pick": N}`. It cannot be a leak. Menu lines are now excluded from the integer scan, while `score:`/`count:` word checks still cover the whole prompt and a high MCTS count *outside* the menu still fails.

**2. `--seed` was parsed and never plumbed.** `split_by_game` was called with a hardcoded `seed=7`, so every seed gave a byte-identical split. Proven fixed on the real log:

| seed | `train.jsonl` sha256 | rows |
|---|---|---|
| 7 | `08f5ca78…` | 3,750 |
| 42 | `4b18c71b…` | 3,857 |

**3. A typo'd `--log` was silently discarded** — the run then printed `=== PIPELINE COMPLETE ===` with 0 decisions and wrote empty split files. `expand_globs` now returns unmatched patterns and `main` exits 2 listing them.

## The drop tally was computed and thrown away

`split_drops` was populated by `stage_render` and never read, so the original body's claim about *why* rows dropped could not have come from this code. It's now printed, and it exposes a real gap:

| drop reason | rows |
|---|---|
| **`chosen_not_in_menu`** | **745** |
| `decision_kind_binary` | 359 |
| `dk_attackers` | 293 |
| `dk_blockers` | 154 |

The 745 is a genuine menu-parity adapter gap — 12.8% of filtered rows, previously invisible. The other 806 are excluded by design (they take the combat/binary path, not this renderer).

## Measured end-to-end run

`--log mz_train_smoke.log --balance downsample-pass`, against master's fixed parser:

```
input decisions   21,609
post-filter        5,835
training records   4,284
pass rate         0.4000 (exactly the ceiling)
leak scan         0 violations
elapsed           9.3s
```

Pass rate per `decision_kind` is now printed pre-balance, so the literal-`"Pass"` gate can't quietly under-measure binary declines (`binary` reads 0.0% literal but 67.1% pass-like).

## Tests

`tests/test_run_wp3_pipeline.py` — 8 tests, **5 of which fail against the pre-fix script**: menu-numbering not flagged, real MCTS leak still caught, forbidden words still caught, seed present in the signature, no hardcoded `seed=` on the split call (AST guard), unmatched patterns reported, CLI exits 2 without printing completion.

```
full suite: 1376 passed, 30 skipped
ruff check . / format --check: clean
```