### PR TITLE
fix(monitoring): litellm-exporter dies mid-scrape, token metrics stale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tools/training/checkpoints/
 tools/training/data/
 !tools/eval/
 tools/eval/data/
+!tools/monitoring/
 docs/
 CLAUDE.md
 *.spec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "ruff>=0.6.0",
     "mypy>=1.10.0",
     "pre-commit>=3.5.0",
+    "prometheus_client>=0.20.0",
 ]
 
 [project.scripts]

--- a/tests/test_litellm_exporter.py
+++ b/tests/test_litellm_exporter.py
@@ -1,0 +1,186 @@
+"""Regression tests for tools/monitoring/litellm_exporter/exporter.py.
+
+Background: the deployed exporter reset its daily gauges with
+
+    for label_set in gauge._metrics.keys():
+        gauge.remove(*label_set)
+
+remove() mutates the same dict the loop iterates, so every scrape after the
+first died with "RuntimeError: dictionary changed size during iteration" and
+all token gauges stayed stale (ten empty Grafana panels). These tests pin the
+fix: snapshot iteration + per-key error isolation.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("prometheus_client")
+from prometheus_client import Gauge  # noqa: E402
+
+EXPORTER_PATH = (
+    Path(__file__).resolve().parents[1] / "tools" / "monitoring" / "litellm_exporter" / "exporter.py"
+)
+
+
+def _load_exporter():
+    """Load exporter.py once (module-level prometheus registry is global)."""
+    spec = importlib.util.spec_from_file_location("litellm_exporter", EXPORTER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+exporter = _load_exporter()
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self._rows = []
+
+    def execute(self, query, params=None):
+        if "LiteLLM_DailyUserSpend" in query:
+            self._rows = self.conn.spend_rows
+        elif '"key_alias"' in query:
+            self._rows = self.conn.alias_rows
+        elif "LiteLLM_VerificationToken" in query:
+            self._rows = self.conn.access_rows
+        else:  # pragma: no cover - guard against surprise queries
+            raise AssertionError(f"unexpected query: {query}")
+
+    def fetchall(self):
+        return self._rows
+
+    def close(self):
+        pass
+
+
+class FakeConn:
+    """Minimal psycopg2 stand-in serving canned rows per query."""
+
+    def __init__(self, alias_rows=(), access_rows=(), spend_rows=()):
+        self.alias_rows = list(alias_rows)
+        self.access_rows = list(access_rows)
+        self.spend_rows = list(spend_rows)
+        self.closed = False
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def close(self):
+        self.closed = True
+
+
+def _error_count(stage):
+    return exporter.litellm_exporter_errors_total.labels(stage=stage)._value.get()
+
+
+def test_old_pattern_reproduces_dict_mutation_crash():
+    """The original loop pattern raises RuntimeError — the bug was real."""
+    g = Gauge("test_old_pattern_crash", "t", ["k"])
+    for i in range(3):
+        g.labels(k=f"k{i}").set(i)
+    try:
+        with pytest.raises(RuntimeError, match="dictionary changed size"):
+            for label_set in g._metrics.keys():  # noqa: SIM118 — original (buggy) pattern
+                g.remove(*label_set)
+    finally:
+        for label_set in list(g._metrics.keys()):
+            g.remove(*label_set)
+
+
+def test_reset_gauge_clears_all_children():
+    g = Gauge("test_reset_clears", "t", ["k", "m"])
+    for i in range(5):
+        g.labels(k=f"k{i}", m="model").set(i)
+    assert len(g._metrics) == 5
+    exporter.reset_gauge(g)
+    assert len(g._metrics) == 0
+
+
+def test_reset_gauge_survives_repeated_cycles():
+    """The exact production failure: cycle 2+ used to crash."""
+    g = Gauge("test_reset_cycles", "t", ["k"])
+    for cycle in range(3):
+        for i in range(4):
+            g.labels(k=f"k{i}").set(cycle * 10 + i)
+        exporter.reset_gauge(g)
+        assert len(g._metrics) == 0
+
+
+def test_fetch_key_aliases_falls_back_to_hash_prefix():
+    conn = FakeConn(alias_rows=[("deadbeef" + "0" * 56, None), ("cafe" + "1" * 60, "hermes")])
+    aliases = exporter.fetch_key_aliases(conn)
+    assert aliases["cafe" + "1" * 60] == "hermes"
+    assert aliases["deadbeef" + "0" * 56] == "deadbeef0000..."
+
+
+def test_update_metrics_sets_token_gauges():
+    conn = FakeConn(
+        access_rows=[("hashA" + "0" * 61, ["deepseek-v4-flash"])],
+        spend_rows=[
+            # api_key, model, model_group, pt, ct, reqs, succ, fail
+            ("hashA" + "0" * 61, "openai/deepseek-v4-flash", None, 100, 250, 7, 6, 1),
+        ],
+    )
+    exporter.update_metrics(conn, {"hashA" + "0" * 61: "josh-desktop"})
+    key_hash = ("hashA" + "0" * 61)[:16] + "..."
+    prompt = exporter.litellm_prompt_tokens.labels(
+        key_alias="josh-desktop", model="openai/deepseek-v4-flash", api_key_hash=key_hash
+    )
+    total = exporter.litellm_total_tokens.labels(
+        key_alias="josh-desktop", model="openai/deepseek-v4-flash", api_key_hash=key_hash
+    )
+    assert prompt._value.get() == 100
+    assert total._value.get() == 350
+    assert (
+        exporter.litellm_requests_total.labels(key_alias="josh-desktop", api_key_hash=key_hash)._value.get()
+        == 7
+    )
+
+
+def test_update_metrics_one_bad_row_does_not_kill_scrape():
+    """A malformed row (api_key None) is skipped; good rows still land."""
+    good = "hashG" + "0" * 60
+    conn = FakeConn(
+        access_rows=[(good, ["deepseek-v4-flash"])],
+        spend_rows=[
+            (None, "openai/deepseek-v4-flash", None, 5, 5, 1, 1, 0),  # bad row
+            (good, "openai/deepseek-v4-flash", None, 42, 58, 3, 3, 0),
+        ],
+    )
+    before = _error_count("row")
+    exporter.update_metrics(conn, {good: "hermes"})
+    assert _error_count("row") == before + 1
+    assert (
+        exporter.litellm_total_tokens.labels(
+            key_alias="hermes",
+            model="openai/deepseek-v4-flash",
+            api_key_hash=good[:16] + "...",
+        )._value.get()
+        == 100
+    )
+
+
+def test_update_metrics_clears_stale_labelsets_between_cycles():
+    """Second cycle with no rows must remove yesterday's label sets."""
+    key = "hashS" + "0" * 60
+    first = FakeConn(spend_rows=[(key, "openai/gemma", None, 1, 2, 1, 1, 0)])
+    exporter.update_metrics(first, {key: "old-key"})
+    assert len(exporter.litellm_total_tokens._metrics) > 0
+
+    empty = FakeConn(spend_rows=[])
+    exporter.update_metrics(empty, {key: "old-key"})
+    for gauge in exporter.RESETTABLE_GAUGES:
+        assert len(gauge._metrics) == 0
+
+
+def test_update_metrics_filters_noise_aliases():
+    noise = "nonono" + "0" * 58
+    conn = FakeConn(spend_rows=[(noise, "openai/gemma", None, 9, 9, 2, 2, 0)])
+    exporter.update_metrics(conn, {noise: "no-key-requi..."})
+    assert len(exporter.litellm_total_tokens._metrics) == 0
+    assert len(exporter.litellm_requests_total._metrics) == 0

--- a/tools/monitoring/litellm_exporter/README.md
+++ b/tools/monitoring/litellm_exporter/README.md
@@ -1,0 +1,68 @@
+# litellm-exporter
+
+Prometheus exporter for per-key / per-model **token accounting** from the
+LiteLLM gateway (api.mtgacoach.com). Reads LiteLLM's PostgreSQL directly
+(the proxy's native `/metrics` returns 404 on `main-stable`) and exposes
+gauges on `:8012` for Prometheus to scrape.
+
+## Provenance
+
+This script was previously **not in any repo** — it lived only on the Plex
+host. Imported verbatim on 2026-07-29 from:
+
+- Host file: `/home/joshu/litellm-exporter.py` on `10.0.0.100` (Plex)
+- md5 of the imported (buggy) version: `92e631261821f124cd934f6aaa471a56`
+- Container: `litellm-exporter`
+  - Image: `python:3.11-slim` (NB: an earlier task brief claimed
+    `lucabecker42/ollama-exporter:latest` — that is stale info; the real
+    image is `python:3.11-slim`)
+  - Cmd: `sh -c 'pip install -q prometheus_client psycopg2-binary && python3 /app/exporter.py'`
+  - Bind mount: `/home/joshu/litellm-exporter.py` → `/app/exporter.py` (ro)
+  - Docker network: `litellm_default` (so it can resolve `litellm-db`)
+  - Port: `0.0.0.0:8012 -> 8012/tcp`
+  - Env: `DB_HOST=litellm-db`, `DB_USER=litellm`, `DB_PASS=<postgres pw>`,
+    `DB_NAME=litellm`, `EXPORTER_PORT=8012`
+
+Runtime deps (installed by the container's Cmd): `prometheus_client`,
+`psycopg2-binary`. Python 3.10+.
+
+## Data source
+
+- `"LiteLLM_DailyUserSpend"` — pre-aggregated per `date + api_key + model`:
+  prompt/completion tokens, api/successful/failed request counts.
+- `"LiteLLM_VerificationToken"` — `token` (hash) → `key_alias`, `models`.
+
+## Metrics
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `litellm_prompt_tokens` | `key_alias, model, api_key_hash` | prompt tokens today |
+| `litellm_completion_tokens` | `key_alias, model, api_key_hash` | completion tokens today |
+| `litellm_total_tokens` | `key_alias, model, api_key_hash` | total tokens today |
+| `litellm_requests_total` | `key_alias, api_key_hash` | API requests today |
+| `litellm_requests_successful` | `key_alias, api_key_hash` | successful requests today |
+| `litellm_requests_failed` | `key_alias, api_key_hash` | failed requests today |
+| `litellm_model_access` | `key_alias, model` | 1 = key has model access |
+| `litellm_exporter_errors_total` | `stage` | internal collector errors (added 2026-07-29) |
+
+All daily gauges reset each scrape cycle (stale label sets are removed first).
+Noise aliases (`None...`, `no-key-requi...`, `ignored...`, `litellm_prox...`)
+are filtered out.
+
+## Deploy (owner runs this on the Plex host)
+
+```bash
+# 1. copy the fixed script over the bind-mounted host file
+scp tools/monitoring/litellm_exporter/exporter.py joshu@10.0.0.100:/home/joshu/litellm-exporter.py
+
+# 2. restart so the bind mount picks up the new file
+ssh joshu@10.0.0.100 "docker restart litellm-exporter"
+
+# 3. verify
+ssh joshu@10.0.0.100 "docker logs litellm-exporter --tail 5"
+curl -s localhost:8012/metrics | grep -c '^litellm_total_tokens'
+```
+
+Prometheus already scrapes `10.0.0.100:8012` as job `litellm-exporter` — no
+Prometheus config change is needed; the ten empty Grafana panels
+(uid `vllm-gemma`) fill in on the next successful scrape.

--- a/tools/monitoring/litellm_exporter/exporter.py
+++ b/tools/monitoring/litellm_exporter/exporter.py
@@ -3,14 +3,16 @@
 litellm-exporter — queries litellm's PostgreSQL for per-user token metrics
 and exposes them as Prometheus metrics on :8012 for scraping.
 
-Run: python3 litellm-exporter.py  (or docker container)
+Run: python3 exporter.py  (or docker container)
 Depends on: psycopg2-binary, prometheus_client
 """
+
 import os
 import time
 from collections import defaultdict
-from prometheus_client import start_http_server, Gauge, Counter
-import psycopg2
+from contextlib import suppress
+
+from prometheus_client import Counter, Gauge, start_http_server
 
 # ── Config from env ─────────────────────────────────────────────────────
 DB_HOST = os.getenv("DB_HOST", "10.0.0.100")
@@ -21,61 +23,103 @@ DB_NAME = os.getenv("DB_NAME", "litellm")
 EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "8012"))
 SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "30"))  # seconds
 
+# Aliases used by internal/system traffic — not real users.
+NOISE_ALIASES = frozenset({"None...", "no-key-requi...", "ignored...", "litellm_prox..."})
+
 # ── Prometheus metrics ──────────────────────────────────────────────────
 
 # Per-user gauge — total prompt tokens today (resets daily)
 litellm_prompt_tokens = Gauge(
     "litellm_prompt_tokens",
     "Total prompt tokens processed per user (today)",
-    ["key_alias", "model", "api_key_hash"]
+    ["key_alias", "model", "api_key_hash"],
 )
 
 # Per-user gauge — total completion tokens today
 litellm_completion_tokens = Gauge(
     "litellm_completion_tokens",
     "Total completion tokens generated per user (today)",
-    ["key_alias", "model", "api_key_hash"]
+    ["key_alias", "model", "api_key_hash"],
 )
 
 # Per-user gauge — total (prompt+completion) tokens today
 litellm_total_tokens = Gauge(
-    "litellm_total_tokens",
-    "Total tokens processed per user (today)",
-    ["key_alias", "model", "api_key_hash"]
+    "litellm_total_tokens", "Total tokens processed per user (today)", ["key_alias", "model", "api_key_hash"]
 )
 
 # Per-user gauge — request count today
 litellm_requests_total = Gauge(
-    "litellm_requests_total",
-    "Total API requests per user (today)",
-    ["key_alias", "api_key_hash"]
+    "litellm_requests_total", "Total API requests per user (today)", ["key_alias", "api_key_hash"]
 )
 
 # Per-user gauge — successful requests today
 litellm_requests_successful = Gauge(
-    "litellm_requests_successful",
-    "Successful API requests per user (today)",
-    ["key_alias", "api_key_hash"]
+    "litellm_requests_successful", "Successful API requests per user (today)", ["key_alias", "api_key_hash"]
 )
 
 # Per-user gauge — failed requests today
 litellm_requests_failed = Gauge(
-    "litellm_requests_failed",
-    "Failed API requests per user (today)",
-    ["key_alias", "api_key_hash"]
+    "litellm_requests_failed", "Failed API requests per user (today)", ["key_alias", "api_key_hash"]
 )
 
 # Per-key alias — model access info
 litellm_model_access = Gauge(
     "litellm_model_access",
     "Model access per key alias (1 = has access, 0 = no access)",
-    ["key_alias", "model"]
+    ["key_alias", "model"],
+)
+
+# Collector health — one bad key/row must never kill the whole scrape.
+litellm_exporter_errors_total = Counter(
+    "litellm_exporter_errors_total",
+    "Internal errors while collecting litellm metrics, by stage "
+    "(scrape, gauge_reset, row, model_access, key_tokens, key_requests)",
+    ["stage"],
+)
+
+# Gauges whose label sets are rebuilt from scratch every scrape cycle.
+RESETTABLE_GAUGES = (
+    litellm_prompt_tokens,
+    litellm_completion_tokens,
+    litellm_total_tokens,
+    litellm_requests_total,
+    litellm_requests_successful,
+    litellm_requests_failed,
 )
 
 
 def get_today_str():
     """Return today's date in litellm's format (YYYY-MM-DD)."""
     return time.strftime("%Y-%m-%d")
+
+
+def connect_db():
+    """Open a new autocommit connection to the litellm Postgres DB.
+
+    psycopg2 is imported lazily so this module stays importable (for tests)
+    on machines that only have prometheus_client installed.
+    """
+    import psycopg2
+
+    conn = psycopg2.connect(host=DB_HOST, port=DB_PORT, user=DB_USER, password=DB_PASS, dbname=DB_NAME)
+    conn.autocommit = True
+    return conn
+
+
+def reset_gauge(gauge):
+    """Remove every labelled child from a Gauge.
+
+    Iterates a *snapshot* of the internal label dict. The previous code did
+    ``for label_set in gauge._metrics.keys(): gauge.remove(*label_set)`` —
+    remove() deletes from that same dict, so the loop died with
+    ``RuntimeError: dictionary changed size during iteration`` on every
+    scrape after the first, leaving all token gauges permanently stale.
+    """
+    for label_set in list(gauge._metrics.keys()):
+        try:
+            gauge.remove(*label_set)
+        except Exception:
+            litellm_exporter_errors_total.labels(stage="gauge_reset").inc()
 
 
 def fetch_key_aliases(conn):
@@ -103,29 +147,39 @@ def fetch_today_user_data(conn, key_aliases):
            WHERE date = %s
              AND (prompt_tokens > 0 OR completion_tokens > 0 OR api_requests > 0)
         """,
-        (today,)
+        (today,),
     )
     rows = cursor.fetchall()
     cursor.close()
 
     # Aggregate per api_key + model
-    per_key_model = defaultdict(lambda: {
-        "prompt_tokens": 0, "completion_tokens": 0,
-        "total_tokens": 0, "requests": 0, "successful": 0, "failed": 0,
-        "models": set()
-    })
+    per_key_model = defaultdict(
+        lambda: {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "requests": 0,
+            "successful": 0,
+            "failed": 0,
+            "models": set(),
+        }
+    )
 
-    for api_key, model, model_group, pt, ct, reqs, succ, fail in rows:
-        key = api_key
-        alias = key_aliases.get(api_key, api_key[:12] + "...")
-        d = per_key_model[(key, alias, model)]
-        d["prompt_tokens"] += (pt or 0)
-        d["completion_tokens"] += (ct or 0)
-        d["total_tokens"] += (pt or 0) + (ct or 0)
-        d["requests"] += (reqs or 0)
-        d["successful"] += (succ or 0)
-        d["failed"] += (fail or 0)
-        d["models"].add(model)
+    for row in rows:
+        try:
+            api_key, model, model_group, pt, ct, reqs, succ, fail = row
+            alias = key_aliases.get(api_key, api_key[:12] + "...")
+            d = per_key_model[(api_key, alias, model)]
+            d["prompt_tokens"] += pt or 0
+            d["completion_tokens"] += ct or 0
+            d["total_tokens"] += (pt or 0) + (ct or 0)
+            d["requests"] += reqs or 0
+            d["successful"] += succ or 0
+            d["failed"] += fail or 0
+            d["models"].add(model)
+        except Exception:
+            # One malformed row must not kill the scrape.
+            litellm_exporter_errors_total.labels(stage="row").inc()
 
     return per_key_model
 
@@ -135,53 +189,51 @@ def update_metrics(conn, key_aliases):
 
     # 1) Key alias → model access info
     cursor = conn.cursor()
-    cursor.execute(
-        'SELECT "token", "models" FROM "LiteLLM_VerificationToken"'
-    )
+    cursor.execute('SELECT "token", "models" FROM "LiteLLM_VerificationToken"')
     access_rows = cursor.fetchall()
     cursor.close()
 
-    all_models = set()
     for token, models in access_rows:
-        alias = key_aliases.get(token, token[:12] + "...")
-        if models:
-            for m in models:
-                all_models.add(m)
-                litellm_model_access.labels(key_alias=alias, model=m).set(1)
+        try:
+            alias = key_aliases.get(token, token[:12] + "...")
+            if models:
+                for m in models:
+                    litellm_model_access.labels(key_alias=alias, model=m).set(1)
+        except Exception:
+            litellm_exporter_errors_total.labels(stage="model_access").inc()
 
     # 2) Today's per-user token data
     per_key_model = fetch_today_user_data(conn, key_aliases)
 
     # Reset all gauges to 0 first (so unused aliases don't show stale data)
-    for label_set in litellm_prompt_tokens._metrics.keys():
-        litellm_prompt_tokens.remove(*label_set)
-    for label_set in litellm_completion_tokens._metrics.keys():
-        litellm_completion_tokens.remove(*label_set)
-    for label_set in litellm_total_tokens._metrics.keys():
-        litellm_total_tokens.remove(*label_set)
-    for label_set in litellm_requests_total._metrics.keys():
-        litellm_requests_total.remove(*label_set)
-    for label_set in litellm_requests_successful._metrics.keys():
-        litellm_requests_successful.remove(*label_set)
-    for label_set in litellm_requests_failed._metrics.keys():
-        litellm_requests_failed.remove(*label_set)
+    for gauge in RESETTABLE_GAUGES:
+        reset_gauge(gauge)
 
     # Set current values
     for (api_key, alias, model), data in per_key_model.items():
         # Skip noise entries
-        if not alias or alias in ["None...", "no-key-requi...", "ignored...", "litellm_prox..."]:
+        if not alias or alias in NOISE_ALIASES:
             continue
         if not model or model == "":
             continue
-        key_hash = api_key[:16] + "..."
-        litellm_prompt_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["prompt_tokens"])
-        litellm_completion_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["completion_tokens"])
-        litellm_total_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["total_tokens"])
+        try:
+            key_hash = api_key[:16] + "..."
+            litellm_prompt_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(
+                data["prompt_tokens"]
+            )
+            litellm_completion_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(
+                data["completion_tokens"]
+            )
+            litellm_total_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(
+                data["total_tokens"]
+            )
+        except Exception:
+            litellm_exporter_errors_total.labels(stage="key_tokens").inc()
 
     # Aggregate per-key for request counts
     per_key_agg = defaultdict(lambda: {"requests": 0, "successful": 0, "failed": 0, "alias": "", "hash": ""})
     for (api_key, alias, model), data in per_key_model.items():
-        if not alias or alias in ["None...", "no-key-requi...", "ignored...", "litellm_prox..."]:
+        if not alias or alias in NOISE_ALIASES:
             continue
         pk = api_key
         per_key_agg[pk]["requests"] += data["requests"]
@@ -191,9 +243,18 @@ def update_metrics(conn, key_aliases):
         per_key_agg[pk]["hash"] = api_key[:16] + "..."
 
     for api_key, data in per_key_agg.items():
-        litellm_requests_total.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["requests"])
-        litellm_requests_successful.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["successful"])
-        litellm_requests_failed.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["failed"])
+        try:
+            litellm_requests_total.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(
+                data["requests"]
+            )
+            litellm_requests_successful.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(
+                data["successful"]
+            )
+            litellm_requests_failed.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(
+                data["failed"]
+            )
+        except Exception:
+            litellm_exporter_errors_total.labels(stage="key_requests").inc()
 
 
 def main():
@@ -205,32 +266,29 @@ def main():
     start_http_server(EXPORTER_PORT)
     print(f"  HTTP server started on :{EXPORTER_PORT}")
 
-    conn = psycopg2.connect(
-        host=DB_HOST, port=DB_PORT,
-        user=DB_USER, password=DB_PASS,
-        dbname=DB_NAME
-    )
-    conn.autocommit = True
-
+    conn = None
     while True:
         try:
-            # Reconnect if needed
-            if conn.closed:
-                conn = psycopg2.connect(
-                    host=DB_HOST, port=DB_PORT,
-                    user=DB_USER, password=DB_PASS,
-                    dbname=DB_NAME
-                )
-                conn.autocommit = True
+            # (Re)connect if needed
+            if conn is None or conn.closed:
+                conn = connect_db()
 
             key_aliases = fetch_key_aliases(conn)
             print(f"  Fetched {len(key_aliases)} key aliases for {get_today_str()}")
 
             update_metrics(conn, key_aliases)
-            print(f"  Metrics updated successfully")
+            print("  Metrics updated successfully")
 
         except Exception as e:
             print(f"  Error: {e}")
+            with suppress(Exception):
+                litellm_exporter_errors_total.labels(stage="scrape").inc()
+            # Drop the connection so the next cycle reconnects cleanly —
+            # a failed query can leave the session unusable.
+            if conn is not None:
+                with suppress(Exception):
+                    conn.close()
+                conn = None
 
         time.sleep(SCRAPE_INTERVAL)
 

--- a/tools/monitoring/litellm_exporter/exporter.py
+++ b/tools/monitoring/litellm_exporter/exporter.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+litellm-exporter — queries litellm's PostgreSQL for per-user token metrics
+and exposes them as Prometheus metrics on :8012 for scraping.
+
+Run: python3 litellm-exporter.py  (or docker container)
+Depends on: psycopg2-binary, prometheus_client
+"""
+import os
+import time
+from collections import defaultdict
+from prometheus_client import start_http_server, Gauge, Counter
+import psycopg2
+
+# ── Config from env ─────────────────────────────────────────────────────
+DB_HOST = os.getenv("DB_HOST", "10.0.0.100")
+DB_PORT = int(os.getenv("DB_PORT", "5432"))
+DB_USER = os.getenv("DB_USER", "litellm")
+DB_PASS = os.getenv("DB_PASS", "")
+DB_NAME = os.getenv("DB_NAME", "litellm")
+EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "8012"))
+SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "30"))  # seconds
+
+# ── Prometheus metrics ──────────────────────────────────────────────────
+
+# Per-user gauge — total prompt tokens today (resets daily)
+litellm_prompt_tokens = Gauge(
+    "litellm_prompt_tokens",
+    "Total prompt tokens processed per user (today)",
+    ["key_alias", "model", "api_key_hash"]
+)
+
+# Per-user gauge — total completion tokens today
+litellm_completion_tokens = Gauge(
+    "litellm_completion_tokens",
+    "Total completion tokens generated per user (today)",
+    ["key_alias", "model", "api_key_hash"]
+)
+
+# Per-user gauge — total (prompt+completion) tokens today
+litellm_total_tokens = Gauge(
+    "litellm_total_tokens",
+    "Total tokens processed per user (today)",
+    ["key_alias", "model", "api_key_hash"]
+)
+
+# Per-user gauge — request count today
+litellm_requests_total = Gauge(
+    "litellm_requests_total",
+    "Total API requests per user (today)",
+    ["key_alias", "api_key_hash"]
+)
+
+# Per-user gauge — successful requests today
+litellm_requests_successful = Gauge(
+    "litellm_requests_successful",
+    "Successful API requests per user (today)",
+    ["key_alias", "api_key_hash"]
+)
+
+# Per-user gauge — failed requests today
+litellm_requests_failed = Gauge(
+    "litellm_requests_failed",
+    "Failed API requests per user (today)",
+    ["key_alias", "api_key_hash"]
+)
+
+# Per-key alias — model access info
+litellm_model_access = Gauge(
+    "litellm_model_access",
+    "Model access per key alias (1 = has access, 0 = no access)",
+    ["key_alias", "model"]
+)
+
+
+def get_today_str():
+    """Return today's date in litellm's format (YYYY-MM-DD)."""
+    return time.strftime("%Y-%m-%d")
+
+
+def fetch_key_aliases(conn):
+    """Fetch key alias → api_key_hash mapping from VerificationToken table."""
+    cursor = conn.cursor()
+    cursor.execute('SELECT "token", "key_alias" FROM "LiteLLM_VerificationToken"')
+    rows = cursor.fetchall()
+    cursor.close()
+    # Return dict of token_hash -> key_alias
+    return {row[0]: row[1] if row[1] else row[0][:12] + "..." for row in rows}
+
+
+def fetch_today_user_data(conn, key_aliases):
+    """
+    Query LiteLLM_DailyUserSpend for today's data,
+    grouped by api_key + model.
+    """
+    today = get_today_str()
+    cursor = conn.cursor()
+    cursor.execute(
+        """SELECT api_key, model, model_group,
+                  prompt_tokens, completion_tokens,
+                  api_requests, successful_requests, failed_requests
+           FROM "LiteLLM_DailyUserSpend"
+           WHERE date = %s
+             AND (prompt_tokens > 0 OR completion_tokens > 0 OR api_requests > 0)
+        """,
+        (today,)
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+
+    # Aggregate per api_key + model
+    per_key_model = defaultdict(lambda: {
+        "prompt_tokens": 0, "completion_tokens": 0,
+        "total_tokens": 0, "requests": 0, "successful": 0, "failed": 0,
+        "models": set()
+    })
+
+    for api_key, model, model_group, pt, ct, reqs, succ, fail in rows:
+        key = api_key
+        alias = key_aliases.get(api_key, api_key[:12] + "...")
+        d = per_key_model[(key, alias, model)]
+        d["prompt_tokens"] += (pt or 0)
+        d["completion_tokens"] += (ct or 0)
+        d["total_tokens"] += (pt or 0) + (ct or 0)
+        d["requests"] += (reqs or 0)
+        d["successful"] += (succ or 0)
+        d["failed"] += (fail or 0)
+        d["models"].add(model)
+
+    return per_key_model
+
+
+def update_metrics(conn, key_aliases):
+    """Query the DB and update all Prometheus metrics."""
+
+    # 1) Key alias → model access info
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT "token", "models" FROM "LiteLLM_VerificationToken"'
+    )
+    access_rows = cursor.fetchall()
+    cursor.close()
+
+    all_models = set()
+    for token, models in access_rows:
+        alias = key_aliases.get(token, token[:12] + "...")
+        if models:
+            for m in models:
+                all_models.add(m)
+                litellm_model_access.labels(key_alias=alias, model=m).set(1)
+
+    # 2) Today's per-user token data
+    per_key_model = fetch_today_user_data(conn, key_aliases)
+
+    # Reset all gauges to 0 first (so unused aliases don't show stale data)
+    for label_set in litellm_prompt_tokens._metrics.keys():
+        litellm_prompt_tokens.remove(*label_set)
+    for label_set in litellm_completion_tokens._metrics.keys():
+        litellm_completion_tokens.remove(*label_set)
+    for label_set in litellm_total_tokens._metrics.keys():
+        litellm_total_tokens.remove(*label_set)
+    for label_set in litellm_requests_total._metrics.keys():
+        litellm_requests_total.remove(*label_set)
+    for label_set in litellm_requests_successful._metrics.keys():
+        litellm_requests_successful.remove(*label_set)
+    for label_set in litellm_requests_failed._metrics.keys():
+        litellm_requests_failed.remove(*label_set)
+
+    # Set current values
+    for (api_key, alias, model), data in per_key_model.items():
+        # Skip noise entries
+        if not alias or alias in ["None...", "no-key-requi...", "ignored...", "litellm_prox..."]:
+            continue
+        if not model or model == "":
+            continue
+        key_hash = api_key[:16] + "..."
+        litellm_prompt_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["prompt_tokens"])
+        litellm_completion_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["completion_tokens"])
+        litellm_total_tokens.labels(key_alias=alias, model=model, api_key_hash=key_hash).set(data["total_tokens"])
+
+    # Aggregate per-key for request counts
+    per_key_agg = defaultdict(lambda: {"requests": 0, "successful": 0, "failed": 0, "alias": "", "hash": ""})
+    for (api_key, alias, model), data in per_key_model.items():
+        if not alias or alias in ["None...", "no-key-requi...", "ignored...", "litellm_prox..."]:
+            continue
+        pk = api_key
+        per_key_agg[pk]["requests"] += data["requests"]
+        per_key_agg[pk]["successful"] += data["successful"]
+        per_key_agg[pk]["failed"] += data["failed"]
+        per_key_agg[pk]["alias"] = alias
+        per_key_agg[pk]["hash"] = api_key[:16] + "..."
+
+    for api_key, data in per_key_agg.items():
+        litellm_requests_total.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["requests"])
+        litellm_requests_successful.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["successful"])
+        litellm_requests_failed.labels(key_alias=data["alias"], api_key_hash=data["hash"]).set(data["failed"])
+
+
+def main():
+    print(f"litellm-exporter starting on :{EXPORTER_PORT}")
+    print(f"  DB: {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}")
+    print(f"  Scrape interval: {SCRAPE_INTERVAL}s")
+
+    # Start Prometheus HTTP server
+    start_http_server(EXPORTER_PORT)
+    print(f"  HTTP server started on :{EXPORTER_PORT}")
+
+    conn = psycopg2.connect(
+        host=DB_HOST, port=DB_PORT,
+        user=DB_USER, password=DB_PASS,
+        dbname=DB_NAME
+    )
+    conn.autocommit = True
+
+    while True:
+        try:
+            # Reconnect if needed
+            if conn.closed:
+                conn = psycopg2.connect(
+                    host=DB_HOST, port=DB_PORT,
+                    user=DB_USER, password=DB_PASS,
+                    dbname=DB_NAME
+                )
+                conn.autocommit = True
+
+            key_aliases = fetch_key_aliases(conn)
+            print(f"  Fetched {len(key_aliases)} key aliases for {get_today_str()}")
+
+            update_metrics(conn, key_aliases)
+            print(f"  Metrics updated successfully")
+
+        except Exception as e:
+            print(f"  Error: {e}")
+
+        time.sleep(SCRAPE_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Cause

The deployed exporter reset its daily gauges with:

```python
for label_set in gauge._metrics.keys():
    gauge.remove(*label_set)
```

`remove()` mutates the same `dict` being iterated — every scrape after the first raised `RuntimeError: dictionary changed size during iteration`. The 30-second crash was confirmed in `docker logs litellm-exporter`:

```
Fetched 138 key aliases for 2026-07-29
Error: dictionary changed size during iteration
```

The gauges **before** the crash (`litellm_model_access`, `litellm_requests_failed`) stayed fresh; the token/request gauges **after** the crash stayed stale, leaving 10 Grafana panels (uid `vllm-gemma`) empty despite 29 indexed series in Prometheus with `job="litellm-exporter"`.

## Fix

| Change | Detail |
|--------|--------|
| **dict snapshot** | `reset_gauge()` iterates `list(gauge._metrics.keys())` instead of the live dict |
| **per-key error isolation** | Every row/key loop wrapped in `try/except` — one bad key cannot kill the whole scrape |
| **`litellm_exporter_errors_total{stage}`** | New Counter makes collector errors visible in Prometheus (not just docker logs) |
| **connection recovery** | Main loop drops and reopens the DB connection after any failure |
| **lazy psycopg2** | `connect_db()` imports lazily so the module is testable without the DB driver |

## Test output

```
$ python3 -m pytest tests/test_litellm_exporter.py -v
============================= 8 passed in 0.04s ==============================
```

## Proof of fix — running against real LiteLLM PG on port 8099

```
$ curl -s localhost:8099/metrics | grep -cE '^litellm_(total|prompt|completion)_tokens'
6

$ curl -s localhost:8099/metrics | grep '^litellm_total_tokens{' | head -3
litellm_total_tokens{api_key_hash="d1c1e5e0e4ff0005...",key_alias="m5 pro",model="openai/deepseek-v4-flash"} 3.9e+06
litellm_total_tokens{api_key_hash="2f1c21a4221578eb...",key_alias="hermes",model="openai/deepseek-v4-flash"} 9.2e+06

$ curl -s localhost:8099/metrics | grep '^litellm_prompt_tokens{' | head -3
litellm_prompt_tokens{api_key_hash="d1c1e5e0e4ff0005...",key_alias="m5 pro",model="openai/deepseek-v4-flash"} 3.88e+06
litellm_prompt_tokens{api_key_hash="2f1c21a4221578eb...",key_alias="hermes",model="openai/deepseek-v4-flash"} 9.18e+06

litellm_exporter_errors_total (empty -- zero errors, clean scrape)
```

## Deploy (owner runs on Plex host)

```bash
scp tools/monitoring/litellm_exporter/exporter.py joshu@10.0.0.100:/home/joshu/litellm-exporter.py
ssh joshu@10.0.0.100 "docker restart litellm-exporter"
ssh joshu@10.0.0.100 "docker logs litellm-exporter --tail 5"
curl -s localhost:8012/metrics | grep -c '^litellm_total_tokens'
```

Prometheus already scrapes `10.0.0.100:8012` with job `litellm-exporter` -- the ten empty Grafana panels (uid `vllm-gemma`) fill in on the next successful scrape.

## Known gaps

- Exporter is not containerized in this repo (the Dockerfile is on the Plex host). Deployed as a bind-mounted script into `python:3.11-slim`.
- No CI integration for the exporter test (no psycopg2 dependency in CI).
