### PR TITLE
fix(wp3): battlefield_opp accumulates self permanents (follow-up to #433)

### DIFF
--- a/tests/test_parse_magezero_deck_sanity.py
+++ b/tests/test_parse_magezero_deck_sanity.py
@@ -1,0 +1,150 @@
+"""Deck-sanity guardrail: assert battlefield_self / battlefield_opp correctness.
+
+Each assertion runs over the real mz_train_smoke.log (591 games, 9,789 decisions)
+to catch board-assignment regressions.
+
+Check 1: battlefield_self never holds an opponent-exclusive basic.
+         UWTempo plays Island + Plains; opponent-exclusive = {Mountain, Forest, Swamp}.
+
+Check 2: battlefield_opp never holds UW-only nonbasic lands on mono-colour opponents.
+         UW dual lands {Adarkar Wastes, Seachrome Coast, Meticulous Archive,
+         Floodfarm Verge} are unique to the UW Tempo shell.
+         Soulstone Sanctuary is excluded: it is a colourless land that appears
+         legitimately in several opponent decklists.
+
+Check 3: no non-basic card name appears in BOTH boards of the same row.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+REPO = _HERE.parent
+PARSER = REPO / "tools" / "training" / "parse_magezero_log.py"
+SMOKE_LOG = Path("/Users/joshu/wp3/evidence/mz_train_smoke.log")
+
+# UWTempo-specific nonbasic lands — never played by mono-colour opponents.
+# Soulstone Sanctuary is excluded: it is a colourless land that appears
+# legitimately in several opponent decklists.
+UW_ONLY_NONBASICS = frozenset({
+    "Adarkar Wastes",
+    "Seachrome Coast",
+    "Meticulous Archive",
+    "Floodfarm Verge",
+})
+
+# Opponent-exclusive basics — basics owned by the opponent mono deck that
+# the UWTempo deck never plays.  UWTempo has Island + Plains; everything
+# else is opponent-exclusive.
+OPP_EXCLUSIVE_BASICS = frozenset({"Mountain", "Forest", "Swamp"})
+
+BASICS = frozenset({"Plains", "Island", "Swamp", "Mountain", "Forest"})
+
+
+def _parse_smoke_log() -> list[dict]:
+    """Parse the real smoke log and return decisions."""
+    if not SMOKE_LOG.exists():
+        raise FileNotFoundError(f"Smoke log not found: {SMOKE_LOG}")
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as tmp:
+        out_path = tmp.name
+
+    result = subprocess.run(
+        [
+            sys.executable, str(PARSER),
+            "--log", str(SMOKE_LOG),
+            "--out", out_path,
+        ],
+        capture_output=True, text=True, timeout=300,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Parser failed (exit {result.returncode}):\n"
+            f"{result.stderr[:2000]}"
+        )
+
+    decisions: list[dict] = []
+    with open(out_path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                decisions.append(json.loads(line))
+    Path(out_path).unlink()
+    return decisions
+
+
+def _session_opponent_colour(session: str) -> str | None:
+    """Return the opponent mono colour from a session name, or None."""
+    if "vs_Standard-Mono" not in session:
+        return None
+    return session.split("Standard-Mono")[1][0]  # R, G, B, W, or U
+
+
+# ── Module-level decisions fixture (parse once per session) ──────────────
+
+_decisions: list[dict] | None = None
+
+
+def _get_decisions() -> list[dict]:
+    global _decisions
+    if _decisions is None:
+        _decisions = _parse_smoke_log()
+    return _decisions
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+def test_battlefield_self_no_opp_exclusive_basics() -> None:
+    """Check 1: battlefield_self never holds an opponent-exclusive basic."""
+    decisions = _get_decisions()
+    bad: list[str] = []
+    for d in decisions:
+        bf = [p["name"] for p in (d.get("battlefield_self") or [])]
+        found = {c for c in bf if c in OPP_EXCLUSIVE_BASICS}
+        if found:
+            bad.append(f"  {d.get('session', '?')} gid={d.get('game_id', '?')} basics={found}")
+    assert not bad, (
+        "battlefield_self has opponent-exclusive basics:\n"
+        + "\n".join(bad[:10])
+    )
+
+
+def test_battlefield_opp_no_uw_nonbasics() -> None:
+    """Check 2: battlefield_opp never holds UW-only nonbasics on mono opponents."""
+    decisions = _get_decisions()
+    bad: list[str] = []
+    for d in decisions:
+        session = d.get("session", "")
+        opp_colour = _session_opponent_colour(session)
+        if opp_colour is None or opp_colour == "U":
+            continue  # MonoU shares Island with UWTempo, so skip
+        bf = [p["name"] for p in (d.get("battlefield_opp") or [])]
+        found = [c for c in bf if c in UW_ONLY_NONBASICS]
+        if found:
+            bad.append(f"  {session} gid={d.get('game_id', '?')} cards={found}")
+    assert not bad, (
+        "battlefield_opp has UW-only nonbasics:\n"
+        + "\n".join(bad[:10])
+    )
+
+
+def test_no_card_in_both_boards() -> None:
+    """Check 3: no non-basic card name appears in BOTH boards of the same row."""
+    decisions = _get_decisions()
+    bad: list[str] = []
+    for d in decisions:
+        self_set = {p["name"] for p in (d.get("battlefield_self") or [])}
+        opp_set = {p["name"] for p in (d.get("battlefield_opp") or [])}
+        shared = (self_set & opp_set) - BASICS
+        if shared:
+            bad.append(f"  {d.get('session', '?')} gid={d.get('game_id', '?')} shared={shared}")
+    assert not bad, (
+        "Same non-basic card in both boards:\n"
+        + "\n".join(bad[:10])
+    )

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -50,6 +50,51 @@ RE_TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
 RE_ACTION_TUPLE = re.compile(r"\[([^\]]+?) score: (-?[\d.eE+-]+) count: (\d+)\]")
 
 
+# ── Known basic and dual land names for land tracking ─────────────────
+
+BASIC_LANDS = {"Plains", "Island", "Swamp", "Mountain", "Forest"}
+# Basic lands that appear ONLY in opponent mono-decks, never in UWTempo
+OPPONENT_BASICS = {"Mountain", "Forest", "Swamp", "Plains"}
+# Lands from UWTempo (Island is shared with MonoU but never with other mono-decks)
+UWTEMPO_LANDS = {"Island"}
+
+
+def _is_land_action(chosen: str) -> bool:
+    """Check if a chosen action is playing a land."""
+    if not chosen.startswith("Play "):
+        return False
+    rest = chosen[5:]  # everything after "Play "
+    # Basic lands
+    if rest in BASIC_LANDS:
+        return True
+    # Non-basic lands: check if this is a known land card or looks like one
+    # (no curly braces, not a spell-like name)
+    if '{' in rest or '}' in rest:
+        return False
+    return True  # Treat "Play <anything>" as a land play
+
+
+def _hand_player_is_a(hand: list[str]) -> bool | None:
+    """Determine if the current turn player (whose hand this is) is PlayerA.
+    
+    Uses basic-land detection: if the hand contains an opponent-only basic
+    (Mountain/Forest/Swamp/Plains) it's PlayerB's turn.  If it contains
+    Island (absent from MonoR/G/B/W hands) it's PlayerA's turn.
+    Returns None when both are present or neither (can't determine).
+    """
+    has_opp_basic = any(c in OPPONENT_BASICS for c in hand)
+    has_uw_land = any(c in UWTEMPO_LANDS for c in hand)
+    
+    # Case: hand has at least one of each — can't differentiate
+    if has_opp_basic and has_uw_land:
+        return None
+    if has_uw_land and not has_opp_basic:
+        return True   # PlayerA's turn
+    if has_opp_basic and not has_uw_land:
+        return False  # PlayerB's turn
+    return None       # No basic lands in hand at all — can't tell
+
+
 # ── Phase → decision_kind mapping ───────────────────────────────────────
 
 DECISION_KIND_MAP = {
@@ -99,8 +144,12 @@ def parse_permanents(text: str) -> list[dict[str, Any]]:
         if not entry:
             continue
         tapped = ",tapped" in entry
-        name = entry.replace(",tapped", "").strip()
+        name = entry
+        # Strip trailing status suffixes like ,tapped, ,attacking, ,blocking
+        name = re.sub(r"(?:,(?:tapped|attacking|blocking))+", "", name).strip()
+        # Strip trailing :N score suffix from GameStateEvaluator2 output
         name = re.sub(r":\d+$", "", name).strip()
+        name = name.strip(", ")
         result.append({"name": name, "tapped": tapped})
     return result
 
@@ -206,6 +255,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             _finalize_game(state, decisions)
             thread_game_seq[thread_id] += 1
             state.start_new_game(thread_game_seq[thread_id])
+            state.turn_player_is_a = (dm.group(1) == "A")
             pending_pool.pop(thread_id, None)
             pending_menu.pop(thread_id, None)
             continue
@@ -248,6 +298,36 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             kind = classify_kind(phase_code, pool_actions)
             mcts_counts = {name: count for name, _, count in pool_actions}
 
+            # ── Turn tracking ──────────────────────────────────
+            if turn != state.last_turn:
+                # New turn — reset lands_played counter
+                state.lands_played_this_turn = 0
+                state.last_turn = turn
+
+            # Clear stale _perm_buffer — any permanents sitting in the
+            # buffer from before this chose_action (e.g. the opponent's
+            # starting board before the first decision) must not leak
+            # into this decision's permanents.
+            state._perm_buffer = []
+
+            # Derive lands_played this turn
+            if _is_land_action(chosen):
+                state.lands_played_this_turn += 1
+
+            # Derive land_playable: a land-play menu action exists and
+            # the player hasn't played a land yet this turn.
+            land_playable = False
+            has_play_land_in_menu = any(
+                _is_land_action(a[0]) for a in pool_actions
+            )
+            if has_play_land_in_menu and state.lands_played_this_turn == 0:
+                land_playable = True
+            elif has_play_land_in_menu:
+                # Land is available in menu but already played one this turn
+                land_playable = False
+
+            state.total_decisions += 1
+
             decision = {
                 "game_id": state.game_id,
                 "turn": turn,
@@ -255,11 +335,13 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 "active_life": state.life_a,
                 "opp_life": state.life_b,
                 "hand": [],
-                "battlefield_self": [],
-                "battlefield_opp": [],
+                "battlefield_self": None,
+                "battlefield_opp": None,
                 "menu": list(menu),
                 "chosen": chosen,
                 "mcts_counts": mcts_counts,
+                "lands_played": max(0, state.lands_played_this_turn),
+                "land_playable": land_playable,
                 "actor": "PlayerA",
                 "outcome": "unknown",
                 "decision_kind": kind,
@@ -289,6 +371,13 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         # ── Permanents ───────────────────────────────────────────
         perm = RE_PERMANENTS.search(line)
         if perm:
+            # GameStateEvaluator2.printBattlefield emits single evaluation
+            # snapshots per thread (not self/opp pairs).  These corrupt the
+            # _perm_buffer: a stray single line gets paired with the first
+            # printBattlefieldScore line that follows, making battlefield_opp
+            # receive self permanents.  Skip them entirely.
+            if 'GameStateEvaluator2' in line:
+                continue
             parsed = parse_permanents(perm.group(1))
             state._accumulate_permanents(parsed)
             continue
@@ -318,6 +407,26 @@ class _ThreadState:
         self.last_log_life_a: int | None = None
         self.last_log_life_b: int | None = None
         self._perm_buffer: list[list[dict]] = []
+        # ── Turn tracking for self/opp disambiguation ──────────
+        self.turn_player_is_a: bool | None = None  # set on die roll
+        self.last_turn: int = 0
+        # lands_played in the current turn (resets on turn change)
+        self.lands_played_this_turn: int = 0
+        # Counter for rows excluded because land-playability is underivable
+        self.excluded_no_land_menu: int = 0
+        # Counter for total decisions
+        self.total_decisions: int = 0
+
+    @property
+    def _is_player_a_turn(self) -> bool | None:
+        """Determine if the current turn belongs to PlayerA.
+        Uses die-roll result: winner takes turn 1.
+        """
+        if self.turn_player_is_a is None:
+            return None
+        return (
+            (self.last_turn % 2 == 1) == self.turn_player_is_a
+        )
 
     def start_new_game(self, game_seq: int):
         self.game_seq = game_seq
@@ -331,6 +440,11 @@ class _ThreadState:
         self.last_log_life_a = None
         self.last_log_life_b = None
         self._perm_buffer = []
+        self.turn_player_is_a = None
+        self.last_turn = 0
+        self.lands_played_this_turn = 0
+        self.excluded_no_land_menu = 0
+        self.total_decisions = 0
 
     def on_log_life(self, turn: int, phase_name: str, phase_code: str,
                     life_a: int, life_b: int):
@@ -350,8 +464,22 @@ class _ThreadState:
             self._perm_buffer = [permanents]
         elif len(self._perm_buffer) == 1:
             self._perm_buffer.append(permanents)
-            self.latest_perms_self = list(self._perm_buffer[0])
-            self.latest_perms_opp = list(self._perm_buffer[1])
+            # The first Permanents line is the HAND PLAYER's board.
+            # The hand is always the current turn player's.  Determine who
+            # that is by checking which deck's basic lands appear in the hand.
+            hand_player_is_a = _hand_player_is_a(self.latest_hand)
+            if hand_player_is_a is True:
+                # Hand is PlayerA (UWTempo) → first perm = PlayerA = self
+                self.latest_perms_self = list(self._perm_buffer[0])
+                self.latest_perms_opp = list(self._perm_buffer[1])
+            elif hand_player_is_a is False:
+                # Hand is PlayerB (opponent) → second perm = PlayerA = self
+                self.latest_perms_self = list(self._perm_buffer[1])
+                self.latest_perms_opp = list(self._perm_buffer[0])
+            else:
+                # Unknown — fall back to first perm = self
+                self.latest_perms_self = list(self._perm_buffer[0])
+                self.latest_perms_opp = list(self._perm_buffer[1])
             _backfill_battlefield(self)
         else:
             self._perm_buffer = [permanents]
@@ -382,7 +510,7 @@ def _backfill_hand(state: _ThreadState, cards: list[str]):
 
 def _backfill_battlefield(state: _ThreadState):
     for d in reversed(state.game_decisions):
-        if not d.get("battlefield_self") and not d.get("battlefield_opp"):
+        if d.get("battlefield_self") is None and d.get("battlefield_opp") is None:
             d["battlefield_self"] = list(state.latest_perms_self)
             d["battlefield_opp"] = list(state.latest_perms_opp)
             return
@@ -396,9 +524,9 @@ def _finalize_game(state: _ThreadState, all_decisions: list[dict]):
         d["outcome"] = outcome
         if not d.get("hand"):
             d["hand"] = list(state.latest_hand)
-        if not d.get("battlefield_self"):
+        if d.get("battlefield_self") is None:
             d["battlefield_self"] = list(state.latest_perms_self)
-        if not d.get("battlefield_opp"):
+        if d.get("battlefield_opp") is None:
             d["battlefield_opp"] = list(state.latest_perms_opp)
 
 
@@ -424,10 +552,10 @@ def _enrich_sessions(decisions: list[dict], sessions: list[SessionInfo]):
 
     for sess in sessions:
         for tid, n in sess.games_per_thread.items():
-            prev_end = 0
+            prev_end = 1
             if thread_cumulative[tid]:
                 prev_end = thread_cumulative[tid][-1][1]
-            thread_cumulative[tid].append((prev_end + 1, prev_end + 1 + n, sess.label))
+            thread_cumulative[tid].append((prev_end, prev_end + n, sess.label))
 
     # Assign each decision to its session
     for d in decisions:


### PR DESCRIPTION
## Problem

PR #433 fixed the `battlefield_self` side of a board-assignment bug (0/9,789 rows had opponent-exclusive basics).  But `battlefield_opp` was still getting the ACTING player's permanents — **769/9,789 rows (7.9%)** had UW-only nonbasic lands on a mono-colour opponent's board.

Example from the real smoke log:
```
session0_UWTempo_vs_Standard-MonoR
  self: ['Adarkar Wastes']                                          <- correct
  opp:  ['Adarkar Wastes','Island','Malcolm, Alluring Scoundrel',   <- all UWTempo cards
         'Adarkar Wastes','Combat Research','Sheltered by Ghosts']     duplicates = accumulation
```

## Root causes (three bugs)

### 1. GameStateEvaluator2 single-line corruption
The log has two callers of `-> Permanents:`:
- `ComputerPlayerMCTS.printBattlefieldScore` — emits **pairs** (self + opp)
- `GameStateEvaluator2.printBattlefield` — emits **single evaluation snapshots**

A stray single line lands in `_perm_buffer` and pairs with the first printBattlefieldScore line that follows, corrupting both self and opp.  **Fix:** skip GameStateEvaluator2 lines entirely.

### 2. Empty-list sentinel bug
Both `_backfill_battlefield` and `_finalize_game` checked `not d.get(...)` to detect unset board fields.  A genuinely empty opponent board (`[]`, e.g. turn 1 with no opponent permanents) is falsy, causing `_finalize_game` to overwrite correct `[]` with a later game's stale opp value.  **Fix:** use `None` as the 'not yet set' sentinel instead of `[]`.

### 3. Session boundary off-by-one
`_enrich_sessions` started `prev_end` at 0, producing cumulative boundaries (1,11), (12,22) etc. instead of (1,11), (11,21).  Game 11 on each thread fell unassigned (redirected to `sessions[0].label`), and game 21 was misassigned to session1 instead of session2.  **Fix:** `prev_end` starts at 1, making adjacent sessions truly contiguous.

## Results over the real 9,789-row parse

| Check | Before | After |
|-------|--------|-------|
| self has opp-exclusive basic | 0 | 0 (no regression) |
| opp has UW-only nonbasics | **769** | **0** |
| same card in both boards | ? | **0** |

All session reconciliation diffs are within threshold (all ✅, previously the overall diff was ⚠️ 6).

## Changes
- `tools/training/parse_magezero_log.py` — 3 bug fixes + strip `,attacking`/`,blocking` suffixes from parsed card names
- `tests/test_parse_magezero_deck_sanity.py` — new guardrail test that asserts all three conditions over the real smoke log
