### PR TITLE
WP-3: no-net baseline arm — power calculator + config + runbook

### DIFF
--- a/tests/test_baseline_plan.py
+++ b/tests/test_baseline_plan.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for baseline_plan.py — power maths against hand-computed values."""
+
+import sys
+import math
+
+import pytest
+
+sys.path.insert(0, "tools/training/wp3")
+from baseline_plan import mde, baseline_games_needed, Z_ALPHA_2, Z_BETA
+
+# ── known constants ────────────────────────────────────────────
+P_BL = 86 / 299  # 0.287625...
+
+
+def assert_approx(actual, expected, tol_pp=0.02, label=""):
+    """Assert |actual - expected| <= tol_pp (in percentage points)."""
+    ok = abs(actual - expected) <= tol_pp
+    status = "✓" if ok else "✗"
+    print(f"  {status} {label}: got {actual:.4f} pp, expected ~{expected:.2f} pp"
+          + ("" if ok else f"  *** FAIL (delta={abs(actual-expected):.4f})"))
+    if not ok:
+        raise AssertionError(f"{label}: {actual:.4f} != {expected:.2f} pp")
+
+
+def assert_int_approx(actual, expected, tol=50, label=""):
+    """Assert |actual - expected| <= tol integer."""
+    ok = abs(actual - expected) <= tol
+    status = "✓" if ok else "✗"
+    print(f"  {status} {label}: got {actual}, expected ~{expected}"
+          + ("" if ok else f"  *** FAIL (delta={abs(actual-expected)})"))
+    if not ok:
+        raise AssertionError(f"{label}: {actual} != {expected}")
+
+
+def test_mde_current():
+    """MDE at current sample sizes (n_baseline=299, n_net=1299)."""
+    print("\n1) Current MDE (299 baseline / 1299 net)")
+    val = mde(P_BL, 299, 1299)
+    assert_approx(val, 8.13, label="MDE(299, 1299)")
+
+
+def test_mde_net_only_growth():
+    """Growing the net arm alone (baseline frozen at 299)."""
+    print("\n2) Net-only growth (n_baseline=299)")
+    # n_net=5000 → ~7.55 pp
+    val = mde(P_BL, 299, 5000)
+    assert_approx(val, 7.55, label="MDE(299, 5000)")
+
+
+def test_mde_balanced():
+    """Symmetric sample sizes."""
+    print("\n3) Symmetric sample sizes")
+    val = mde(P_BL, 500, 500)
+    assert_approx(val, 8.02, label="MDE(500, 500)")
+
+    val = mde(P_BL, 1000, 1000)
+    assert_approx(val, 5.67, label="MDE(1000, 1000)")
+
+    val = mde(P_BL, 2000, 2000)
+    assert_approx(val, 4.01, label="MDE(2000, 2000)")
+
+
+def test_mde_baseline_growth():
+    """Growing baseline arm (net fixed at 1299)."""
+    print("\n4) Baseline growth (n_net=1299)")
+    val = mde(P_BL, 1000, 1299)
+    assert_approx(val, 5.34, label="MDE(1000, 1299)")
+
+    val = mde(P_BL, 2000, 1299)
+    assert_approx(val, 4.52, label="MDE(2000, 1299)")
+
+
+def test_z_values():
+    """Verify the z-quantile constants are correct."""
+    pytest.importorskip("scipy.stats")
+    from scipy.stats import norm
+    # z_{0.025} = 1.959964
+    expected_alpha = norm.ppf(1 - 0.05 / 2)
+    assert abs(Z_ALPHA_2 - expected_alpha) < 0.0001, \
+        f"Z_ALPHA_2 off: {Z_ALPHA_2} vs {expected_alpha}"
+    # z_{0.20} = 0.841621
+    expected_beta = norm.ppf(0.80)
+    assert abs(Z_BETA - expected_beta) < 0.0001, \
+        f"Z_BETA off: {Z_BETA} vs {expected_beta}"
+    print(f"\n5) Z-quantiles: Z_ALPHA_2={Z_ALPHA_2:.6f} Z_BETA={Z_BETA:.6f}")
+
+
+def test_inverse():
+    """Inverse: baseline games needed for target MDE."""
+    print("\n6) Inverse: n_baseline for target MDE")
+    # At 5 pp with n_net=1299, should be ~1275 games
+    n = baseline_games_needed(P_BL, 1299, 5.0)
+    assert_int_approx(n, 1275, tol=50, label="n_baseline for 5 pp (net=1299)")
+    # Verify that n actually achieves <= 5pp
+    assert mde(P_BL, n, 1299) <= 5.0, \
+        f"MDE({n}, 1299) = {mde(P_BL, n, 1299):.4f} > 5.0 pp"
+
+    # At 4 pp with n_net=1299, should be ~4444 games
+    n = baseline_games_needed(P_BL, 1299, 4.0)
+    assert_int_approx(n, 4444, tol=50, label="n_baseline for 4 pp (net=1299)")
+    assert mde(P_BL, n, 1299) <= 4.0, \
+        f"MDE({n}, 1299) = {mde(P_BL, n, 1299):.4f} > 4.0 pp"
+
+
+def test_formula_bounds():
+    """Sanity: MDE decreases as n increases; more unbalanced → larger MDE."""
+    print("\n7) Monotonicity / bounds sanity")
+    # More data → smaller MDE
+    assert mde(P_BL, 100, 100) > mde(P_BL, 1000, 1000)
+    # Asymmetric is less powerful than symmetric at same total N
+    total = 2000
+    asymmetric = mde(P_BL, 500, 1500)
+    symmetric = mde(P_BL, 1000, 1000)
+    assert asymmetric > symmetric, \
+        f"Asymmetric ({asymmetric:.4f}) should be > symmetric ({symmetric:.4f})"
+    print(f"  ✓ asymmetric (500+1500)={asymmetric:.4f} > symmetric (1000+1000)={symmetric:.4f}")
+
+
+if __name__ == "__main__":
+    print("baseline_plan.py — hand-validated tests")
+    print("=" * 56)
+
+    test_mde_current()
+    test_mde_net_only_growth()
+    test_mde_balanced()
+    test_mde_baseline_growth()
+    test_z_values()
+    test_inverse()
+    test_formula_bounds()
+
+    print("\n" + "=" * 56)
+    print("All tests passed.")

--- a/tools/training/wp3/PROGRESS-wp3-baseline-arm.md
+++ b/tools/training/wp3/PROGRESS-wp3-baseline-arm.md
@@ -1,0 +1,50 @@
+# PROGRESS-wp3-baseline-arm.md
+
+## Deliverables
+
+### 1. Power Calculator — `tools/training/wp3/baseline_plan.py`
+
+A self-contained power analysis using the two-proportion z-test (pooled SE):
+
+```
+MDE = (z_{α/2} + z_β) · √(p_baseline·(1-p_baseline) · (1/n_baseline + 1/n_net))
+```
+
+Key numbers from current observations (baseline=86/299=28.76%, net=398/1299=30.64%):
+
+| Scenario | n_baseline | n_net | MDE |
+|---|---|---|---|
+| Current | 299 | 1,299 | **8.13 pp** |
+| Net-only growth | 299 | 5,000 | 7.55 pp |
+| Baseline growth | 1,000 | 1,299 | **5.34 pp** |
+| Symmetric | 1,000 | 1,000 | 5.67 pp |
+| Symmetric | 2,000 | 2,000 | 4.01 pp |
+
+Inverse: for a target MDE of 5 pp (net fixed at 1299), need ~1,275 baseline games.
+
+### 2. Config — `tools/training/wp3/run_baseline.yml`
+
+Creates an offline / no-net baseline arm:
+
+- **`start_from_version: null`** — no seed checkpoint (runner.py lines 173-174)
+- **`version: 2`** — distinct from ver1 which has a 3.9 GB checkpoint. `has_checkpoint("UWTempo", 2)` returns False → `bootstrap=True` → `primary_offline=True`, so no servers are started (runner.py lines 430, 441-442, 457-458)
+- 5 minimax opponents — no checkpoints needed
+- Single generation, 1000 games_per_gen → ~1000 baseline games
+
+### 3. Tests — `tests/test_baseline_plan.py`
+
+7 tests: MDE at current sizes, net-only growth, symmetric, baseline growth, z-quantiles (scipy-dependent, skipped on this host), inverse search, monotonicity. 6 pass, 1 skipped on macOS.
+
+### Runbook (do NOT execute)
+
+```bash
+# On blackwell (or wherever magezero is installed):
+cd /home/joshu/repos/magezero
+cp /path/to/mtgacoach/tools/training/wp3/run_baseline.yml configs/
+python3 -m magezero.runner --run configs/run_baseline.yml
+```
+
+**⚠ Do NOT use `version: 1`** or the existing ver1 model will be overwritten.
+Use `version: 2` as configured. The config lives inside the mtgaCoach repo at
+`tools/training/wp3/run_baseline.yml` and must be copied/linked into magezero's
+`configs/` before running.

--- a/tools/training/wp3/baseline_plan.py
+++ b/tools/training/wp3/baseline_plan.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+baseline_plan.py — Power calculator for the MageZero no-net baseline arm.
+
+Given (baseline_p, n_baseline, n_net, alpha, power) prints the minimum
+detectable effect (MDE) in percentage points.  Inverts to find the number
+of baseline games needed for a target MDE of 3, 4, and 5 pp.
+
+Uses the standard two-proportion z-test (pooled SE) formula:
+
+    MDE = (z_{α/2} + z_β) · √( p̄·(1-p̄) · (1/n₁ + 1/n₂) )
+
+    where p̄ = (p₁·n₁ + p₂·n₂) / (n₁ + n₂) under the null, approximated
+    by freezing p̄ at the baseline proportion (conservative for p ≈ 0.3).
+
+Usage:
+    python3 tools/training/wp3/baseline_plan.py
+
+References
+----------
+- Fleiss, J. L., Levin, B., & Paik, M. C. (2003). Statistical Methods for
+  Rates and Proportions (3rd ed.). Wiley. §4.2.
+- https://en.wikipedia.org/wiki/Power_(statistics)#Two-proportion_z-test
+"""
+
+import math
+
+# ── standard normal quantiles ─────────────────────────────────
+Z_ALPHA_2 = 1.959964   # α = 0.05, two-sided
+Z_BETA = 0.841621       # β = 0.20 (power = 0.80)
+
+
+def mde(p_baseline: float, n_baseline: int, n_net: int) -> float:
+    """Minimum detectable effect (percentage points) for a given baseline.
+
+    Uses the **pooled** standard error evaluated at the baseline proportion
+    (conservative — the true pooled proportion shifts toward the net arm's
+    win rate, but freezing at p_baseline slightly overestimates SE when
+    p_baseline ≈ 0.3, making this a conservative estimate of MDE).
+
+    Parameters
+    ----------
+    p_baseline : float
+        Observed win rate of the no-net arm (e.g. 0.2876).
+    n_baseline : int
+        Number of games in the baseline arm.
+    n_net : int
+        Number of games in the net-guided arm.
+
+    Returns
+    -------
+    float
+        Minimum detectable effect in percentage points.
+    """
+    p = p_baseline
+    se = math.sqrt(p * (1 - p) * (1 / n_baseline + 1 / n_net))
+    return (Z_ALPHA_2 + Z_BETA) * se * 100  # convert to pp
+
+
+def baseline_games_needed(p_baseline: float, n_net: int,
+                          target_mde_pp: float,
+                          min_games: int = 10,
+                          max_games: int = 50_000) -> int:
+    """Binary-search for the smallest n_baseline meeting target MDE.
+
+    Parameters
+    ----------
+    p_baseline : float
+        Observed win rate of the no-net arm.
+    n_net : int
+        Number of net-guided games (fixed, does not grow).
+    target_mde_pp : float
+        Desired minimum detectable effect in percentage points.
+    min_games, max_games : int
+        Search bounds.
+
+    Returns
+    -------
+    int
+        Minimum n_baseline achieving the target MDE.
+    """
+    lo, hi = min_games, max_games
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if mde(p_baseline, mid, n_net) <= target_mde_pp:
+            hi = mid
+        else:
+            lo = mid + 1
+    # Ensure the found value actually meets the target
+    if mde(p_baseline, lo, n_net) > target_mde_pp:
+        return -1  # impossible within bounds
+    return lo
+
+
+def fmt_pp(val: float) -> str:
+    """Format a proportion-difference as a readable pp string."""
+    return f"{val:.2f} pp"
+
+
+def current_state() -> dict:
+    """Return current observed statistics."""
+    return {
+        "baseline_wins": 86,
+        "baseline_games": 299,
+        "net_wins": 398,
+        "net_games": 1299,
+    }
+
+
+def main():
+    cur = current_state()
+    p_bl = cur["baseline_wins"] / cur["baseline_games"]
+    p_net = cur["net_wins"] / cur["net_games"]
+    n_bl = cur["baseline_games"]
+    n_net = cur["net_games"]
+
+    print("=" * 72)
+    print("  MageZero Baseline Arm — Power Analysis")
+    print("=" * 72)
+    print()
+    print(f"  Current observations")
+    print(f"    No-net (baseline): {cur['baseline_wins']}/{cur['baseline_games']}"
+          f"  = {p_bl:.4f}  ({p_bl*100:.2f}%)")
+    print(f"    Net-guided:        {cur['net_wins']}/{cur['net_games']}"
+          f"  = {p_net:.4f}  ({p_net*100:.2f}%)")
+    print(f"    Observed gap:      {(p_net - p_bl) * 100:.2f} pp")
+    print()
+
+    # ── Worked example: current sample sizes ──────────────────
+    print(f"  ── Current resolution (n_baseline={n_bl}, n_net={n_net})")
+    current_mde = mde(p_bl, n_bl, n_net)
+    print(f"     MDE = {fmt_pp(current_mde)}")
+    print()
+
+    # ── What growing the NET arm alone does ──────────────────
+    print("  ── Growing the net arm alone (baseline frozen at 299)")
+    for nn in [299, 1299, 5000, 10000]:
+        m = mde(p_bl, 299, nn)
+        print(f"     n_net={nn:>5} → MDE = {fmt_pp(m)}")
+    print()
+
+    # ── What growing the BASELINE arm does ───────────────────
+    print("  ── Growing the baseline arm (net at current 1299)")
+    for nb in [500, 1000, 1500, 2000]:
+        m = mde(p_bl, nb, 1299)
+        print(f"     n_baseline={nb:>4} → MDE = {fmt_pp(m)}")
+    print()
+
+    # ── Balanced approach ─────────────────────────────────────
+    print("  ── Symmetric growth (n_baseline = n_net)")
+    for n in [299, 1000, 2000, 5000]:
+        m = mde(p_bl, n, n)
+        print(f"     n={n:>4} each → MDE = {fmt_pp(m)}")
+    print()
+
+    # ── Inverse: games needed for target MDE ─────────────────
+    print("  ── Baseline games needed for target MDE")
+    print(f"     (net arm fixed at {n_net} games, p_baseline = {p_bl:.4f})")
+    for target in [3, 4, 5]:
+        needed = baseline_games_needed(p_bl, n_net, target)
+        if needed > 0:
+            print(f"     Target {target} pp  →  n_baseline ≥ {needed:,}  "
+                  f"(+{needed - n_bl:,} from current {n_bl})")
+        else:
+            print(f"     Target {target} pp  →  impossible within 50,000 games")
+    print()
+
+    # ── Single-gen cost estimate ──────────────────────────────
+    print("  ── Cost: single-generation config")
+    print("     games_per_gen: 1000  →  ~1,000 baseline games"
+          "  (MDE ≈ {:.2f} pp, net arm at current 1299)".format(
+              mde(p_bl, 1000, n_net)))
+    print("     games_per_gen: 1000  →  ~1,000 baseline games"
+          "  (MDE ≈ {:.2f} pp, symmetric n_net=1000)".format(
+              mde(p_bl, 1000, 1000)))
+    print()
+
+    # ── Key takeaway ──────────────────────────────────────────
+    print("  Key takeaway:")
+    print(f"    Current resolution (n_baseline={n_bl}) = {fmt_pp(current_mde)}")
+    print(f"    ~1,000 baseline games  →  MDE ≈ {fmt_pp(mde(p_bl, 1000, n_net))}")
+    print(f"    ~2,000 baseline games  →  MDE ≈ {fmt_pp(mde(p_bl, 2000, n_net))}")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/training/wp3/run_baseline.yml
+++ b/tools/training/wp3/run_baseline.yml
@@ -1,0 +1,50 @@
+# run_baseline.yml — Offline / no-net baseline arm
+#
+# Produces a no-net baseline by using a fresh version (ver2) with
+# start_from_version: null so no checkpoint is seeded.  The runner
+# detects has_checkpoint(deck="UWTempo", version=2) == False, which
+# drives bootstrap=True → primary_offline=True → servers are skipped
+# and the MCTS agent uses a heuristic value function with uniform
+# priors (the "offline" / bootstrap mode).
+#
+# ═══════════════════════════════════════════════════════════════
+#  CRITICAL: DO NOT use version: 1 here.
+#  A checkpoint already exists at models/UWTempo/ver1/model.pt.gz
+#  (3.9 GB).  Using version: 1 would cause has_checkpoint() to
+#  return True, bootstrap=False, and the run would NOT go offline —
+#  it would start servers and use the neural net, overwriting the
+#  trained model.
+#
+#  By using version: 2, has_checkpoint("UWTempo", 2) returns False,
+#  so bootstrap=True, primary_offline=True, no servers are launched,
+#  and the existing ver1 model is untouched.
+# ═══════════════════════════════════════════════════════════════
+
+deck: UWTempo
+version: 2                     # ⚠ DISTINCT from ver1 (which has trained checkpoint)
+start_from_version: null        # null = no seed checkpoint → offline bootstrap
+
+generations: 1
+games_per_gen: 1000            # yields ~1,000 baseline games
+replay_buffer_gens: 1          # single-gen run, no windowing needed
+
+opponents:
+  - deck: Standard-MonoR
+    mode: minimax              # minimax = no checkpoint needed, no server started
+  - deck: Standard-MonoG
+    mode: minimax
+  - deck: Standard-MonoB
+    mode: minimax
+  - deck: Standard-MonoW
+    mode: minimax
+  - deck: Standard-MonoU
+    mode: minimax
+
+training:
+  analyze_dataset: false       # skip analysis — baseline data has no target labels
+  generate_plots: false
+  eval_previous_model: false   # no previous model to evaluate
+
+log_level: ERROR
+
+curriculum: configs/curriculum.yml


### PR DESCRIPTION
## What

Deliverables for the WP-3 baseline arm:

1. **Power calculator** (`tools/training/wp3/baseline_plan.py`) — two-proportion z-test MDE calculator with inverse search. Current worked example: baseline 86/299 (28.76%), net 398/1299 (30.64%), MDE = 8.13 pp. ~1,000 baseline games pulls MDE to 5.34 pp.

2. **Config** (`tools/training/wp3/run_baseline.yml`) — produces an offline/no-net baseline arm:
   - `start_from_version: null` → no checkpoint seeded (runner.py:173-174)
   - **version: 2** — critical: ver1 already has a 3.9 GB model.pt.gz at `models/UWTempo/ver1/model.pt.gz`. Using version:1 would cause `has_checkpoint()` to return True (runner.py:167-168), making `bootstrap=False`, `primary_offline=False`, and the run would NOT be offline. With version:2, `has_checkpoint()` returns False, so `bootstrap=True → primary_offline=True` and no servers are started (runner.py:430, 442, 457-458).
   - 5 minimax opponents, single generation, 1000 games_per_gen

3. **Tests** (`tests/test_baseline_plan.py`) — 7 hand-validated tests against hand-computed values

4. **Runbook + Progress** (`tools/training/wp3/PROGRESS-wp3-baseline-arm.md`)

## How tested

```
$ python3 -m pytest tests/test_baseline_plan.py -q
......s                                                          [100%]
6 passed, 1 skipped in 0.01s
```

Manually verified against hand-computed MDE:
- MDE(299, 1299) = 8.13 pp ✓
- MDE(299, 5000) = 7.55 pp ✓ (matches task's ~7.6 pp at n_net=5000)
- MDE(1000, 1299) = 5.34 pp ✓
- MDE(2000, 2000) = 4.01 pp ✓

## Known gaps

- The power calculator is a `tools/training/wp3/` tool — the owner copies `run_baseline.yml` to magezero's `configs/` before running. This is by design: the config lives with the PR's tooling.
- `analyze_dataset`, `generate_plots`, and `eval_previous_model` are all `false` because a no-net run produces no target/policy labels for analysis, and there is no previous model to evaluate on the first generation. If the owner wants them, re-enable.
- **I did NOT launch any run.** The config and runbook are ready for the owner to execute.
