### PR TITLE
WP-3: class-histogram guard + downsample rebalance for build_magezero_combat

### DIFF
--- a/tests/test_combat_balance.py
+++ b/tests/test_combat_balance.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Tests for class-histogram guard and downsample rebalance in build_magezero_combat.
+
+Run:
+    python3 -m pytest tests/test_combat_balance.py -v
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SRC = REPO / "src"
+for _p in (str(SRC), str(REPO)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.training.build_magezero_combat import (
+    _class_histogram,
+    _check_class_share,
+    _downsample,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def skewed_block_records() -> list[dict]:
+    """78 block records: 56 no_block (71.8 %), 17 partial_block, 5 block_all."""
+    recs: list[dict] = []
+    for i in range(78):
+        if i < 56:
+            cls = "no_block"
+        elif i < 73:
+            cls = "partial_block"
+        else:
+            cls = "block_all"
+        recs.append({
+            "id": f"mzc-skewed-{i:04d}",
+            "kind": "combat_block",
+            "meta": {"block_class": cls},
+            "user": "",
+            "response": "{}",
+        })
+    return recs
+
+
+@pytest.fixture
+def balanced_block_records() -> list[dict]:
+    """78 block records perfectly split: 26 each."""
+    recs: list[dict] = []
+    for i in range(78):
+        if i < 26:
+            cls = "no_block"
+        elif i < 52:
+            cls = "partial_block"
+        else:
+            cls = "block_all"
+        recs.append({
+            "id": f"mzc-balanced-{i:04d}",
+            "kind": "combat_block",
+            "meta": {"block_class": cls},
+            "user": "",
+            "response": "{}",
+        })
+    return recs
+
+
+@pytest.fixture
+def mixed_records(skewed_block_records) -> list[dict]:
+    """Add 104 attack records (98 proper_subset + 6 all_in) to the block fixture."""
+    recs = list(skewed_block_records)
+    for i in range(104):
+        cls = "proper_subset" if i < 98 else "all_in"
+        recs.append({
+            "id": f"mzc-mix-atk-{i:04d}",
+            "kind": "combat_attack",
+            "meta": {"attack_class": cls},
+            "user": "",
+            "response": "{}",
+        })
+    return recs
+
+
+# ── Guard fires on skewed fixture ──────────────────────────────────────────
+
+
+def test_guard_fires_on_skewed_block(skewed_block_records) -> None:
+    """_check_class_share raises SystemExit for block class > 0.50."""
+    hist = _class_histogram(
+        skewed_block_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+    with pytest.raises(SystemExit) as exc:
+        _check_class_share(hist, 0.50, "block")
+    msg = str(exc.value)
+    assert "no_block" in msg
+    assert "71.8%" in msg or "71.79%" in msg or "71.8" in msg
+
+
+def test_guard_fires_on_skewed_attack(mixed_records) -> None:
+    """_check_class_share raises SystemExit for attack class > 0.50."""
+    hist = _class_histogram(
+        mixed_records, "attack_class",
+        lambda r: r.get("kind") == "combat_attack",
+    )
+    with pytest.raises(SystemExit) as exc:
+        _check_class_share(hist, 0.50, "attack")
+    msg = str(exc.value)
+    assert "proper_subset" in msg
+    assert "FAIL-CLOSED" in msg
+
+
+def test_guard_passes_on_balanced(balanced_block_records) -> None:
+    """_check_class_share does NOT raise for balanced distributions."""
+    hist = _class_histogram(
+        balanced_block_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+    # Each class is 33.3% — well under 0.50, so no SystemExit
+    _check_class_share(hist, 0.50, "block")
+    # If we get here without exception, the test passes
+
+
+# ── Histogram correctness ──────────────────────────────────────────────────
+
+
+def test_histogram_shares_sum_to_one(skewed_block_records) -> None:
+    """Shares in the histogram should sum to 1.0 (within rounding)."""
+    hist = _class_histogram(
+        skewed_block_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+    total_share = sum(share for _, _, share in hist)
+    assert abs(total_share - 1.0) < 0.01, f"shares sum to {total_share}"
+
+
+def test_histogram_sorted_descending(skewed_block_records) -> None:
+    """Histogram items sorted by share descending."""
+    hist = _class_histogram(
+        skewed_block_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+    shares = [s for _, _, s in hist]
+    assert shares == sorted(shares, reverse=True), (
+        f"histogram not sorted descending: {shares}"
+    )
+
+
+# ── Downsample determinism and correctness ─────────────────────────────────
+
+
+def test_downsample_deterministic(mixed_records) -> None:
+    """Two downsample runs with the same seed produce the same kept record ids."""
+    hist_a = _class_histogram(
+        mixed_records, "attack_class",
+        lambda r: r.get("kind") == "combat_attack",
+    )
+    hist_b = _class_histogram(
+        mixed_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+
+    r1 = _downsample(copy.deepcopy(mixed_records), hist_a, hist_b, 0.50)
+    r2 = _downsample(copy.deepcopy(mixed_records), hist_a, hist_b, 0.50)
+
+    ids1 = sorted(r["id"] for r in r1)
+    ids2 = sorted(r["id"] for r in r2)
+    assert ids1 == ids2, "downsample is not deterministic"
+
+
+def test_downsample_reduces_majority(mixed_records) -> None:
+    """After downsampling, no class exceeds 0.50 share."""
+    hist_a = _class_histogram(
+        mixed_records, "attack_class",
+        lambda r: r.get("kind") == "combat_attack",
+    )
+    hist_b = _class_histogram(
+        mixed_records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+
+    balanced = _downsample(
+        copy.deepcopy(mixed_records), hist_a, hist_b, 0.50
+    )
+
+    for kind_field, meta_field in [
+        ("combat_attack", "attack_class"),
+        ("combat_block", "block_class"),
+    ]:
+        subset = [r for r in balanced if r.get("kind") == kind_field]
+        assert len(subset) > 0, f"no {kind_field} records after downsample"
+        total = len(subset)
+        counts = Counter(r["meta"][meta_field] for r in subset)
+        for cls, n in counts.items():
+            share = n / total
+            assert share <= 0.50 + 0.01, (
+                f"{cls} in {kind_field} is {share:.1%} after downsample"
+            )
+
+
+def test_downsample_clamps_below_one() -> None:
+    """Downsample with a tiny minority class still works (no crash)."""
+    recs: list[dict] = []
+    for i in range(10):
+        cls = "no_block" if i < 9 else "partial_block"
+        recs.append({
+            "id": f"mzc-clamp-{i:04d}",
+            "kind": "combat_block",
+            "meta": {"block_class": cls},
+            "user": "",
+            "response": "{}",
+        })
+    hist = _class_histogram(
+        recs, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+    result = _downsample(recs, [], hist, 0.50)
+    # partial_block has 1 record — must still be present
+    partial_ids = [
+        r["id"] for r in result
+        if r["meta"].get("block_class") == "partial_block"
+    ]
+    assert len(partial_ids) == 1, "minority class was lost"
+    no_block_ids = [
+        r["id"] for r in result
+        if r["meta"].get("block_class") == "no_block"
+    ]
+    # no_block should be downsampled from 9 toward 1 (can't go below 1)
+    assert len(no_block_ids) >= 1
+    assert len(no_block_ids) < 9, "majority class was not reduced"
+
+
+# ── Empty / edge cases ─────────────────────────────────────────────────────
+
+
+def test_empty_histogram_does_not_raise() -> None:
+    """_check_class_share on an empty histogram is a no-op."""
+    _check_class_share([], 0.50, "attack")  # should not raise
+
+
+def test_empty_records_downsample() -> None:
+    """Downsample on an empty list returns an empty list."""
+    result = _downsample([], [], [], 0.50)
+    assert result == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_magezero_combat.py
+++ b/tests/test_magezero_combat.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Fail-closed leak scan + acceptance for MageZero combat records.
+
+Every attacker/blocker record emitted by build_magezero_combat.py must pass:
+
+  A1 — prompt contains no "Computed optimal" solver line
+  A2 — prompt contains no MCTS visit count values > 20
+  A3 — prompt contains no "score:" or "count:" keywords
+  A4 — response is valid declare_attackers or declare_blockers JSON
+  A5 — response names exist in the prompt's menu
+
+Run with:
+    python3 -m pytest tests/test_magezero_combat.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+INPUT_JSONL = Path("/tmp/combat_in.jsonl")
+OUTPUT_JSONL = Path("/tmp/combat_out.jsonl")
+
+LEAK_WORDS = frozenset({"score:", "count:"})
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+def _read_jsonl(path: Path) -> list[dict]:
+    out: list[dict] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def _numbers_in_prompt(prompt: str) -> set[int]:
+    """Return every integer token appearing in the prompt text."""
+    return {int(m) for m in re.findall(r"\b\d+\b", prompt)}
+
+
+def _extract_menu_names(prompt: str, prefix: str) -> list[str]:
+    """Extract creature names from a 'Legal:' menu in the prompt."""
+    lines = prompt.split("\n")
+    names: list[str] = []
+    for line in lines:
+        line = line.strip()
+        # Match "  N. Attack with: Name" or "  N. Block with: Name"
+        m = re.match(r"\d+\.\s*" + re.escape(prefix) + r"\s+(.+)", line)
+        if m:
+            names.append(m.group(1).strip())
+    return names
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def input_rows() -> list[dict]:
+    assert INPUT_JSONL.exists(), f"input not found: {INPUT_JSONL}"
+    return _read_jsonl(INPUT_JSONL)
+
+
+@pytest.fixture(scope="session")
+def output_records() -> list[dict]:
+    assert OUTPUT_JSONL.exists(), (
+        f"output not found: {OUTPUT_JSONL} — "
+        f"run build_magezero_combat.py first"
+    )
+    return _read_jsonl(OUTPUT_JSONL)
+
+
+@pytest.fixture(scope="session")
+def mcts_by_game_id(input_rows) -> dict[str, dict]:
+    """Map game_id -> mcts_counts dict from the input."""
+    out: dict[str, dict] = {}
+    for r in input_rows:
+        if r.get("decision_kind") in ("attackers", "blockers"):
+            gid = r.get("game_id", "")
+            if gid:
+                out[gid] = r.get("mcts_counts", {})
+    return out
+
+
+# ── Counts ─────────────────────────────────────────────────────────────────
+
+def test_all_combat_rows_consumed(output_records: list[dict], input_rows: list[dict]) -> None:
+    """All attackers/blockers rows produce a record or are explicitly dropped."""
+    n_att_blocks = sum(
+        1 for r in input_rows if r.get("decision_kind") in ("attackers", "blockers")
+    )
+    n_skip = sum(
+        1 for r in input_rows if r.get("decision_kind") not in ("attackers", "blockers")
+    )
+    report(output_records, n_att_blocks, n_skip)
+
+
+def test_counts_match_expectation(output_records: list[dict], input_rows: list[dict]) -> None:
+    """Specific count expectations from the smoke log."""
+    attack_recs = [r for r in output_records if r.get("kind") == "combat_attack"]
+    block_recs = [r for r in output_records if r.get("kind") == "combat_block"]
+    n_attackers_in = sum(1 for r in input_rows if r.get("decision_kind") == "attackers")
+    n_blockers_in = sum(1 for r in input_rows if r.get("decision_kind") == "blockers")
+
+    assert n_attackers_in == 379, f"expected 379 attackers, got {n_attackers_in}"
+    assert n_blockers_in == 199, f"expected 199 blockers, got {n_blockers_in}"
+    # We should have SOME attack records (those with ,attacking markers)
+    assert len(attack_recs) > 0, "no attack records produced"
+    assert len(block_recs) > 0, "no block records produced"
+    # At most the input count per kind
+    assert len(attack_recs) <= n_attackers_in
+    assert len(block_recs) <= n_blockers_in
+
+
+# ── A1: No solver line leak ───────────────────────────────────────────────
+
+def test_no_solver_line(output_records: list[dict]) -> None:
+    """A1: No 'Computed optimal' may appear in the prompt (solver is OFF)."""
+    failures: list[str] = []
+    for r in output_records:
+        if "Computed optimal" in r.get("user", ""):
+            failures.append(
+                f"{r.get('id', '?')}: solver line found in prompt"
+            )
+    assert not failures, "\n".join(failures)
+
+
+# ── A2: No MCTS count leak ────────────────────────────────────────────────
+
+def test_no_mcts_count_leak(
+    output_records: list[dict],
+    mcts_by_game_id: dict[str, dict],
+) -> None:
+    """A2: No MCTS count value > 20 may appear bare in the prompt."""
+    failures: list[str] = []
+    for r in output_records:
+        gid = r.get("meta", {}).get("game_id", "")
+        mcts = mcts_by_game_id.get(gid, {})
+        leaky = {v for v in mcts.values() if v > 20}
+        if not leaky:
+            continue
+        prompt_numbers = _numbers_in_prompt(r.get("user", ""))
+        found = leaky & prompt_numbers
+        if found:
+            failures.append(
+                f"{r.get('id', '?')}: MCTS values {sorted(found)} appear in prompt"
+            )
+    assert not failures, "\n".join(failures)
+
+
+# ── A3: No score/count keywords ───────────────────────────────────────────
+
+def test_no_score_count_words(output_records: list[dict]) -> None:
+    """A3: 'score:' or 'count:' must not appear (case-insensitive) in prompt."""
+    failures: list[str] = []
+    for r in output_records:
+        prompt_lower = r.get("user", "").lower()
+        for word in LEAK_WORDS:
+            if word in prompt_lower:
+                failures.append(
+                    f"{r.get('id', '?')}: forbidden word '{word}' in prompt"
+                )
+    assert not failures, "\n".join(failures)
+
+
+# ── A4: Response JSON validity ────────────────────────────────────────────
+
+def test_response_is_valid_combat_json(output_records: list[dict]) -> None:
+    """A4: Response must be valid declare_attackers or declare_blockers JSON."""
+    failures: list[str] = []
+    for r in output_records:
+        kind = r.get("kind", "")
+        try:
+            resp = json.loads(r["response"])
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            failures.append(f"{r.get('id', '?')}: invalid response JSON: {e}")
+            continue
+        actions = resp.get("actions", [])
+        if not actions:
+            failures.append(f"{r.get('id', '?')}: response has no actions")
+            continue
+        action = actions[0]
+        if kind == "combat_attack":
+            if action.get("action_type") != "declare_attackers":
+                failures.append(
+                    f"{r.get('id', '?')}: expected declare_attackers, "
+                    f"got {action.get('action_type')}"
+                )
+            names = action.get("attacker_names")
+            if not isinstance(names, list):
+                failures.append(
+                    f"{r.get('id', '?')}: attacker_names is not a list: {names}"
+                )
+            for n in names:
+                if not isinstance(n, str):
+                    failures.append(
+                        f"{r.get('id', '?')}: attacker_name not a string: {n}"
+                    )
+        elif kind == "combat_block":
+            if action.get("action_type") != "declare_blockers":
+                failures.append(
+                    f"{r.get('id', '?')}: expected declare_blockers, "
+                    f"got {action.get('action_type')}"
+                )
+            assigns = action.get("blocker_assignments", {})
+            if not isinstance(assigns, dict):
+                failures.append(
+                    f"{r.get('id', '?')}: blocker_assignments is not a dict: {assigns}"
+                )
+            for b_name, a_name in assigns.items():
+                if not isinstance(b_name, str) or not isinstance(a_name, str):
+                    failures.append(
+                        f"{r.get('id', '?')}: non-string in assignments: "
+                        f"{b_name!r} -> {a_name!r}"
+                    )
+        else:
+            failures.append(f"{r.get('id', '?')}: unknown kind: {kind}")
+    assert not failures, "\n".join(failures)
+
+
+# ── A5: Response names exist in the prompt's menu ─────────────────────────
+
+def test_response_names_in_prompt_menu(output_records: list[dict]) -> None:
+    """A5: Every name in the response must appear in the prompt's menu."""
+    failures: list[str] = []
+    for r in output_records:
+        kind = r.get("kind", "")
+        user = r.get("user", "")
+        rid = r.get("id", "?")
+
+        if kind == "combat_attack":
+            menu_names = _extract_menu_names(user, "Attack with:")
+            if not menu_names:
+                failures.append(f"{rid}: no attack menu found in prompt")
+                continue
+            try:
+                resp = json.loads(r["response"])
+                declared = resp["actions"][0]["attacker_names"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                failures.append(f"{rid}: unparseable response")
+                continue
+            for n in declared:
+                if n not in menu_names:
+                    failures.append(
+                        f"{rid}: declared attacker '{n}' not in menu: {menu_names}"
+                    )
+
+        elif kind == "combat_block":
+            menu_names = _extract_menu_names(user, "Block with:")
+            try:
+                resp = json.loads(r["response"])
+                assigns = resp["actions"][0]["blocker_assignments"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                failures.append(f"{rid}: unparseable response")
+                continue
+            for b_name in assigns:
+                if b_name not in menu_names:
+                    failures.append(
+                        f"{rid}: declared blocker '{b_name}' not in menu: {menu_names}"
+                    )
+    assert not failures, "\n".join(failures)
+
+
+# ── Verification record dump (for PR body) ────────────────────────────────
+
+def test_verbatim_records(output_records: list[dict]) -> None:
+    """Capture one attackers + one blockers record verbatim for the PR."""
+    attack_recs = [r for r in output_records if r.get("kind") == "combat_attack"]
+    block_recs = [r for r in output_records if r.get("kind") == "combat_block"]
+
+    assert attack_recs, "no attack records to show"
+    assert block_recs, "no block records to show"
+
+    print("\n\n=== VERBATIM ATTACK RECORD ===")
+    _print_compact(attack_recs[0])
+    print("\n\n=== VERBATIM BLOCK RECORD ===")
+    _print_compact(block_recs[0])
+    print()
+
+
+def test_summary_stats(output_records: list[dict]) -> None:
+    """Print summary stats for the PR body."""
+    attack_recs = [r for r in output_records if r.get("kind") == "combat_attack"]
+    block_recs = [r for r in output_records if r.get("kind") == "combat_block"]
+
+    from collections import Counter
+    attack_classes = Counter(r["meta"].get("attack_class", "?") for r in attack_recs)
+    block_classes = Counter(r["meta"].get("block_class", "?") for r in block_recs)
+
+    print(f"\n\n=== SUMMARY ===")
+    print(f"  Total records: {len(output_records)}")
+    print(f"  Attack records: {len(attack_recs)}")
+    print(f"  Block records: {len(block_recs)}")
+    print(f"  Attack classes: {dict(attack_classes)}")
+    print(f"  Block classes: {dict(block_classes)}")
+    print(f"  Solver line leaks: 0 (verified by test_no_solver_line)")
+    print(f"  MCTS count leaks: 0 (verified by test_no_mcts_count_leak)")
+    print()
+
+
+def _print_compact(rec: dict) -> None:
+    """Print a record in a compact, readable format."""
+    print(f"  id: {rec['id']}")
+    print(f"  kind: {rec['kind']}")
+    print(f"  response: {rec['response']}")
+    print(f"  meta: {json.dumps(rec['meta'], ensure_ascii=False)}")
+    print()
+    user = rec.get("user", "")
+    print(f"  user prompt ({len(user)} chars):")
+    for line in user.split("\n"):
+        print(f"    {line}")
+
+
+# ── Report helper (called by test_all_combat_rows_consumed) ────────────────
+
+def report(records: list[dict], n_combat: int, n_skip: int) -> None:
+    attack_recs = [r for r in records if r.get("kind") == "combat_attack"]
+    block_recs = [r for r in records if r.get("kind") == "combat_block"]
+    print(f"\n  Input combat rows: {n_combat} (379 attackers + 199 blockers)")
+    print(f"  Skipped non-combat: {n_skip} (8887 priority + 324 binary)")
+    print(f"  Output attack recs: {len(attack_recs)}")
+    print(f"  Output block recs: {len(block_recs)}")

--- a/tools/training/build_magezero_combat.py
+++ b/tools/training/build_magezero_combat.py
@@ -13,10 +13,33 @@ are skipped and counted.
 Solver lines: OFF (the equivalent of --solver-line off).  Every record carries
 NO_SOLVER_ADDENDUM and no mcts_counts leak into the prompt.
 
+Class-histogram guard
+---------------------
+The report now prints per-class shares *with percentages* so a build skew
+-- the original 71.8 % no_block that went undetected — is visible at a
+glance.  If any single class exceeds ``--max-class-share`` (default 0.50)
+the build ABORTS with the histogram, unless ``--allow-skewed`` is passed.
+Modeled on the solver-line fail-closed guard in build_combat_decisions.py.
+
+Rebalance mode
+--------------
+``--balance downsample`` deterministically (seed=7) downsamples the
+majority class toward the threshold, reporting what was dropped.
+No upsampling or duplication.
+
 Usage
 -----
-    python3 tools/training/build_magezero_combat.py \\
+    python3 tools/training/build_magezero_combat.py \
         --in <decisions.jsonl> --out <combat_records.jsonl> [--report]
+
+    # guard will abort on the real corpus; pass --allow-skewed to force:
+    python3 tools/training/build_magezero_combat.py \
+        --in <decisions.jsonl> --out <combat_records.jsonl> --report --allow-skewed
+
+    # downsample the majority class toward 0.50:
+    python3 tools/training/build_magezero_combat.py \
+        --in <decisions.jsonl> --out <combat_records.jsonl> --report \
+        --balance downsample --allow-skewed
 """
 
 from __future__ import annotations
@@ -538,6 +561,126 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
 
 # ── IO and CLI ─────────────────────────────────────────────────────────────
 
+from typing import Callable
+
+
+def _class_histogram(
+    records: list[dict], field: str, predicate: Callable[[dict], bool]
+) -> list[tuple[str, int, float]]:
+    """Return sorted [(class, count, share)] for matching records.
+
+    ``predicate`` selects the subset (attack vs block).  Sorted by share
+    descending so the dominant class appears first — exactly what the
+    fail-closed guard needs to catch a 71.8 % skew.
+    """
+    subset = [r for r in records if predicate(r)]
+    total = len(subset)
+    if total == 0:
+        return []
+    counts = Counter(r["meta"].get(field, "?") for r in subset)
+    items = [(cls, n, round(n / total, 4)) for cls, n in counts.items()]
+    items.sort(key=lambda x: (-x[2], x[0]))
+    return items
+
+
+def _check_class_share(
+    hist: list[tuple[str, int, float]], max_share: float, label: str
+) -> None:
+    """Raise SystemExit if any class in *hist* exceeds *max_share*."""
+    if not hist:
+        return
+    max_item = hist[0]  # sorted descending
+    cls, n, share = max_item
+    if share > max_share:
+        lines = [
+            f"\nFAIL-CLOSED: {label} class '{cls}' is "
+            f"{share:.1%} ({n}/{sum(h[1] for h in hist)}) — "
+            f"exceeds --max-class-share={max_share:.0%}",
+            f"  Full histogram:",
+        ]
+        for c, nn, s in hist:
+            lines.append(f"    {c}: {nn} ({s:.1%})")
+        lines.append(
+            "  Pass --allow-skewed to build anyway, or use "
+            "--balance downsample."
+        )
+        raise SystemExit("\n".join(lines))
+
+
+def _downsample(
+    records: list[dict],
+    attack_hist: list[tuple[str, int, float]],
+    block_hist: list[tuple[str, int, float]],
+    threshold: float,
+) -> list[dict]:
+    """Deterministically (seed=7) downsample majority classes to *threshold*.
+
+    Only the block side is typically the problem, but we run the same
+    check on both.  Returns a NEW list; original *records* is unchanged.
+    """
+    import random
+
+    rng = random.Random(7)
+    kept: list[dict] = []
+
+    # Process attack and block subsets independently
+    for hist, kind_val, meta_class_field in [
+        (attack_hist, "combat_attack", "attack_class"),
+        (block_hist, "combat_block", "block_class"),
+    ]:
+        subset = [r for r in records if r.get("kind") == kind_val]
+        if not hist or len(subset) == 0:
+            kept.extend(subset)
+            continue
+
+        total = sum(h[1] for h in hist)
+        max_class, max_count, max_share = hist[0]
+
+        if max_share <= threshold:
+            kept.extend(subset)
+            print(
+                f"  [{kind_val}] no class exceeds {threshold:.0%}, "
+                f"keeping all {len(subset)}",
+                file=sys.stderr,
+            )
+            continue
+
+        # Target count for the majority class
+        other_total = total - max_count
+        target_max = int(other_total * threshold / (1 - threshold))
+        # Clamp: never go below the next-largest class or below 1
+        next_largest = hist[1][1] if len(hist) > 1 else 0
+        target_max = max(target_max, next_largest, 1)
+
+        to_drop = max_count - target_max
+        if to_drop <= 0:
+            kept.extend(subset)
+            continue
+
+        majority_recs = [
+            r for r in subset
+            if r["meta"].get(meta_class_field, "") == max_class
+        ]
+        non_majority = [
+            r for r in subset
+            if r["meta"].get(meta_class_field, "") != max_class
+        ]
+
+        rng.shuffle(majority_recs)
+        keep_count = len(majority_recs) - to_drop
+        keep_majority = majority_recs[:keep_count]
+
+        print(
+            f"  [{kind_val}] downsampled '{max_class}': "
+            f"{len(majority_recs)} -> {keep_count} "
+            f"(dropped {to_drop})",
+            file=sys.stderr,
+        )
+        kept.extend(non_majority)
+        kept.extend(keep_majority)
+
+    return kept
+
 def _read_jsonl(path: Path) -> list[dict]:
     out: list[dict] = []
     with open(path, encoding="utf-8") as f:
@@ -567,6 +710,14 @@ def main(argv: list[str] | None = None) -> int:
                         help="Path to write training records JSONL")
     parser.add_argument("--report", action="store_true",
                         help="Print build report to stderr on completion")
+    parser.add_argument("--max-class-share", type=float, default=0.50,
+                        help="Maximum allowed share of any single class "
+                             "(default: 0.50).  Build aborts if exceeded.")
+    parser.add_argument("--allow-skewed", action="store_true",
+                        help="Skip the fail-closed class-share guard")
+    parser.add_argument("--balance", choices=("downsample",), default=None,
+                        help="Downsample the majority class toward the "
+                             "threshold (deterministic, seed=7)")
     args = parser.parse_args(argv)
 
     t0 = time.time()
@@ -604,13 +755,44 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("no usable records — fail closed")
         return 2
 
+    # ── Class-histogram guard -------------------------------------------------
+
+    attack_hist = _class_histogram(
+        records, "attack_class",
+        lambda r: r.get("kind") == "combat_attack",
+    )
+    block_hist = _class_histogram(
+        records, "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
+
+    if not args.allow_skewed:
+        _check_class_share(attack_hist, args.max_class_share, "attack")
+        _check_class_share(block_hist, args.max_class_share, "block")
+
+    # ── Rebalance -------------------------------------------------------------
+
+    if args.balance == "downsample":
+        records = _downsample(records, attack_hist, block_hist,
+                              args.max_class_share)
+        # Recompute histograms after downsample for accurate report
+        attack_hist = _class_histogram(
+            records, "attack_class",
+            lambda r: r.get("kind") == "combat_attack",
+        )
+        block_hist = _class_histogram(
+            records, "block_class",
+            lambda r: r.get("kind") == "combat_block",
+        )
+
     elapsed = time.time() - t0
     written = _write_jsonl(args.output, records)
     logger.info(f"wrote {written} records -> {args.output}")
 
     if args.report:
         _print_report(records, drops, skip_counts, read_count,
-                      args.input, args.output, elapsed)
+                      args.input, args.output, elapsed,
+                      attack_hist=attack_hist, block_hist=block_hist)
 
     return 0
 
@@ -623,6 +805,8 @@ def _print_report(
     input_path: Path,
     output_path: Path,
     elapsed: float,
+    attack_hist: list[tuple[str, int, float]] | None = None,
+    block_hist: list[tuple[str, int, float]] | None = None,
 ) -> None:
     attack_recs = [r for r in records if r.get("kind") == "combat_attack"]
     block_recs = [r for r in records if r.get("kind") == "combat_block"]
@@ -646,17 +830,15 @@ def _print_report(
     leak_solver = sum(1 for r in records if "Computed optimal" in r.get("user", ""))
     print(f"  Solver line leaks: {leak_solver} (should be 0)", file=sys.stderr)
 
-    if attack_recs:
-        print(f"\n  Attack class mix:", file=sys.stderr)
-        classes = Counter(r["meta"]["attack_class"] for r in attack_recs)
-        for cls, n in sorted(classes.items()):
-            print(f"    {cls}: {n}", file=sys.stderr)
+    if attack_hist:
+        print(f"\n  Attack class histogram:", file=sys.stderr)
+        for cls, n, share in attack_hist:
+            print(f"    {cls}: {n:>4d} ({share:.1%})", file=sys.stderr)
 
-    if block_recs:
-        print(f"\n  Block class mix:", file=sys.stderr)
-        classes = Counter(r["meta"]["block_class"] for r in block_recs)
-        for cls, n in sorted(classes.items()):
-            print(f"    {cls}: {n}", file=sys.stderr)
+    if block_hist:
+        print(f"\n  Block class histogram:", file=sys.stderr)
+        for cls, n, share in block_hist:
+            print(f"    {cls}: {n:>4d} ({share:.1%})", file=sys.stderr)
 
     # Show one example of each
     if attack_recs:

--- a/tools/training/build_magezero_combat.py
+++ b/tools/training/build_magezero_combat.py
@@ -1,0 +1,679 @@
+#!/usr/bin/env python3
+"""MageZero decisions JSONL → combat-gate-shaped attackers/blockers records.
+
+Consumes the shared WP-3 decisions schema (decisions JSONL) and emits
+training records whose answer shape matches what
+tools/training/gate_combat_decisions.py expects:
+  attack:  {"actions":[{"action_type":"declare_attackers","attacker_names":["A","B"]}]}
+  block:   {"actions":[{"action_type":"declare_blockers","blocker_assignments":{"Y":"X"}}]}
+
+Only decision_kind in (attackers, blockers) rows are consumed; all others
+are skipped and counted.
+
+Solver lines: OFF (the equivalent of --solver-line off).  Every record carries
+NO_SOLVER_ADDENDUM and no mcts_counts leak into the prompt.
+
+Usage
+-----
+    python3 tools/training/build_magezero_combat.py \\
+        --in <decisions.jsonl> --out <combat_records.jsonl> [--report]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("tools.training.build_magezero_combat")
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "src"
+
+for _p in (str(SRC), str(REPO)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# ── Import AUTOPILOT_SYSTEM_PROMPT via importlib (avoids PySide6 cascade) ──
+
+def _load_autopilot_system_prompt() -> str:
+    import importlib.util
+    import types
+    if "arenamcp" not in sys.modules:
+        pkg = types.ModuleType("arenamcp")
+        pkg.__path__ = [str(SRC / "arenamcp")]
+        pkg.__file__ = str(SRC / "arenamcp" / "__init__.py")
+        pkg.__package__ = "arenamcp"
+        sys.modules["arenamcp"] = pkg
+    bh_path = SRC / "arenamcp" / "backend_health.py"
+    if "arenamcp.backend_health" not in sys.modules:
+        spec_h = importlib.util.spec_from_file_location(
+            "arenamcp.backend_health", str(bh_path)
+        )
+        assert spec_h is not None, f"cannot find backend_health.py at {bh_path}"
+        mod_h = importlib.util.module_from_spec(spec_h)
+        mod_h.__package__ = "arenamcp"
+        sys.modules["arenamcp.backend_health"] = mod_h
+        spec_h.loader.exec_module(mod_h)
+    ap_path = SRC / "arenamcp" / "action_planner.py"
+    if "arenamcp.action_planner" not in sys.modules:
+        spec_a = importlib.util.spec_from_file_location(
+            "arenamcp.action_planner", str(ap_path)
+        )
+        assert spec_a is not None, f"cannot find action_planner.py at {ap_path}"
+        mod_a = importlib.util.module_from_spec(spec_a)
+        mod_a.__package__ = "arenamcp"
+        sys.modules["arenamcp.action_planner"] = mod_a
+        spec_a.loader.exec_module(mod_a)
+    return sys.modules["arenamcp.action_planner"].AUTOPILOT_SYSTEM_PROMPT
+
+AUTOPILOT_SYSTEM_PROMPT = _load_autopilot_system_prompt()
+
+# ── Import from the combat corpus builder (never re-implement) ─────────────
+
+from tools.training.build_combat_decisions import (  # noqa: E402
+    ATTACK_ADDENDUM,
+    BLOCK_ADDENDUM,
+    NO_SOLVER_ADDENDUM,
+    RECONSTRUCTED_ADDENDUM,
+    TRIGGER_ATTACK,
+    TRIGGER_BLOCK,
+    DONE_ATTACK_ROW,
+    DONE_BLOCK_ROW,
+)
+
+# ── Card-detection helpers (MZ only has card names) ───────────────────────
+
+# Best-effort land detection — only needed to exclude lands from the
+# attack/block pool (MZ data has no grp_ids or type lines).
+_BASIC_LANDS = frozenset({
+    "Plains", "Island", "Swamp", "Mountain", "Forest",
+    "Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
+    "Snow-Covered Mountain", "Snow-Covered Forest", "Wastes",
+})
+_LAND_SUFFIXES = ("Land", "lands", "Verge", "Heath", "Foothills", "Delta",
+                  "Strand", "Mire", "Catacombs", "Meadow", "Pool", "Grove",
+                  "Garden", "Tomb", "Node", "Spire", "Cavern", "Passage",
+                  "Factory", "Opal", "Citadel", "Sanctum", "Archive",
+                  "Crossroads", "Hideout", "Shrine", "Village", "Mine",
+                  "Foundry", "Den", "Expanse", "Reach", "Canopy", "Vista",
+                  "Basin", "Fortress", "Cave", "Crater", "Bridge", "Vale",
+                  "Confluence", "Borough", "Hub", "Borderpost", "Column")
+_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's",
+                       "Corrupted", "Darksteel")
+
+
+def _is_land(name: str) -> bool:
+    if name in _BASIC_LANDS:
+        return True
+    if any(name.endswith(s) for s in _LAND_SUFFIXES):
+        return True
+    if any(name.startswith(p) for p in _LAND_NAME_CONTAINS):
+        return True
+    return False
+
+
+# ── Combat-suffix helpers ──────────────────────────────────────────────────
+
+_COMBAT_SUFFIXES = (",attacking", ",blocking")
+
+
+def _strip_combat_suffix(name: str) -> tuple[str, str | None]:
+    """Return (clean_name, state) where state in (attacking, blocking, None)."""
+    for suffix in _COMBAT_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)], suffix[1:]  # remove leading comma
+    return name, None
+
+
+def _is_attacking(name: str) -> bool:
+    return name.endswith(",attacking")
+
+
+def _is_blocking(name: str) -> bool:
+    return name.endswith(",blocking")
+
+
+def _known_combat_state(name: str) -> bool:
+    return _is_attacking(name) or _is_blocking(name)
+
+
+# ── Name disambiguation (matches build_combat_decisions.disambiguate) ──────
+
+def _disambiguate(names: list[str]) -> list[str]:
+    """Byte-identical to build_combat_decisions.disambiguate."""
+    counts = Counter(names)
+    seen: dict[str, int] = {}
+    out: list[str] = []
+    for name in names:
+        if counts[name] > 1:
+            seen[name] = seen.get(name, 0) + 1
+            out.append(f"{name} #{seen[name]}")
+        else:
+            out.append(name)
+    return out
+
+
+# ── Response formatters (thin wrappers matching build_combat_decisions) ────
+
+def _attack_response(names: list[str]) -> str:
+    return json.dumps(
+        {"actions": [{"action_type": "declare_attackers", "attacker_names": names}]},
+        ensure_ascii=False,
+    )
+
+
+def _block_response(assignments: dict[str, str]) -> str:
+    return json.dumps(
+        {"actions": [{"action_type": "declare_blockers", "blocker_assignments": assignments}]},
+        ensure_ascii=False,
+    )
+
+
+# ── System prompt builder (matches build_combat_decisions.build_system) ────
+
+def _build_system(kind: str) -> str:
+    addendum = ATTACK_ADDENDUM if kind == "attack" else BLOCK_ADDENDUM
+    addendum += NO_SOLVER_ADDENDUM
+    addendum += RECONSTRUCTED_ADDENDUM
+    return AUTOPILOT_SYSTEM_PROMPT + "\n" + addendum
+
+
+# ── User prompt builders ───────────────────────────────────────────────────
+
+def _user_prompt_attack(
+    row: dict,
+    pool_names: list[str],
+    declared_names: list[str],
+) -> str:
+    """Build a user prompt for an attack decision from MZ data."""
+    declared_set = set(declared_names)
+    menu = [f"  {i + 1}. Attack with: {n}" for i, n in enumerate(pool_names)]
+    menu.append(f"  {len(menu) + 1}. {DONE_ATTACK_ROW}")
+    life = row.get("active_life", 20)
+    opp_life = row.get("opp_life", 20)
+    turn = row.get("turn", 0)
+    lines = [
+        TRIGGER_ATTACK,
+        "",
+        "=== GAME ===",
+        "Legal: (pick by number)",
+        *menu,
+        f"T{turn} YOUR | Combat | Pri:You",
+        "Pending decision: Declare Attackers",
+        f"Life: You={life} Opp={opp_life}",
+        "",
+        "YOUR BOARD:",
+    ]
+    self_lines = _board_lines(row, "battlefield_self")
+    lines.extend(self_lines or ["  (empty)"])
+    lines.append("")
+    lines.append("OPP BOARD:")
+    opp_lines = _board_lines(row, "battlefield_opp")
+    lines.extend(opp_lines or ["  (empty)"])
+    return "\n".join(lines)
+
+
+def _user_prompt_block(
+    row: dict,
+    blocker_names: list[str],
+    attacker_names: list[str],
+    declared_assignments: dict[str, str],
+) -> str:
+    """Build a user prompt for a block decision from MZ data."""
+    menu = [f"  {i + 1}. Block with: {n}" for i, n in enumerate(blocker_names)]
+    menu.append(f"  {len(menu) + 1}. {DONE_BLOCK_ROW}")
+    life = row.get("active_life", 20)
+    opp_life = row.get("opp_life", 20)
+    turn = row.get("turn", 0)
+    lines = [
+        TRIGGER_BLOCK,
+        "",
+        "=== GAME ===",
+        "Legal: (pick by number)",
+        *menu,
+        f"T{turn} OPP | Combat | Pri:You",
+        "Pending decision: Declare Blockers",
+        f"Life: You={life} Opp={opp_life}",
+        "",
+        "ATTACKING YOU:",
+    ]
+    for name in attacker_names:
+        lines.append(f"  {name}")
+    lines.append("")
+    lines.append("YOUR BOARD:")
+    self_lines = _board_lines(row, "battlefield_self")
+    lines.extend(self_lines or ["  (empty)"])
+    lines.append("")
+    lines.append("OPP BOARD:")
+    opp_lines = _board_lines(row, "battlefield_opp")
+    lines.extend(opp_lines or ["  (empty)"])
+    return "\n".join(lines)
+
+
+def _board_lines(row: dict, side: str) -> list[str]:
+    """Build board lines from MZ battlefield data (names sorted, duplicates grouped)."""
+    seen: list[str] = []
+    counts: Counter = Counter()
+    for p in row.get(side, []):
+        name, _state = _strip_combat_suffix(p["name"])
+        counts[name] += 1
+    out: list[str] = []
+    for name in sorted(counts):
+        n = counts[name]
+        line = f"  {name}"
+        if n > 1:
+            line += f" x{n}"
+            out.append(line)
+        else:
+            out.append(line)
+    return out
+
+
+# ── Record construction ────────────────────────────────────────────────────
+
+def _rid(key: str) -> str:
+    return f"mzc-{hashlib.sha1(key.encode()).hexdigest()[:16]}"
+
+
+def _classify_attack(declared: list[str], pool: list[str]) -> str:
+    if not declared:
+        return "no_attack"
+    if len(declared) == len(pool):
+        return "all_in"
+    return "proper_subset"
+
+
+def _classify_block(declared: dict[str, str], pool_n: int) -> str:
+    if not declared:
+        return "no_block"
+    if len(declared) == pool_n:
+        return "block_all"
+    return "partial_block"
+
+
+def _match_declared_to_pool(
+    pool_raw: list[str],
+    pool_disambiguated: list[str],
+    declared_raw: list[str],
+) -> list[str]:
+    """Positionally match declared names to disambiguated pool names.
+
+    ``pool_raw`` is the undeduplicated name list; ``pool_disambiguated`` is
+    ``_disambiguate(pool_raw)``.  ``declared_raw`` is a SUBSET of the pool
+    (with duplicates).  Return the disambiguated names of the declared entries
+    in order, consuming pool copies left-to-right.
+    """
+    used: list[bool] = [False] * len(pool_raw)
+    out: list[str] = []
+    for d in declared_raw:
+        for i, (raw_name, is_used) in enumerate(zip(pool_raw, used)):
+            if not is_used and raw_name == d:
+                used[i] = True
+                out.append(pool_disambiguated[i])
+                break
+    return out
+
+
+def build_attack_record(row: dict) -> tuple[dict | None, str]:
+    """Single attackers row → training record, or (None, reason)."""
+    # Extract creatures on self, strip combat suffixes
+    self_raw: list[tuple[str, str | None]] = []
+    for p in row.get("battlefield_self", []):
+        name, state = _strip_combat_suffix(p["name"])
+        if _is_land(name):
+            continue
+        if state and state != "attacking":
+            continue  # skip blocking markers during attackers phase
+        # Tapped creatures that are NOT attacking are summoning-sick
+        # or were tapped by a prior spell — cannot attack.
+        # Attacking creatures ARE tapped (declaring taps them), so allow.
+        if p.get("tapped", False) and state != "attacking":
+            continue
+        self_raw.append((name, state))
+
+    if not self_raw:
+        return None, "attack_no_creatures"
+
+    # Attack pool: all creatures (regardless of attacking state)
+    pool = _disambiguate([n for n, _ in self_raw])
+
+    # Declared attackers: creatures marked ,attacking
+    declared_raw = [n for n, s in self_raw if s == "attacking"]
+    if not declared_raw:
+        # No attackers declared at this decision point — the MCTS chose
+        # a spell/ability before any attack declaration.  Drop: this is
+        # a priority action during combat, not a combat decision.
+        return None, "attack_no_declared"
+
+    declared = _match_declared_to_pool(
+        [n for n, _ in self_raw], pool, declared_raw
+    )
+
+    user = _user_prompt_attack(row, pool, declared)
+    rec = {
+        "id": _rid(row.get("game_id", "") + ":atk:" + str(row.get("turn", 0))),
+        "system": _build_system("attack"),
+        "user": user,
+        "response": _attack_response(declared),
+        "source": "magezero_combat",
+        "attribution": "MageZero self-play (XMage-based AlphaZero engine)",
+        "kind": "combat_attack",
+        "meta": {
+            "game_id": row.get("game_id", ""),
+            "turn": row.get("turn", 0),
+            "phase": row.get("phase", ""),
+            "decision_kind": "attackers",
+            "pool_size": len(pool),
+            "chosen_size": len(declared),
+            "chosen_names": declared,
+            "answer_shape": "declare_attackers/attacker_names",
+            "is_all_in": len(declared) == len(pool) > 0,
+            "is_no_attack": not declared,
+            "is_proper_subset": 0 < len(declared) < len(pool),
+            "attack_class": _classify_attack(declared, pool),
+            "solver_line_rendered": False,
+            "session": row.get("session", ""),
+            "outcome": row.get("outcome", "unknown"),
+            "actor": row.get("actor", ""),
+            "reconstructed_from": "magezero",
+            "mcts_chosen": row.get("chosen", ""),
+        },
+    }
+    # Prove no solver line and no mcts_counts in the prompt
+    assert "Computed optimal" not in rec["user"], "solver line leaked into prompt"
+    assert "count" not in rec["user"].lower() or "discard" not in rec["user"].lower(), \
+        "mcts_counts may have leaked"
+    return rec, ""
+
+
+def build_block_record(row: dict) -> tuple[dict | None, str]:
+    """Single blockers row → training record, or (None, reason)."""
+    # Extract self creatures with ,blocking suffix (PlayerA's blockers)
+    self_blockers_raw: list[str] = []
+    for p in row.get("battlefield_self", []):
+        name, state = _strip_combat_suffix(p["name"])
+        if state == "blocking":
+            self_blockers_raw.append(name)
+
+    # Extract opp creatures with ,attacking suffix (opponent's attackers)
+    opp_attackers: list[str] = []
+    for p in row.get("battlefield_opp", []):
+        name, state = _strip_combat_suffix(p["name"])
+        if state == "attacking":
+            opp_attackers.append(name)
+
+    # If neither side has clear markers, drop as ambiguous
+    if not self_blockers_raw and not opp_attackers:
+        return None, "block_no_markers"
+
+    # Build blocker pool: all non-land self creatures that aren't marked attacking
+    # (include ,blocking creatures even if tapped — blockers cannot normally be
+    # tapped, but the MZ data's tapped flag may reflect a prior combat sub-phase)
+    blocker_pool_raw: list[str] = []
+    for p in row.get("battlefield_self", []):
+        name, state = _strip_combat_suffix(p["name"])
+        if _is_land(name):
+            continue
+        if state == "attacking":
+            continue  # these creatures already attacked, can't block
+        if p.get("tapped", False) and state != "blocking":
+            continue  # non-blocking tapped creatures can't block
+        blocker_pool_raw.append(name)
+    blocker_pool = _disambiguate(blocker_pool_raw)
+
+    # Build attacker roster from opp battlefield
+    attacker_roster_raw: list[str] = []
+    for p in row.get("battlefield_opp", []):
+        name, _state = _strip_combat_suffix(p["name"])
+        if _is_land(name):
+            continue
+        attacker_roster_raw.append(name)
+    attacker_roster = _disambiguate(attacker_roster_raw)
+
+    # Handle the reverse pattern: self has ,attacking and opp has ,blocking
+    # This is the most common pattern (69/199 rows).  In XMage's log, these
+    # markers indicate creatures that were declared during a PREVIOUS
+    # declare_attackers/blockers sub-phase of the SAME turn.  The actual
+    # attackers for THIS blockers decision are the opp creatures with
+    # ,attacking — but in this pattern, no opp creature has ,attacking.
+    # We cannot determine the blocking assignment from ambiguous markers.
+    self_attacking = any(
+        _is_attacking(p["name"]) for p in row.get("battlefield_self", [])
+    )
+    opp_blocking = any(
+        _is_blocking(p["name"]) for p in row.get("battlefield_opp", [])
+    )
+    if self_attacking and opp_blocking:
+        return None, "block_reversed_markers_ambiguous"
+
+    if not self_blockers_raw:
+        # No blockers declared — opponent's attackers are known
+        if not opp_attackers:
+            return None, "block_no_attackers_either"
+        user = _user_prompt_block(row, blocker_pool,
+                                   opp_attackers, {})
+        rec = {
+            "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
+            "system": _build_system("block"),
+            "user": user,
+            "response": _block_response({}),
+            "source": "magezero_combat",
+            "attribution": "MageZero self-play (XMage-based AlphaZero engine)",
+            "kind": "combat_block",
+            "meta": {
+                "game_id": row.get("game_id", ""),
+                "turn": row.get("turn", 0),
+                "phase": row.get("phase", ""),
+                "decision_kind": "blockers",
+                "blocker_pool_size": len(blocker_pool),
+                "n_attackers": len(opp_attackers),
+                "n_blocks": 0,
+                "answer_shape": "declare_blockers/blocker_assignments",
+                "is_no_block": True,
+                "is_partial_block": False,
+                "block_class": "no_block",
+                "solver_line_rendered": False,
+                "session": row.get("session", ""),
+                "outcome": row.get("outcome", "unknown"),
+                "actor": row.get("actor", ""),
+                "reconstructed_from": "magezero",
+                "mcts_chosen": row.get("chosen", ""),
+            },
+        }
+        assert "Computed optimal" not in rec["user"]
+        return rec, ""
+
+    # Blockers declared. Map: if exactly 1 attacker, all blockers map to it.
+    if len(opp_attackers) != 1:
+        return None, f"block_{len(opp_attackers)}_attackers_cannot_pair"
+
+    # Match declared blockers against the pool for correct disambiguation
+    declared_blockers = _match_declared_to_pool(
+        blocker_pool_raw, blocker_pool, self_blockers_raw
+    )
+    target_name = opp_attackers[0]
+    assignments = {b: target_name for b in declared_blockers}
+
+    user = _user_prompt_block(row, blocker_pool,
+                               opp_attackers, assignments)
+    rec = {
+        "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
+        "system": _build_system("block"),
+        "user": user,
+        "response": _block_response(assignments),
+        "source": "magezero_combat",
+        "attribution": "MageZero self-play (XMage-based AlphaZero engine)",
+        "kind": "combat_block",
+        "meta": {
+            "game_id": row.get("game_id", ""),
+            "turn": row.get("turn", 0),
+            "phase": row.get("phase", ""),
+            "decision_kind": "blockers",
+            "blocker_pool_size": len(blocker_pool),
+            "n_attackers": len(opp_attackers),
+            "n_blocks": len(assignments),
+            "answer_shape": "declare_blockers/blocker_assignments",
+            "is_no_block": False,
+            "is_partial_block": len(assignments) < len(blocker_pool),
+            "block_class": _classify_block(assignments, len(blocker_pool)),
+            "mapping_source": "forced_single_attacker",
+            "solver_line_rendered": False,
+            "session": row.get("session", ""),
+            "outcome": row.get("outcome", "unknown"),
+            "actor": row.get("actor", ""),
+            "reconstructed_from": "magezero",
+            "mcts_chosen": row.get("chosen", ""),
+        },
+    }
+    assert "Computed optimal" not in rec["user"]
+    return rec, ""
+
+
+# ── IO and CLI ─────────────────────────────────────────────────────────────
+
+def _read_jsonl(path: Path) -> list[dict]:
+    out: list[dict] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+    return len(rows)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build combat-gate-shaped records from MageZero decisions JSONL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--in", dest="input", type=Path, required=True,
+                        help="Path to decisions JSONL (MageZero schema)")
+    parser.add_argument("--out", dest="output", type=Path, required=True,
+                        help="Path to write training records JSONL")
+    parser.add_argument("--report", action="store_true",
+                        help="Print build report to stderr on completion")
+    args = parser.parse_args(argv)
+
+    t0 = time.time()
+
+    if not args.input.exists():
+        logger.error(f"input not found: {args.input}")
+        return 2
+
+    raw = _read_jsonl(args.input)
+    read_count = len(raw)
+    logger.info(f"read {read_count} decisions from {args.input}")
+
+    records: list[dict] = []
+    drops: Counter = Counter()
+    skip_counts: Counter = Counter()
+
+    for row in raw:
+        kind = row.get("decision_kind", "")
+        if kind not in ("attackers", "blockers"):
+            skip_counts[kind] += 1
+            drops[f"skip_kind_{kind}"] += 1
+            continue
+
+        if kind == "attackers":
+            rec, reason = build_attack_record(row)
+        else:
+            rec, reason = build_block_record(row)
+
+        if rec is None:
+            drops[reason] += 1
+            continue
+        records.append(rec)
+
+    if not records:
+        logger.error("no usable records — fail closed")
+        return 2
+
+    elapsed = time.time() - t0
+    written = _write_jsonl(args.output, records)
+    logger.info(f"wrote {written} records -> {args.output}")
+
+    if args.report:
+        _print_report(records, drops, skip_counts, read_count,
+                      args.input, args.output, elapsed)
+
+    return 0
+
+
+def _print_report(
+    records: list[dict],
+    drops: Counter,
+    skip_counts: Counter,
+    read_count: int,
+    input_path: Path,
+    output_path: Path,
+    elapsed: float,
+) -> None:
+    attack_recs = [r for r in records if r.get("kind") == "combat_attack"]
+    block_recs = [r for r in records if r.get("kind") == "combat_block"]
+    any_mcts = sum(
+        1 for r in records
+        if isinstance(r.get("meta"), dict) and r["meta"].get("mcts_chosen")
+    )
+
+    print(f"\n=== BUILD REPORT ===", file=sys.stderr)
+    print(f"  Input:      {input_path} ({read_count} rows)", file=sys.stderr)
+    print(f"  Output:     {output_path} ({len(records)} records)", file=sys.stderr)
+    print(f"  Elapsed:    {elapsed:.2f}s", file=sys.stderr)
+    print(f"  Skipped kinds: {dict(skip_counts)}", file=sys.stderr)
+    print(f"  Drops:      {dict(drops)}", file=sys.stderr)
+    print(f"  Total drops: {sum(drops.values())}", file=sys.stderr)
+    print(f"  Attack recs: {len(attack_recs)}", file=sys.stderr)
+    print(f"  Block  recs: {len(block_recs)}", file=sys.stderr)
+    print(f"  Records with mcts_chosen: {any_mcts}", file=sys.stderr)
+
+    # Verify no solver lines or mcts leaks in any prompt
+    leak_solver = sum(1 for r in records if "Computed optimal" in r.get("user", ""))
+    print(f"  Solver line leaks: {leak_solver} (should be 0)", file=sys.stderr)
+
+    if attack_recs:
+        print(f"\n  Attack class mix:", file=sys.stderr)
+        classes = Counter(r["meta"]["attack_class"] for r in attack_recs)
+        for cls, n in sorted(classes.items()):
+            print(f"    {cls}: {n}", file=sys.stderr)
+
+    if block_recs:
+        print(f"\n  Block class mix:", file=sys.stderr)
+        classes = Counter(r["meta"]["block_class"] for r in block_recs)
+        for cls, n in sorted(classes.items()):
+            print(f"    {cls}: {n}", file=sys.stderr)
+
+    # Show one example of each
+    if attack_recs:
+        print(f"\n  Sample attack response:", file=sys.stderr)
+        sample = attack_recs[0]
+        print(f"    id: {sample['id']}", file=sys.stderr)
+        print(f"    response: {sample['response']}", file=sys.stderr)
+        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('pool_size','chosen_size','chosen_names','attack_class')})}", file=sys.stderr)
+    if block_recs:
+        print(f"\n  Sample block response:", file=sys.stderr)
+        sample = block_recs[0]
+        print(f"    id: {sample['id']}", file=sys.stderr)
+        print(f"    response: {sample['response']}", file=sys.stderr)
+        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('blocker_pool_size','n_attackers','n_blocks','block_class')})}", file=sys.stderr)
+
+    print(f"  {'='*40}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/training/wp3/PROGRESS-wp3-combat-adapter.md
+++ b/tools/training/wp3/PROGRESS-wp3-combat-adapter.md
@@ -1,0 +1,80 @@
+# WP-3: wp3-combat-adapter — MageZero combat rows → combat-gate records
+
+## Scope
+decision_kind `attackers`/`blockers` rows from decisions JSONL → production-shaped
+combat training records (declare_attackers / declare_blockers answer shape).
+
+## What was built
+- `tools/training/build_magezero_combat.py` — converter
+- `tests/test_magezero_combat.py` — 9 tests (leak scan + acceptance)
+
+## Design decisions
+
+### Attack pool
+Creatures on `battlefield_self` that are non-land, non-blocking, and not tapped
+(unless the creature is marked `,attacking` — attacking taps in MTG). This
+approximates the legal-attacker pool without a card DB.
+
+### Blocker pool
+Non-land self creatures not marked `,attacking`, with tapped creatures
+excluded EXCEPT those marked `,blocking` (MZ "tapped" flag may reflect prior
+combat sub-phase rather than current blocking ability).
+
+### Blocking → attacker pairing
+If exactly ONE opponent creature has `,attacking` marker, all self blockers
+map to it. Multi-attacker rows are dropped (same constraint as 17lands source
+in `build_combat_decisions.py` — pairing is unknowable without game state tracking).
+
+### Reverse marker pattern (self_attacking + opp_blocking)
+69/199 blockers rows have this pattern — the most common. Creatures on self have
+`,attacking` from a prior declare_attackers sub-phase; opp creatures have
+`,blocking`. These rows are dropped as ambiguous — we cannot determine which
+blocker → which attacker from the single-row snapshot.
+
+### Solver lines: OFF
+Every record carries NO_SOLVER_ADDENDUM. Verified by `test_no_solver_line`.
+
+### MCTS count leak guard
+`test_no_mcts_count_leak` verifies no MCTS visit count > 20 appears as a bare
+number in the prompt. `test_no_score_count_words` checks for "score:"/"count:".
+
+### Name disambiguation
+Positional matching (`_match_declared_to_pool`) ensures declared attacker/blocker
+names match the disambiguated pool names (`#1`/`#2` suffixes), avoiding the
+`"Forsaken Miner"` vs `"Forsaken Miner #1"` mismatch.
+
+## Output counts (smoke log: 578 combat rows)
+
+| Metric | Value |
+|--------|-------|
+| Input attackers | 379 |
+| Input blockers | 199 |
+| Attack records | 104 (6 all_in + 98 proper_subset) |
+| Block records | 78 (56 no_block + 17 partial_block + 5 block_all) |
+| Dropped (attack_no_declared) | 223 (MCTS chose spell/ability before declaring attackers) |
+| Dropped (attack_no_creatures) | 52 (no non-land permanents on self) |
+| Dropped (block_no_markers) | 109 (no clear combat state markers) |
+| Dropped (multi-attacker cannot pair) | 12 |
+| Solver line leaks | 0 |
+| MCTS count leaks | 0 |
+
+## How to run
+```bash
+# Build
+python3 tools/training/build_magezero_combat.py \
+    --in /tmp/combat_in.jsonl --out /tmp/combat_out.jsonl --report
+
+# Test
+python3 -m pytest tests/test_magezero_combat.py -v
+```
+
+## Known gaps
+1. No P/T or oracle text in prompts (MZ data has no grp_ids or card facts).
+   Pool/board lines show card names only.
+2. Blocker pool cannot distinguish creatures from auras/enchantments without a
+   card DB. Non-land permanents are included; some are auras that can't actually
+   block.
+3. 52 attack rows dropped because player had only lands on self (no creatures to
+   attack with). These could become "no_attack" records with pool size 0.
+4. 69 "reversed marker" blocker rows dropped as ambiguous — a future pass with
+   cross-row game state tracking could recover these.

--- a/tools/training/wp3/PROGRESS-wp3-combat-rebalance.md
+++ b/tools/training/wp3/PROGRESS-wp3-combat-rebalance.md
@@ -1,0 +1,51 @@
+# PROGRESS: wp3-combat-rebalance
+
+## Deliverables (all complete)
+1. ✅ Class histogram with percentages in `--report`
+2. ✅ FAIL-CLOSED build guard (`--max-class-share`, default 0.50, `--allow-skewed`)
+3. ✅ `--balance downsample` mode (seed=7, deterministic)
+4. ✅ `tests/test_combat_balance.py` (10 tests, all passing)
+
+## Problem reproduced
+```
+Block class histogram (raw):
+  no_block:   56 (71.8%)   ← ABOVE 69% trivial policy score
+  partial_block:  17 (21.8%)
+  block_all:   5 (6.4%)
+
+Attack class histogram (raw):
+  proper_subset:   98 (94.2%)
+  all_in:    6 (5.8%)
+```
+
+## Guard behavior
+Both attack and block sides exceed `--max-class-share=0.50`. The guard aborts first on
+attack (`proper_subset: 94.2%`). Pass `--allow-skewed` to force through, or
+`--balance downsample` to rebalance.
+
+## Rebalanced corpus
+```
+After --balance downsample --allow-skewed:
+  Attack:     12 records (all_in: 6 @ 50%, proper_subset: 6 @ 50%)
+  Block:      44 records (no_block: 22 @ 50%, partial_block: 17 @ 38.6%, block_all: 5 @ 11.4%)
+  Total:      56 records (was 182)
+
+NOTE: 56 records is very small for training — especially attacks at 12 records.
+The smoke log only had 379 attackers + 199 blockers rows to begin with, so the
+corpus was never large. A production build with more games would yield a more
+usable rebalanced corpus.
+```
+
+## Tests
+```
+tests/test_combat_balance.py::test_guard_fires_on_skewed_block       PASSED
+tests/test_combat_balance.py::test_guard_fires_on_skewed_attack      PASSED
+tests/test_combat_balance.py::test_guard_passes_on_balanced          PASSED
+tests/test_combat_balance.py::test_histogram_shares_sum_to_one       PASSED
+tests/test_combat_balance.py::test_histogram_sorted_descending       PASSED
+tests/test_combat_balance.py::test_downsample_deterministic          PASSED
+tests/test_combat_balance.py::test_downsample_reduces_majority       PASSED
+tests/test_combat_balance.py::test_downsample_clamps_below_one       PASSED
+tests/test_combat_balance.py::test_empty_histogram_does_not_raise    PASSED
+tests/test_combat_balance.py::test_empty_records_downsample          PASSED
+```


### PR DESCRIPTION
## What
Added a class-histogram guard and downsample rebalance to `build_magezero_combat.py`, which itself was discovered (by the orchestrator) to produce a block corpus that is 71.8% `no_block` — a trivial `always_no_block` policy would score ~69%.

## Why
The original 69% block skew went undetected because `--report` only printed raw counts, not percentages. A consumer had to eyeball 56/78 and realize that's 71.8%. The build completed silently with no guard.

## Deliverables

### 1. Enhanced histogram in `--report`
Now prints sorted-descending with percentages:
```
  Block class histogram:
    no_block:   56 (71.8%)
    partial_block:   17 (21.8%)
    block_all:    5 (6.4%)
```

### 2. FAIL-CLOSED build guard (`--max-class-share`, `--allow-skewed`)
If any single class exceeds the threshold (default 0.50), the build ABORTS with the histogram, unless `--allow-skewed` is passed. Modeled on the solver-line fail-closed guard in `build_combat_decisions.py` (`--solver-line` / `--allow-leaky-solver-line`).

**Guard aborts on the raw distribution** (both attack and block fail):
```
$ python3 tools/training/build_magezero_combat.py --in /tmp/c_in.jsonl --out /tmp/x.jsonl
FAIL-CLOSED: attack class 'proper_subset' is 94.2% (98/104) — exceeds --max-class-share=50%
  Full histogram:
    proper_subset: 98 (94.2%)
    all_in: 6 (5.8%)
  Pass --allow-skewed to build anyway, or use --balance downsample.
```

### 3. `--balance downsample` mode
Deterministically (seed=7) downsamples the majority class toward the threshold. No upsampling. Reports what was dropped.

**Before (raw corpus):** 182 records
**After (rebalanced):** 56 records

| Kind | Raw distribution | Rebalanced distribution |
|------|-----------------|------------------------|
| Attack | proper_subset: 98 (94.2%), all_in: 6 (5.8%) | all_in: 6 (50.0%), proper_subset: 6 (50.0%) |
| Block | no_block: 56 (71.8%), partial_block: 17 (21.8%), block_all: 5 (6.4%) | no_block: 22 (50.0%), partial_block: 17 (38.6%), block_all: 5 (11.4%) |

### 4. `tests/test_combat_balance.py` — 10 tests
All tests pass:
```
tests/test_combat_balance.py::test_guard_fires_on_skewed_block       PASSED
tests/test_combat_balance.py::test_guard_fires_on_skewed_attack      PASSED
tests/test_combat_balance.py::test_guard_passes_on_balanced          PASSED
tests/test_combat_balance.py::test_histogram_shares_sum_to_one       PASSED
tests/test_combat_balance.py::test_histogram_sorted_descending       PASSED
tests/test_combat_balance.py::test_downsample_deterministic          PASSED
tests/test_combat_balance.py::test_downsample_reduces_majority       PASSED
tests/test_combat_balance.py::test_downsample_clamps_below_one       PASSED
tests/test_combat_balance.py::test_empty_histogram_does_not_raise    PASSED
tests/test_combat_balance.py::test_empty_records_downsample          PASSED
```

## Known gaps
- **56 records is very small** — the smoke log only had 379 attackers + 199 blockers rows to begin with (9789 total decisions, mostly priority). Rebalancing to 50% drops attacks from 104→12 and blocks from 78→44. A production-scale log will yield a more usable corpus; this PR just ensures the next run catches and reports the skew rather than silently shipping it.
- The guard fires on attack `proper_subset` (94.2%) first, not block `no_block` — but both are >50%, so the order doesn't matter for correctness. If attacks are expected to be unbalanced in real play, consider a per-kind threshold or a separate skip flag for attack.