### PR TITLE
fix(wp3): Permanents line is OMITTED when a board is empty (finishes #430)

### DIFF
--- a/tests/test_parse_magezero_deck_sanity.py
+++ b/tests/test_parse_magezero_deck_sanity.py
@@ -1,0 +1,151 @@
+"""Guardrail: deck-membership sanity checks over the real MageZero log.
+
+Asserts three invariants on battlefield_self and battlefield_opp for every
+parsed decision row.  Designed to catch regressions in the permanents-line
+assignment logic (esp. the 1-line "opponent board is empty" case).
+
+Uses the real 201 MB smoke log at /Users/joshu/wp3/evidence/mz_train_smoke.log
+and the deck files under /Volumes/repos/magezero/xmage/decks/.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent / "tools" / "training"))
+
+from parse_magezero_log import parse_log  # noqa: E402
+
+import pytest
+
+LOG = Path("/Users/joshu/wp3/evidence/mz_train_smoke.log")
+DECKS_DIR = Path("/Volumes/repos/magezero/xmage/decks")
+
+# ── Deck card-set parser ────────────────────────────────────────────
+RE_DCK = re.compile(r"^\d+\s+\[[^\]]*\]\s+(.+)$")
+SESSION_OPP_RE = re.compile(r"session\d+_UWTempo_vs_Standard-Mono([RGBWU])")
+
+
+def _parse_dck(path: Path) -> set[str]:
+    cards: set[str] = set()
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        for line in f:
+            m = RE_DCK.match(line)
+            if m:
+                cards.add(m.group(1).strip())
+    return cards
+
+
+def _load_decks() -> tuple[set[str], dict[str, set[str]]]:
+    """Return (uwtempo_cards, monster_cards) where monster_cards[name] = card_set."""
+    dck_files: dict[str, set[str]] = {}
+    for p in sorted(DECKS_DIR.glob("*.dck")):
+        dck_files[p.stem] = _parse_dck(p)
+
+    uwtempo = dck_files.get("UWTempo", set())
+
+    mono = {}
+    for name in ["Standard-MonoR", "Standard-MonoG", "Standard-MonoB",
+                  "Standard-MonoW", "Standard-MonoU"]:
+        cards = dck_files.get(name, set())
+        if cards:
+            mono[name] = cards
+
+    return uwtempo, mono
+
+
+@pytest.fixture(scope="module")
+def parsed_data():
+    decisions, sessions = parse_log(str(LOG))
+    return decisions, sessions
+
+
+@pytest.fixture(scope="module")
+def deck_data():
+    return _load_decks()
+
+
+def _card_name(p) -> str:
+    if isinstance(p, dict):
+        return p.get("name", "")
+    return str(p)
+
+
+# ════════════════════════════════════════════════════════════════════
+# Deck-sanity assertions
+# ════════════════════════════════════════════════════════════════════
+
+class TestDeckSanity:
+    """Three invariants every parsed decision row must satisfy."""
+
+    def test_all_zero_violations(self, parsed_data, deck_data):
+        """Assert all three counts are zero.
+
+        This is the summary test — it computes all three counts and asserts
+        them all at once so we see the complete picture in a single failure.
+        """
+        decisions, sessions = parsed_data
+        uwtempo_cards, mono_decks = deck_data
+
+        # Precompute card-sets per opponent
+        opp_only: dict[str, set[str]] = {}
+        uw_only: dict[str, set[str]] = {}
+        shared_cards: dict[str, set[str]] = {}
+
+        for name, cards in mono_decks.items():
+            opp_only[name] = cards - uwtempo_cards
+            uw_only[name] = uwtempo_cards - cards
+            shared_cards[name] = uwtempo_cards & cards
+
+        v_self_opp_only = 0   # assertion 1
+        v_opp_uw_only = 0     # assertion 2
+        v_dual_board = 0      # assertion 3
+
+        for d in decisions:
+            sm = SESSION_OPP_RE.match(d.get("session", ""))
+            if not sm:
+                continue
+            color_key = f"Standard-Mono{sm.group(1)}"
+
+            bself_names = {_card_name(p) for p in d.get("battlefield_self", []) if _card_name(p)}
+            bopp_names = {_card_name(p) for p in d.get("battlefield_opp", []) if _card_name(p)}
+
+            # Assertion 1: self board never has opponent-only cards
+            if bself_names & opp_only.get(color_key, set()):
+                v_self_opp_only += 1
+
+            # Assertion 2: opp board never has UWTempo-only cards
+            if bopp_names & uw_only.get(color_key, set()):
+                v_opp_uw_only += 1
+
+            # Assertion 3: no card on both boards unless both decks run it
+            both = bself_names & bopp_names
+            both -= shared_cards.get(color_key, set())
+            if both:
+                v_dual_board += 1
+
+        # Report all three
+        msg = (
+            f"\nAssertion 1 (self → opp-only cards): {v_self_opp_only}\n"
+            f"Assertion 2 (opp → UW-only cards):    {v_opp_uw_only}\n"
+            f"Assertion 3 (both boards same card):  {v_dual_board}"
+        )
+        assert v_self_opp_only == 0 and v_opp_uw_only == 0 and v_dual_board == 0, msg
+
+    def test_total_decisions(self, parsed_data):
+        """Sanity check — make sure we parsed the expected number of rows."""
+        decisions, _ = parsed_data
+        # 10 sessions × 6 threads, total parsed rows is stable at 9789
+        assert len(decisions) == 9789, f"Expected 9789, got {len(decisions)}"
+
+    def test_empty_opp_board(self, parsed_data):
+        """At least some rows have an empty opponent board (1-line case)."""
+        decisions, _ = parsed_data
+        empty_opp = sum(
+            1 for d in decisions
+            if d.get("battlefield_opp") is not None and len(d["battlefield_opp"]) == 0
+        )
+        assert empty_opp > 0, "Expected at least one row with empty opponent board"

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -255,8 +255,8 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 "active_life": state.life_a,
                 "opp_life": state.life_b,
                 "hand": [],
-                "battlefield_self": [],
-                "battlefield_opp": [],
+                "battlefield_self": None,
+                "battlefield_opp": None,
                 "menu": list(menu),
                 "chosen": chosen,
                 "mcts_counts": mcts_counts,
@@ -283,6 +283,11 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         if hm:
             cards = parse_card_list(hm.group(1))
             state.latest_hand = cards
+            # Reset permanents buffer at start of every Hand-block.
+            # In the 1-line case the second Permanents line (opponent board)
+            # is OMITTED by XMage; clearing both here prevents stale carry-over.
+            state._perm_buffer = []
+            state.latest_perms_opp = []
             _backfill_hand(state, cards)
             continue
 
@@ -347,14 +352,22 @@ class _ThreadState:
 
     def _accumulate_permanents(self, permanents: list[dict]):
         if not self._perm_buffer:
+            # First Permanents line in this Hand-block = acting player's board
             self._perm_buffer = [permanents]
+            self.latest_perms_self = list(permanents)
+            self.latest_perms_opp = []
+            _backfill_battlefield(self)
         elif len(self._perm_buffer) == 1:
+            # Second Permanents line = opponent's board
             self._perm_buffer.append(permanents)
-            self.latest_perms_self = list(self._perm_buffer[0])
-            self.latest_perms_opp = list(self._perm_buffer[1])
+            self.latest_perms_opp = list(permanents)
             _backfill_battlefield(self)
         else:
+            # Overflow (shouldn't happen with Hand-block reset), start fresh
             self._perm_buffer = [permanents]
+            self.latest_perms_self = list(permanents)
+            self.latest_perms_opp = []
+            _backfill_battlefield(self)
 
     def infer_outcome(self) -> str:
         """Infer outcome from life values at the last known state."""
@@ -382,9 +395,19 @@ def _backfill_hand(state: _ThreadState, cards: list[str]):
 
 def _backfill_battlefield(state: _ThreadState):
     for d in reversed(state.game_decisions):
-        if not d.get("battlefield_self") and not d.get("battlefield_opp"):
+        if d.get("battlefield_self") is None and d.get("battlefield_opp") is None:
             d["battlefield_self"] = list(state.latest_perms_self)
             d["battlefield_opp"] = list(state.latest_perms_opp)
+            return
+        # One of the fields may have been set already (1-line case)
+        changed = False
+        if d.get("battlefield_self") is None:
+            d["battlefield_self"] = list(state.latest_perms_self)
+            changed = True
+        if d.get("battlefield_opp") is None:
+            d["battlefield_opp"] = list(state.latest_perms_opp)
+            changed = True
+        if changed:
             return
 
 
@@ -396,9 +419,9 @@ def _finalize_game(state: _ThreadState, all_decisions: list[dict]):
         d["outcome"] = outcome
         if not d.get("hand"):
             d["hand"] = list(state.latest_hand)
-        if not d.get("battlefield_self"):
+        if d.get("battlefield_self") is None:
             d["battlefield_self"] = list(state.latest_perms_self)
-        if not d.get("battlefield_opp"):
+        if d.get("battlefield_opp") is None:
             d["battlefield_opp"] = list(state.latest_perms_opp)
 
 


### PR DESCRIPTION
## Cause

46% of Hand-blocks emit only one \`-> Permanents:\` line — XMage omits the second line entirely when the opponent board is empty. The old accumulator only set \`latest_perms_self\`/opp on the SECOND line, leaving the first line values stale. Without a per-Hand-block reset, the previous block self board leaked into the next block as the opponent board.

Observed signature:
```
session3_UWTempo_vs_Standard-MonoW
  self: [Island]                     opp: [Island]
  self: [Island,Seachrome Coast]   opp: [Island,Island]
```

## Fix
1. Reset \`_perm_buffer\` and \`latest_perms_opp\` at the START of every Hand-block (when \`-> Hand:\` is seen), so nothing carries across blocks.
2. On the first Permanents line: set \`latest_perms_self\` immediately; \`latest_perms_opp = []\`.
3. On the second line (if present): set \`latest_perms_opp\`.
4. \`_backfill_battlefield\` fills each field independently (one may be set before the other in the 1-line case).
5. Changed battlefield defaults from \`[]\` to \`None\` to distinguish "not yet filled" from "empty but filled".

## Guardrail test
\`tests/test_parse_magezero_deck_sanity.py\` asserts three invariants over the real 201 MB \`mz_train_smoke.log\` (9789 rows) using deck card-sets parsed from \`xmage/decks/*.dck\`:
1. No opponent-only card on \`battlefield_self\`
2. No UWTempo-only card on \`battlefield_opp\`
3. No card name on BOTH boards unless both decks legitimately run it (only Island/Negate/Spell Pierce in the Mono-U matchup)

## Counts

| Assertion | Master base | After fix |
|---|---|---|
| 1: self has opp-only cards | 2099 | **0** |
| 2: opp has UW-only cards | 5551 | **0** |
| 3: same card on both boards | 1677 | **0** |

All three counts → **0**. Pre-existing parser tests: 40/40 pass. Reconciliation report unchanged.