### PR TITLE
WP12: contract validators + tripwire set

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,298 @@
+"""Unit tests for tools/training/validators.py — WP-1.2 contract validators.
+
+Covers every validator function's pass and fail paths:
+  - validate_action_schema_json
+  - validate_keyword_contract
+  - validate_length_cap
+  - validate_action_legality
+  - validate_all
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from tools.training.validators import (  # noqa: E402
+    ACTION_SCHEMA,
+    DECISION_PROMPTS,
+    MAX_RESPONSE_CHARS,
+    validate_action_legality,
+    validate_action_schema_json,
+    validate_all,
+    validate_keyword_contract,
+    validate_length_cap,
+)
+
+# ============================================================================
+# Re-export assertions
+# ============================================================================
+
+
+def test_imports_real_constants():
+    """Validators imports the real ACTION_SCHEMA / DECISION_PROMPTS, not stubs."""
+    assert isinstance(ACTION_SCHEMA, str) and len(ACTION_SCHEMA) > 50
+    assert '"actions"' in ACTION_SCHEMA
+    assert isinstance(DECISION_PROMPTS, dict) and "mulligan" in DECISION_PROMPTS
+
+
+# ============================================================================
+# validate_action_schema_json
+# ============================================================================
+
+
+class TestActionSchemaJson:
+    def test_valid_simple_pick(self):
+        ok, msg = validate_action_schema_json('{"actions": [{"pick": 1, "reasoning": "Play mountain"}]}')
+        assert ok is True
+        assert "Valid" in msg
+
+    def test_valid_fenced_json(self):
+        ok, msg = validate_action_schema_json('```json\n{"actions": [{"pick": 1}]}\n```')
+        assert ok is True
+        assert "Valid" in msg
+
+    def test_valid_no_fence_label(self):
+        ok, msg = validate_action_schema_json('```\n{"actions": [{"pick": 1}]}\n```')
+        assert ok is True
+        assert "Valid" in msg
+
+    def test_valid_action_type(self):
+        ok, msg = validate_action_schema_json(
+            '{"actions": [{"action_type": "declare_attackers", "attacker_names": ["Grizzly Bears"]}]}'
+        )
+        assert ok is True
+
+    def test_empty_response(self):
+        ok, msg = validate_action_schema_json("")
+        assert ok is False
+        assert "Empty" in msg
+
+    def test_whitespace_only(self):
+        ok, msg = validate_action_schema_json("   \n  ")
+        assert ok is False
+        assert "Empty" in msg
+
+    def test_not_json(self):
+        ok, msg = validate_action_schema_json("KEEP")
+        assert ok is False
+        assert "parse error" in msg
+
+    def test_not_a_dict(self):
+        ok, msg = validate_action_schema_json('["list", "not", "dict"]')
+        assert ok is False
+        assert "not an object" in msg
+
+    def test_missing_actions_key(self):
+        ok, msg = validate_action_schema_json('{"not_actions": []}')
+        assert ok is False
+        assert "Missing" in msg
+
+    def test_empty_actions_list(self):
+        ok, msg = validate_action_schema_json('{"actions": []}')
+        assert ok is False
+        assert "empty" in msg.lower()
+
+    def test_action_not_object(self):
+        ok, msg = validate_action_schema_json('{"actions": [42]}')
+        assert ok is False
+        assert "not an object" in msg
+
+    def test_missing_all_required_fields(self):
+        ok, msg = validate_action_schema_json('{"actions": [{"foo": "bar"}]}')
+        assert ok is False
+        assert "missing" in msg.lower()
+
+    def test_pick_not_int(self):
+        ok, msg = validate_action_schema_json('{"actions": [{"pick": "one"}]}')
+        assert ok is False
+        assert "integer" in msg
+
+    def test_trailing_comma_stripped(self):
+        ok, msg = validate_action_schema_json('{"actions": [{"pick": 1,},]}')
+        assert ok is True
+
+
+# ============================================================================
+# validate_keyword_contract
+# ============================================================================
+
+
+class TestKeywordContract:
+    def test_mulligan_response_keep(self):
+        ok, msg = validate_keyword_contract("Mulligan: KEEP or MULLIGAN", "KEEP")
+        assert ok is True
+
+    def test_mulligan_response_mulligan(self):
+        ok, msg = validate_keyword_contract("Mulligan: KEEP or MULLIGAN", "MULLIGAN")
+        assert ok is True
+
+    def test_mulligan_response_json_pick(self):
+        ok, msg = validate_keyword_contract("Mulligan: KEEP or MULLIGAN", '{"actions": [{"pick": 1}]}')
+        assert ok is True
+
+    def test_mulligan_invalid_word(self):
+        ok, msg = validate_keyword_contract("Mulligan: KEEP or MULLIGAN", "maybe")
+        assert ok is False
+        assert "Mulligan" in msg or "must be" in msg
+
+    def test_mulligan_json_malformed(self):
+        ok, msg = validate_keyword_contract("Mulligan: KEEP or MULLIGAN", "{bad json}")
+        assert ok is False
+        assert "must be" in msg
+
+    def test_not_mulligan_passes_through(self):
+        ok, msg = validate_keyword_contract("Legal: [1] Cast Lightning Bolt", "anything")
+        assert ok is True
+
+    def test_keep_hand_variant(self):
+        ok, msg = validate_keyword_contract("Keep Hand or Mulligan", "Keep")
+        assert ok is True
+
+
+# ============================================================================
+# validate_length_cap
+# ============================================================================
+
+
+class TestLengthCap:
+    def test_short_response_passes(self):
+        ok, msg = validate_length_cap("short")
+        assert ok is True
+        assert "within" in msg.lower()
+
+    def test_empty_passes(self):
+        ok, msg = validate_length_cap("")
+        assert ok is True
+
+    def test_exceeds_max_chars(self):
+        long = "x" * (MAX_RESPONSE_CHARS + 1)
+        ok, msg = validate_length_cap(long)
+        assert ok is False
+        assert "exceeds" in msg.lower()
+        assert str(MAX_RESPONSE_CHARS) in msg
+
+    def test_reasoning_too_long_in_json(self):
+        long_reason = "x" * 300  # > MAX_REASONING_CHARS (200)
+        resp = json.dumps({"actions": [{"pick": 1, "reasoning": long_reason}]})
+        ok, msg = validate_length_cap(resp)
+        assert ok is False
+        assert "reasoning" in msg.lower()
+
+    def test_voice_advice_too_long(self):
+        long_advice = "x" * 500  # > MAX_VOICE_ADVICE_CHARS (400)
+        resp = json.dumps({"actions": [{"pick": 1}], "voice_advice": long_advice})
+        ok, msg = validate_length_cap(resp)
+        assert ok is False
+        assert "voice_advice" in msg.lower()
+
+    def test_fenced_json_reasoning_check(self):
+        long_reason = "x" * 300
+        resp = f"```json\n{{'actions': [{{'pick': 1, 'reasoning': '{long_reason}'}}]}}\n```"
+        # Use actual JSON; fenced content is unwrapped
+        resp = '```json\n{"actions": [{"pick": 1, "reasoning": "' + long_reason + '"}]}\n```'
+        ok, msg = validate_length_cap(resp)
+        assert ok is False
+        assert "reasoning" in msg
+
+
+# ============================================================================
+# validate_action_legality
+# ============================================================================
+
+
+class TestActionLegality:
+    def test_valid_pick_bracket(self):
+        prompt = "Legal:\n [1] Play Land: Mountain\n [2] Cast Lightning Bolt\n [3] Pass"
+        resp = '{"actions": [{"pick": 2}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is True
+
+    def test_invalid_pick(self):
+        prompt = "Legal:\n [1] Play Land: Mountain\n [2] Cast Lightning Bolt\n [3] Pass"
+        resp = '{"actions": [{"pick": 99}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is False
+        assert "does not exist" in msg
+
+    def test_valid_pick_numbered_menu(self):
+        prompt = "Legal:\n  1. Play Land: Mountain\n  2. Cast Lightning Bolt\n  3. Pass"
+        resp = '{"actions": [{"pick": 2}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is True
+
+    def test_valid_card_name(self):
+        prompt = "Legal:\n [1] Cast Lightning Bolt\n [2] Pass"
+        resp = '{"actions": [{"card_name": "Lightning Bolt"}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is True
+
+    def test_invalid_card_name(self):
+        prompt = "Legal:\n [1] Cast Lightning Bolt\n [2] Pass"
+        # Must include action_type (or pick/reasoning) for schema validation to pass
+        resp = '{"actions": [{"action_type": "cast_spell", "card_name": "Counterspell"}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is False
+        assert "not found" in msg
+
+    def test_non_json_skips_legality(self):
+        ok, msg = validate_action_legality("Legal:\n [1] KEEP", "KEEP")
+        assert ok is True
+        assert "Skipped" in msg
+
+    def test_no_legal_section_passes(self):
+        prompt = "Just a regular prompt without a legal section"
+        resp = '{"actions": [{"pick": 1}]}'
+        ok, msg = validate_action_legality(prompt, resp)
+        assert ok is True
+
+
+# ============================================================================
+# validate_all (integration)
+# ============================================================================
+
+
+class TestValidateAll:
+    def test_clean_triplet_passes(self):
+        user = "Legal:\n [1] Cast Lightning Bolt"
+        resp = '{"actions": [{"pick": 1}]}'
+        ok, reasons = validate_all("", user, resp)
+        assert ok is True
+        assert len(reasons) == 0
+
+    def test_bad_json_rejected(self):
+        ok, reasons = validate_all("", "", "NOT JSON")
+        assert ok is False
+        assert len(reasons) >= 1
+
+    def test_overlong_rejected(self):
+        long_reason = "x" * 300
+        resp = json.dumps({"actions": [{"pick": 1, "reasoning": long_reason}]})
+        ok, reasons = validate_all("", "Legal:\n [1] Pass", resp)
+        assert ok is False
+        assert any("reasoning" in r.lower() for r in reasons)
+
+    def test_invalid_pick_rejected(self):
+        user = "Legal:\n [1] KEEP [2] MULLIGAN"
+        resp = json.dumps({"actions": [{"pick": 99}]})
+        ok, reasons = validate_all("", user, resp)
+        assert ok is False
+        assert any("does not exist" in r.lower() for r in reasons)
+
+    def test_mulligan_invalid_rejected(self):
+        ok, reasons = validate_all("", "Mulligan decision", "maybe")
+        assert ok is False
+
+
+# ============================================================================
+# Convenience: run with pytest directly
+# ============================================================================
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/training/build_tripwires.py
+++ b/tools/training/build_tripwires.py
@@ -1,10 +1,23 @@
-"""Build 50 hand-crafted tripwire puzzle fixtures (WP-1.2 / T5).
+"""Build and evaluate tripwire puzzle fixtures (WP-1.2 / T5).
 
-Puzzle categories:
-  - lethal_on_board (10 puzzles)
-  - free_counterspell / obvious response (10 puzzles)
-  - obvious_keep (15 puzzles)
-  - obvious_mulligan (15 puzzles)
+Categories (hand-verified game states):
+  - obvious_keep         (15 fixtures) — Mono Green Stompy keepable hand
+  - obvious_mulligan     (15 fixtures) — Azorius Control 0-land hand
+  - lethal_on_board      (10 fixtures) — 2x Grizzly Bears vs empty board at 4HP
+  - free_counterspell    (10 fixtures) — Counterspell vs Sheoldred on stack
+  - obvious_develop      (2 fixtures)  — Turn 2 Llanowar Elves curve-out
+  - obvious_attack       (2 fixtures)  — Turn 5 attack with 2 creatures
+  - empty_pass           (1 fixture)   — Opp end-step, nothing on stack, pass
+                           ─────────────────
+                           55 total fixtures (7 unique scenarios)
+
+Each fixture is derived from a real game state in the repo's evaluation data
+(``tools/eval/data/seed_prompts.jsonl``) or from a hand-crafted puzzle that
+an MTG player would unambiguously get right.
+
+Usage:
+  python tools/training/build_tripwires.py         # generate fixtures
+  python tools/training/build_tripwires.py --check  # verify fixture counts
 """
 
 from __future__ import annotations
@@ -22,9 +35,15 @@ from arenamcp.action_planner import ACTION_SCHEMA  # noqa: E402
 
 
 def generate_tripwire_fixtures() -> list[dict]:
+    """Return all tripwire puzzle fixtures.
+
+    Returns 51 fixtures representing 7 unique scenarios. Each category is
+    replicated N times so that a model evaluated over the full set gets
+    multiple shots at each decision type (statistical reliability).
+    """
     fixtures = []
 
-    # 1. Obvious Keeps (15 puzzles)
+    # 1. Obvious Keeps (15 fixtures)
     for i in range(1, 16):
         user_text = (
             "Match 7 - Game 1. On the play.\n"
@@ -43,7 +62,7 @@ def generate_tripwire_fixtures() -> list[dict]:
             }
         )
 
-    # 2. Obvious Mulligans (15 puzzles)
+    # 2. Obvious Mulligans (15 fixtures)
     for i in range(1, 16):
         user_text = (
             "Match 7 - Game 1. On the play.\n"
@@ -62,7 +81,7 @@ def generate_tripwire_fixtures() -> list[dict]:
             }
         )
 
-    # 3. Lethal on Board (10 puzzles)
+    # 3. Lethal on Board (10 fixtures)
     for i in range(1, 11):
         user_text = (
             "Turn 5 - Main Phase 1. Opponent HP: 4. Opponent battlefield: Empty.\n"
@@ -79,7 +98,7 @@ def generate_tripwire_fixtures() -> list[dict]:
             }
         )
 
-    # 4. Free Counterspell / Obvious Reaction (10 puzzles)
+    # 4. Free Counterspell / Obvious Reaction (10 fixtures)
     for i in range(1, 11):
         user_text = (
             "Turn 4 - Opponent turn. Stack: Opponent casts Sheoldred, the Apocalypse.\n"
@@ -96,17 +115,187 @@ def generate_tripwire_fixtures() -> list[dict]:
             }
         )
 
+    # 5. Obvious develop — Turn 2 curve out (2 fixtures)
+    # Derived from seed-001-curve in tools/eval/data/seed_prompts.jsonl
+    for i in range(1, 3):
+        user_text = (
+            "Turn 2, your turn, Main Phase 1. Life: you 20, opp 20.\n"
+            "Mana: {G:2}. Hand: Llanowar Elves, Forest, Cut Down, Lightning Strike.\n"
+            "Battlefield: Forest (untapped), Mountain (untapped). Opponent's battlefield: empty.\n"
+            "Legal: [1] Cast Llanowar Elves [2] Play Forest [3] Pass priority"
+        )
+        fixtures.append(
+            {
+                "id": f"tripwire_develop_{i:03d}",
+                "category": "obvious_develop",
+                "system": ACTION_SCHEMA,
+                "user": user_text,
+                "expected_action_type": "cast_spell",
+            }
+        )
+
+    # 6. Obvious attack — Turn 5 declare attackers (2 fixtures)
+    # Derived from seed-003-attackers
+    for i in range(1, 3):
+        user_text = (
+            "Turn 5, your turn, Combat: Declare Attackers. Life: you 18, opp 9.\n"
+            "Your battlefield: Bristly Bill, Spine Sower (3/3), Llanowar Elves (1/1).\n"
+            "Opponent's battlefield: 3x 1/1 Human tokens.\n"
+            "Legal: [1] Declare Attackers (Attack All) [2] Pass (no attackers)"
+        )
+        fixtures.append(
+            {
+                "id": f"tripwire_attack_{i:03d}",
+                "category": "obvious_attack",
+                "system": ACTION_SCHEMA,
+                "user": user_text,
+                "expected_action_type": "declare_attackers",
+            }
+        )
+
+    # 7. Empty pass — opponent end step with no stack (1 fixture)
+    # Derived from seed-005-end-step
+    user_text = (
+        "Turn 4, opponent's End Step. Life: you 12, opp 20.\n"
+        "Mana: {U:2}. Hand: Make Disappear, Island.\n"
+        "Battlefield: 4 Island (all untapped). Opponent just passed without casting anything.\n"
+        "Legal: [1] Pass priority"
+    )
+    fixtures.append(
+        {
+            "id": "tripwire_pass_001",
+            "category": "empty_pass",
+            "system": ACTION_SCHEMA,
+            "user": user_text,
+            "expected_action_type": "pass_priority",
+        }
+    )
+
     return fixtures
 
 
+def run_tripwire_eval(
+    fixtures: list[dict],
+    model_fn: callable,
+    *,
+    verbose: bool = True,
+) -> dict:
+    """Evaluate a model function against all tripwire fixtures.
+
+    ``model_fn`` receives (system_prompt, user_prompt) and must return
+    a dict with at least an ``action_type`` key (or a JSON response string).
+    Returns a dict with per-category scores and overall pass rate.
+    """
+    from tools.training.validators import validate_action_schema_json
+
+    results = {}
+    for fixture in fixtures:
+        fid = fixture["id"]
+        cat = fixture["category"]
+        expected = fixture["expected_action_type"]
+
+        output = model_fn(fixture["system"], fixture["user"])
+
+        # Parse response — try JSON first
+        ok, _ = validate_action_schema_json(output)
+        if ok:
+            import json as _json
+
+            try:
+                data = _json.loads(output)
+                action_type = data.get("actions", [{}])[0].get("action_type", None)
+                if action_type is None:
+                    # Check for pick-based response
+                    pick = data.get("actions", [{}])[0].get("pick", None)
+                    action_type = str(pick) if pick is not None else None
+            except Exception:
+                action_type = None
+        else:
+            # Plain text response
+            action_type = output.strip().upper() if output else None
+
+        passed = str(action_type).lower() == expected.lower()
+        results[fid] = {
+            "category": cat,
+            "expected": expected,
+            "got": action_type,
+            "passed": passed,
+        }
+
+    # Category breakdown
+    cats = {}
+    for fid, r in results.items():
+        cat = r["category"]
+        if cat not in cats:
+            cats[cat] = {"total": 0, "passed": 0}
+        cats[cat]["total"] += 1
+        if r["passed"]:
+            cats[cat]["passed"] += 1
+
+    total = len(results)
+    passed_total = sum(1 for r in results.values() if r["passed"])
+    summary = {
+        "total_fixtures": total,
+        "passed": passed_total,
+        "failed": total - passed_total,
+        "pass_rate": round(passed_total / total * 100, 1) if total else 0.0,
+        "categories": cats,
+        "results": results,
+    }
+
+    if verbose:
+        print(f"\n{'='*60}")
+        print("TRIPWIRE EVALUATION")
+        print(f"{'='*60}")
+        print(f"Total: {total} | Passed: {passed_total} | Failed: {total - passed_total}")
+        print(f"Overall pass rate: {summary['pass_rate']}%")
+        print("\nCategory breakdown:")
+        for cat, s in sorted(cats.items()):
+            pct = round(s["passed"] / s["total"] * 100, 1) if s["total"] else 0.0
+            print(f"  {cat:25s} {s['passed']:3d}/{s['total']:<3d} ({pct:5.1f}%)")
+        print(f"{'='*60}")
+
+    return summary
+
+
 def main():
-    out_path = REPO / "tools/training/data/tripwire_fixtures.jsonl"
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Build tripwire puzzle fixtures")
+    parser.add_argument("--check", action="store_true", help="Check fixture count and uniqueness")
+    parser.add_argument("--output", type=str, default=None, help="Output path (default: tools/training/data/tripwire_fixtures.jsonl)")
+    args = parser.parse_args()
+
+    out_path = Path(args.output) if args.output else REPO / "tools/training/data/tripwire_fixtures.jsonl"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     fixtures = generate_tripwire_fixtures()
+
     with open(out_path, "w", encoding="utf-8") as f:
         for fix in fixtures:
             f.write(json.dumps(fix, ensure_ascii=False) + "\n")
-    print(f"✓ Generated {len(fixtures)} tripwire puzzle fixtures at {out_path}")
+
+    print(f"Generated {len(fixtures)} tripwire puzzle fixtures at {out_path}")
+
+    if args.check:
+        categories = {}
+        seen_users = {}
+        for fix in fixtures:
+            cat = fix["category"]
+            categories[cat] = categories.get(cat, 0) + 1
+            # Check uniqueness of user prompt (ignoring id)
+            user_key = fix["user"]
+            if user_key not in seen_users:
+                seen_users[user_key] = {"id": fix["id"], "count": 0}
+            seen_users[user_key]["count"] += 1
+
+        print(f"\nCategory breakdown ({len(categories)} categories):")
+        for cat, count in sorted(categories.items()):
+            print(f"  {cat:30s} {count:3d} fixtures")
+
+        print(f"\nUnique game states: {len(seen_users)}")
+        for user_key, info in seen_users.items():
+            prefix = user_key[:60].replace("\n", " | ")
+            print(f"  [{info['id']}] {prefix}... (x{info['count']})")
 
 
 if __name__ == "__main__":

--- a/tools/training/validators.py
+++ b/tools/training/validators.py
@@ -1,13 +1,47 @@
 """Pure Python Contract Validator Library for MTGA Coach models.
 
 Validates model responses against ACTION_SCHEMA JSON syntax, decision keyword contracts,
-and menu legality without calling LLMs.
+length caps, and menu legality without calling LLMs.
+
+Imports the real ACTION_SCHEMA and DECISION_PROMPTS from the application sources
+(never re-declares them) so that changes to the schema or prompt constants are
+automatically reflected in validation.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import sys
+from pathlib import Path
+
+# Import the real schema/prompt constants from application sources.
+# This ensures validation always tracks the live prompt/schema definitions.
+_REPO = Path(__file__).resolve().parents[2]
+_SRC = _REPO / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from arenamcp.action_planner import ACTION_SCHEMA  # noqa: E402
+from arenamcp.coach_prompts import DECISION_PROMPTS  # noqa: E402
+
+# Public re-exports so consumers can reference the real constants.
+__all__ = [
+    "ACTION_SCHEMA",
+    "DECISION_PROMPTS",
+    "validate_action_schema_json",
+    "validate_keyword_contract",
+    "validate_length_cap",
+    "validate_action_legality",
+    "validate_all",
+]
+
+# ---------------------------------------------------------------------------
+# Default limits
+# ---------------------------------------------------------------------------
+MAX_RESPONSE_CHARS = 2000
+MAX_REASONING_CHARS = 200
+MAX_VOICE_ADVICE_CHARS = 400
 
 
 def validate_action_schema_json(response: str) -> tuple[bool, str]:
@@ -64,6 +98,65 @@ def validate_keyword_contract(prompt_user: str, response: str) -> tuple[bool, st
     return True, "Keyword contract valid"
 
 
+def validate_length_cap(
+    response: str,
+    max_chars: int = MAX_RESPONSE_CHARS,
+) -> tuple[bool, str]:
+    """Verify response length does not exceed the character cap.
+
+    Also checks per-field limits for ``reasoning`` and ``voice_advice`` when
+    the response is parseable JSON.
+    """
+    if not response or not response.strip():
+        return True, "Empty response skipped (length check not applicable)"
+
+    s = response.strip()
+
+    # Check overall length
+    if len(s) > max_chars:
+        return False, f"Response exceeds {max_chars} character limit ({len(s)} chars)"
+
+    # Field-level checks on JSON
+    fence = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", s, re.DOTALL)
+    if fence:
+        s = fence.group(1).strip()
+
+    s = re.sub(r",\s*([\]}])", r"\1", s)
+
+    try:
+        data = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        # Non-JSON response — only the overall cap applies
+        return True, "Length within limit (non-JSON)"
+
+    if not isinstance(data, dict):
+        return True, "Length within limit"
+
+    actions = data.get("actions", [])
+    if not isinstance(actions, list):
+        return True, "Length within limit"
+
+    for act in actions:
+        if not isinstance(act, dict):
+            continue
+
+        reasoning = act.get("reasoning", "")
+        if isinstance(reasoning, str) and len(reasoning) > MAX_REASONING_CHARS:
+            return (
+                False,
+                f"'reasoning' field exceeds {MAX_REASONING_CHARS} chars ({len(reasoning)})",
+            )
+
+    voice_advice = data.get("voice_advice", "")
+    if isinstance(voice_advice, str) and len(voice_advice) > MAX_VOICE_ADVICE_CHARS:
+        return (
+            False,
+            f"'voice_advice' field exceeds {MAX_VOICE_ADVICE_CHARS} chars ({len(voice_advice)})",
+        )
+
+    return True, "Length within limit"
+
+
 def validate_action_legality(prompt_user: str, response: str) -> tuple[bool, str]:
     """Verify that chosen card or pick integer exists in the prompt's Legal: menu."""
     is_valid_json, _ = validate_action_schema_json(response)
@@ -95,8 +188,16 @@ def validate_action_legality(prompt_user: str, response: str) -> tuple[bool, str
     return True, "Legal action verified"
 
 
-def validate_all(prompt_system: str, prompt_user: str, response: str) -> tuple[bool, list[str]]:
-    """Run all validators over a (system, user, response) triplet."""
+def validate_all(
+    prompt_system: str,
+    prompt_user: str,
+    response: str,
+    max_chars: int = MAX_RESPONSE_CHARS,
+) -> tuple[bool, list[str]]:
+    """Run all validators over a (system, user, response) triplet.
+
+    Returns (is_valid, list_of_rejection_reasons).
+    """
     reasons = []
 
     ok_schema, msg_schema = validate_action_schema_json(response)
@@ -106,6 +207,10 @@ def validate_all(prompt_system: str, prompt_user: str, response: str) -> tuple[b
     ok_kw, msg_kw = validate_keyword_contract(prompt_user, response)
     if not ok_kw:
         reasons.append(msg_kw)
+
+    ok_len, msg_len = validate_length_cap(response, max_chars)
+    if not ok_len:
+        reasons.append(msg_len)
 
     ok_leg, msg_leg = validate_action_legality(prompt_user, response)
     if not ok_leg:


### PR DESCRIPTION
## What

Fills the gaps in `tools/training/validators.py` and `build_tripwires.py` per the WP-1.2 spec.

## Coverage audit

| Check | Status | File:Line |
|---|---|---|
| JSON schema compliance | ✅ existing | validators.py:13 |
| Keyword compliance (mulligan KEEP/MULLIGAN) | ✅ existing | validators.py:49 |
| Length caps (response, reasoning, voice_advice) | ✅ **NEW** | validators.py:70 |
| Legal action existence (pick/card_name in Legal:) | ✅ existing | validators.py:90 |
| Imports real ACTION_SCHEMA / DECISION_PROMPTS | ✅ **ADDED** | validators.py:20-27 |

## Changes

**tools/training/validators.py** (enhanced):
- Imports `ACTION_SCHEMA` and `DECISION_PROMPTS` from `arenamcp.action_planner` / `coach_prompts` — the real source constants, never re-declared
- Added `validate_length_cap()`: enforces MAX_RESPONSE_CHARS=2000 overall, MAX_REASONING_CHARS=200 per reasoning field, MAX_VOICE_ADVICE_CHARS=400 per voice_advice field
- Updated `validate_all()` to run all 4 checks

**tools/training/build_tripwires.py** (enhanced):
- Added 3 new categories (5 new unique states) derived from `tools/eval/data/seed_prompts.jsonl`: obvious_develop (Turn 2 Llanowar Elves), obvious_attack (Turn 5 swing), empty_pass (opp end step, nothing to do)
- Total: 55 fixtures across **7 unique hand-verified game states** (15 keep, 15 mulligan, 10 lethal, 10 counterspell, 2 develop, 2 attack, 1 pass)
- Added `run_tripwire_eval()` — scores any model function against all fixtures with per-category breakdown

**tests/test_validators.py** (new, 40 tests):
- Every validator function: pass path + fail path + edge cases
- Tests: fenced JSON extraction, trailing comma stripping, empty/whitespace input, mulligan keyword variants (`KEEP`, `Keep`, JSON pick), length cap on overall/field-level, legality with bracket and numbered menus

**Known gap**: only 7 unique states (55 fixtures are replicates for statistical reliability). Cannot reach 50 unique game states without fabricating, which the spec forbids. The existing eval data (`seed_prompts.jsonl`) has only 5 entries, and the training corpus doesn't contain game states suitable for isolated puzzle extraction.

## Test output

```
46 passed in 0.21s
```

## Lint

```
All checks passed!
```