### PR TITLE
combat-guard-fix: guard only applies to constant-policy classes

### DIFF
--- a/tests/test_combat_balance.py
+++ b/tests/test_combat_balance.py
@@ -22,6 +22,7 @@ for _p in (str(SRC), str(REPO)):
         sys.path.insert(0, _p)
 
 from tools.training.build_magezero_combat import (
+    CONSTANT_POLICY_CLASSES,
     _class_histogram,
     _check_class_share,
     _downsample,
@@ -42,13 +43,15 @@ def skewed_block_records() -> list[dict]:
             cls = "partial_block"
         else:
             cls = "block_all"
-        recs.append({
-            "id": f"mzc-skewed-{i:04d}",
-            "kind": "combat_block",
-            "meta": {"block_class": cls},
-            "user": "",
-            "response": "{}",
-        })
+        recs.append(
+            {
+                "id": f"mzc-skewed-{i:04d}",
+                "kind": "combat_block",
+                "meta": {"block_class": cls},
+                "user": "",
+                "response": "{}",
+            }
+        )
     return recs
 
 
@@ -63,39 +66,54 @@ def balanced_block_records() -> list[dict]:
             cls = "partial_block"
         else:
             cls = "block_all"
-        recs.append({
-            "id": f"mzc-balanced-{i:04d}",
-            "kind": "combat_block",
-            "meta": {"block_class": cls},
-            "user": "",
-            "response": "{}",
-        })
+        recs.append(
+            {
+                "id": f"mzc-balanced-{i:04d}",
+                "kind": "combat_block",
+                "meta": {"block_class": cls},
+                "user": "",
+                "response": "{}",
+            }
+        )
     return recs
 
 
 @pytest.fixture
-def mixed_records(skewed_block_records) -> list[dict]:
-    """Add 104 attack records (98 proper_subset + 6 all_in) to the block fixture."""
-    recs = list(skewed_block_records)
+def skewed_attack_records() -> list[dict]:
+    """104 attack records: 98 proper_subset (94.2%), 6 all_in (5.8%).
+
+    No constant-policy attack class (no_attack, all_in) is dominant —
+    this simulates the real corpus where guard should NOT fire.
+    """
+    recs: list[dict] = []
     for i in range(104):
         cls = "proper_subset" if i < 98 else "all_in"
-        recs.append({
-            "id": f"mzc-mix-atk-{i:04d}",
-            "kind": "combat_attack",
-            "meta": {"attack_class": cls},
-            "user": "",
-            "response": "{}",
-        })
+        recs.append(
+            {
+                "id": f"mzc-skewed-atk-{i:04d}",
+                "kind": "combat_attack",
+                "meta": {"attack_class": cls},
+                "user": "",
+                "response": "{}",
+            }
+        )
     return recs
 
 
-# ── Guard fires on skewed fixture ──────────────────────────────────────────
+@pytest.fixture
+def mixed_records(skewed_block_records, skewed_attack_records) -> list[dict]:
+    """Combine block + attack skew fixtures for integration tests."""
+    return list(skewed_block_records) + list(skewed_attack_records)
+
+
+# ── Guard fires on skewed block (constant-policy class) ─────────────────────
 
 
 def test_guard_fires_on_skewed_block(skewed_block_records) -> None:
     """_check_class_share raises SystemExit for block class > 0.50."""
     hist = _class_histogram(
-        skewed_block_records, "block_class",
+        skewed_block_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
     with pytest.raises(SystemExit) as exc:
@@ -105,23 +123,49 @@ def test_guard_fires_on_skewed_block(skewed_block_records) -> None:
     assert "71.8%" in msg or "71.79%" in msg or "71.8" in msg
 
 
-def test_guard_fires_on_skewed_attack(mixed_records) -> None:
-    """_check_class_share raises SystemExit for attack class > 0.50."""
+def test_guard_ignores_proper_subset_skew(skewed_attack_records) -> None:
+    """_check_class_share does NOT raise for 94.2 % proper_subset.
+
+    proper_subset is NOT a constant-policy class — the model must still
+    choose WHICH creatures, so high share there is harmless.  The guard
+    only fires on constant-policy classes.
+    """
     hist = _class_histogram(
-        mixed_records, "attack_class",
+        skewed_attack_records,
+        "attack_class",
         lambda r: r.get("kind") == "combat_attack",
     )
+    assert hist[0][0] == "proper_subset"
+    assert hist[0][2] > 0.50  # 94.2% — well over threshold
+    # Should NOT raise — proper_subset is not guard-eligible
+    _check_class_share(hist, 0.50, "attack")
+
+
+def test_guard_fires_on_no_block_skew(skewed_block_records) -> None:
+    """_check_class_share raises SystemExit for 71.8 % no_block.
+
+    no_block IS a constant-policy class — this is the exact skew that
+    blocked the previous combat candidate.  71.8 % exceeds the 69 %
+    always_no_block floor, proving the model can answer without reading
+    the board.
+    """
+    hist = _class_histogram(
+        skewed_block_records,
+        "block_class",
+        lambda r: r.get("kind") == "combat_block",
+    )
     with pytest.raises(SystemExit) as exc:
-        _check_class_share(hist, 0.50, "attack")
+        _check_class_share(hist, 0.50, "block")
     msg = str(exc.value)
-    assert "proper_subset" in msg
-    assert "FAIL-CLOSED" in msg
+    assert "no_block" in msg
+    assert "71.8%" in msg or "71.79%" in msg or "71.8" in msg
 
 
 def test_guard_passes_on_balanced(balanced_block_records) -> None:
     """_check_class_share does NOT raise for balanced distributions."""
     hist = _class_histogram(
-        balanced_block_records, "block_class",
+        balanced_block_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
     # Each class is 33.3% — well under 0.50, so no SystemExit
@@ -135,7 +179,8 @@ def test_guard_passes_on_balanced(balanced_block_records) -> None:
 def test_histogram_shares_sum_to_one(skewed_block_records) -> None:
     """Shares in the histogram should sum to 1.0 (within rounding)."""
     hist = _class_histogram(
-        skewed_block_records, "block_class",
+        skewed_block_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
     total_share = sum(share for _, _, share in hist)
@@ -145,13 +190,12 @@ def test_histogram_shares_sum_to_one(skewed_block_records) -> None:
 def test_histogram_sorted_descending(skewed_block_records) -> None:
     """Histogram items sorted by share descending."""
     hist = _class_histogram(
-        skewed_block_records, "block_class",
+        skewed_block_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
     shares = [s for _, _, s in hist]
-    assert shares == sorted(shares, reverse=True), (
-        f"histogram not sorted descending: {shares}"
-    )
+    assert shares == sorted(shares, reverse=True), f"histogram not sorted descending: {shares}"
 
 
 # ── Downsample determinism and correctness ─────────────────────────────────
@@ -160,11 +204,13 @@ def test_histogram_sorted_descending(skewed_block_records) -> None:
 def test_downsample_deterministic(mixed_records) -> None:
     """Two downsample runs with the same seed produce the same kept record ids."""
     hist_a = _class_histogram(
-        mixed_records, "attack_class",
+        mixed_records,
+        "attack_class",
         lambda r: r.get("kind") == "combat_attack",
     )
     hist_b = _class_histogram(
-        mixed_records, "block_class",
+        mixed_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
 
@@ -179,17 +225,17 @@ def test_downsample_deterministic(mixed_records) -> None:
 def test_downsample_reduces_majority(mixed_records) -> None:
     """After downsampling, no class exceeds 0.50 share."""
     hist_a = _class_histogram(
-        mixed_records, "attack_class",
+        mixed_records,
+        "attack_class",
         lambda r: r.get("kind") == "combat_attack",
     )
     hist_b = _class_histogram(
-        mixed_records, "block_class",
+        mixed_records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
 
-    balanced = _downsample(
-        copy.deepcopy(mixed_records), hist_a, hist_b, 0.50
-    )
+    balanced = _downsample(copy.deepcopy(mixed_records), hist_a, hist_b, 0.50)
 
     for kind_field, meta_field in [
         ("combat_attack", "attack_class"),
@@ -201,9 +247,7 @@ def test_downsample_reduces_majority(mixed_records) -> None:
         counts = Counter(r["meta"][meta_field] for r in subset)
         for cls, n in counts.items():
             share = n / total
-            assert share <= 0.50 + 0.01, (
-                f"{cls} in {kind_field} is {share:.1%} after downsample"
-            )
+            assert share <= 0.50 + 0.01, f"{cls} in {kind_field} is {share:.1%} after downsample"
 
 
 def test_downsample_clamps_below_one() -> None:
@@ -211,28 +255,25 @@ def test_downsample_clamps_below_one() -> None:
     recs: list[dict] = []
     for i in range(10):
         cls = "no_block" if i < 9 else "partial_block"
-        recs.append({
-            "id": f"mzc-clamp-{i:04d}",
-            "kind": "combat_block",
-            "meta": {"block_class": cls},
-            "user": "",
-            "response": "{}",
-        })
+        recs.append(
+            {
+                "id": f"mzc-clamp-{i:04d}",
+                "kind": "combat_block",
+                "meta": {"block_class": cls},
+                "user": "",
+                "response": "{}",
+            }
+        )
     hist = _class_histogram(
-        recs, "block_class",
+        recs,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
     result = _downsample(recs, [], hist, 0.50)
     # partial_block has 1 record — must still be present
-    partial_ids = [
-        r["id"] for r in result
-        if r["meta"].get("block_class") == "partial_block"
-    ]
+    partial_ids = [r["id"] for r in result if r["meta"].get("block_class") == "partial_block"]
     assert len(partial_ids) == 1, "minority class was lost"
-    no_block_ids = [
-        r["id"] for r in result
-        if r["meta"].get("block_class") == "no_block"
-    ]
+    no_block_ids = [r["id"] for r in result if r["meta"].get("block_class") == "no_block"]
     # no_block should be downsampled from 9 toward 1 (can't go below 1)
     assert len(no_block_ids) >= 1
     assert len(no_block_ids) < 9, "majority class was not reduced"

--- a/tools/training/build_magezero_combat.py
+++ b/tools/training/build_magezero_combat.py
@@ -65,9 +65,11 @@ for _p in (str(SRC), str(REPO)):
 
 # ── Import AUTOPILOT_SYSTEM_PROMPT via importlib (avoids PySide6 cascade) ──
 
+
 def _load_autopilot_system_prompt() -> str:
     import importlib.util
     import types
+
     if "arenamcp" not in sys.modules:
         pkg = types.ModuleType("arenamcp")
         pkg.__path__ = [str(SRC / "arenamcp")]
@@ -76,9 +78,7 @@ def _load_autopilot_system_prompt() -> str:
         sys.modules["arenamcp"] = pkg
     bh_path = SRC / "arenamcp" / "backend_health.py"
     if "arenamcp.backend_health" not in sys.modules:
-        spec_h = importlib.util.spec_from_file_location(
-            "arenamcp.backend_health", str(bh_path)
-        )
+        spec_h = importlib.util.spec_from_file_location("arenamcp.backend_health", str(bh_path))
         assert spec_h is not None, f"cannot find backend_health.py at {bh_path}"
         mod_h = importlib.util.module_from_spec(spec_h)
         mod_h.__package__ = "arenamcp"
@@ -86,9 +86,7 @@ def _load_autopilot_system_prompt() -> str:
         spec_h.loader.exec_module(mod_h)
     ap_path = SRC / "arenamcp" / "action_planner.py"
     if "arenamcp.action_planner" not in sys.modules:
-        spec_a = importlib.util.spec_from_file_location(
-            "arenamcp.action_planner", str(ap_path)
-        )
+        spec_a = importlib.util.spec_from_file_location("arenamcp.action_planner", str(ap_path))
         assert spec_a is not None, f"cannot find action_planner.py at {ap_path}"
         mod_a = importlib.util.module_from_spec(spec_a)
         mod_a.__package__ = "arenamcp"
@@ -96,7 +94,24 @@ def _load_autopilot_system_prompt() -> str:
         spec_a.loader.exec_module(mod_a)
     return sys.modules["arenamcp.action_planner"].AUTOPILOT_SYSTEM_PROMPT
 
+
 AUTOPILOT_SYSTEM_PROMPT = _load_autopilot_system_prompt()
+
+# ── Constant-policy classes (guard-eligible) ──────────────────────────────
+
+CONSTANT_POLICY_CLASSES: frozenset[str] = frozenset(
+    {
+        "no_block",
+        "block_all",
+        "all_in",
+        "no_attack",
+    }
+)
+"""Classes that are CONSTANT POLICIES — the model can answer without reading
+the board (always block nothing, always block everything, attack with all,
+attack with none).  Their share IS the score a do-nothing model achieves.
+``proper_subset`` and ``partial_block`` are NOT single answers — the model
+must still choose WHICH creatures — so high share there is harmless."""
 
 # ── Import from the combat corpus builder (never re-implement) ─────────────
 
@@ -115,21 +130,69 @@ from tools.training.build_combat_decisions import (  # noqa: E402
 
 # Best-effort land detection — only needed to exclude lands from the
 # attack/block pool (MZ data has no grp_ids or type lines).
-_BASIC_LANDS = frozenset({
-    "Plains", "Island", "Swamp", "Mountain", "Forest",
-    "Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
-    "Snow-Covered Mountain", "Snow-Covered Forest", "Wastes",
-})
-_LAND_SUFFIXES = ("Land", "lands", "Verge", "Heath", "Foothills", "Delta",
-                  "Strand", "Mire", "Catacombs", "Meadow", "Pool", "Grove",
-                  "Garden", "Tomb", "Node", "Spire", "Cavern", "Passage",
-                  "Factory", "Opal", "Citadel", "Sanctum", "Archive",
-                  "Crossroads", "Hideout", "Shrine", "Village", "Mine",
-                  "Foundry", "Den", "Expanse", "Reach", "Canopy", "Vista",
-                  "Basin", "Fortress", "Cave", "Crater", "Bridge", "Vale",
-                  "Confluence", "Borough", "Hub", "Borderpost", "Column")
-_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's",
-                       "Corrupted", "Darksteel")
+_BASIC_LANDS = frozenset(
+    {
+        "Plains",
+        "Island",
+        "Swamp",
+        "Mountain",
+        "Forest",
+        "Snow-Covered Plains",
+        "Snow-Covered Island",
+        "Snow-Covered Swamp",
+        "Snow-Covered Mountain",
+        "Snow-Covered Forest",
+        "Wastes",
+    }
+)
+_LAND_SUFFIXES = (
+    "Land",
+    "lands",
+    "Verge",
+    "Heath",
+    "Foothills",
+    "Delta",
+    "Strand",
+    "Mire",
+    "Catacombs",
+    "Meadow",
+    "Pool",
+    "Grove",
+    "Garden",
+    "Tomb",
+    "Node",
+    "Spire",
+    "Cavern",
+    "Passage",
+    "Factory",
+    "Opal",
+    "Citadel",
+    "Sanctum",
+    "Archive",
+    "Crossroads",
+    "Hideout",
+    "Shrine",
+    "Village",
+    "Mine",
+    "Foundry",
+    "Den",
+    "Expanse",
+    "Reach",
+    "Canopy",
+    "Vista",
+    "Basin",
+    "Fortress",
+    "Cave",
+    "Crater",
+    "Bridge",
+    "Vale",
+    "Confluence",
+    "Borough",
+    "Hub",
+    "Borderpost",
+    "Column",
+)
+_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's", "Corrupted", "Darksteel")
 
 
 def _is_land(name: str) -> bool:
@@ -169,6 +232,7 @@ def _known_combat_state(name: str) -> bool:
 
 # ── Name disambiguation (matches build_combat_decisions.disambiguate) ──────
 
+
 def _disambiguate(names: list[str]) -> list[str]:
     """Byte-identical to build_combat_decisions.disambiguate."""
     counts = Counter(names)
@@ -184,6 +248,7 @@ def _disambiguate(names: list[str]) -> list[str]:
 
 
 # ── Response formatters (thin wrappers matching build_combat_decisions) ────
+
 
 def _attack_response(names: list[str]) -> str:
     return json.dumps(
@@ -201,6 +266,7 @@ def _block_response(assignments: dict[str, str]) -> str:
 
 # ── System prompt builder (matches build_combat_decisions.build_system) ────
 
+
 def _build_system(kind: str) -> str:
     addendum = ATTACK_ADDENDUM if kind == "attack" else BLOCK_ADDENDUM
     addendum += NO_SOLVER_ADDENDUM
@@ -209,6 +275,7 @@ def _build_system(kind: str) -> str:
 
 
 # ── User prompt builders ───────────────────────────────────────────────────
+
 
 def _user_prompt_attack(
     row: dict,
@@ -301,6 +368,7 @@ def _board_lines(row: dict, side: str) -> list[str]:
 
 # ── Record construction ────────────────────────────────────────────────────
 
+
 def _rid(key: str) -> str:
     return f"mzc-{hashlib.sha1(key.encode()).hexdigest()[:16]}"
 
@@ -375,9 +443,7 @@ def build_attack_record(row: dict) -> tuple[dict | None, str]:
         # a priority action during combat, not a combat decision.
         return None, "attack_no_declared"
 
-    declared = _match_declared_to_pool(
-        [n for n, _ in self_raw], pool, declared_raw
-    )
+    declared = _match_declared_to_pool([n for n, _ in self_raw], pool, declared_raw)
 
     user = _user_prompt_attack(row, pool, declared)
     rec = {
@@ -411,8 +477,9 @@ def build_attack_record(row: dict) -> tuple[dict | None, str]:
     }
     # Prove no solver line and no mcts_counts in the prompt
     assert "Computed optimal" not in rec["user"], "solver line leaked into prompt"
-    assert "count" not in rec["user"].lower() or "discard" not in rec["user"].lower(), \
+    assert "count" not in rec["user"].lower() or "discard" not in rec["user"].lower(), (
         "mcts_counts may have leaked"
+    )
     return rec, ""
 
 
@@ -467,12 +534,8 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
     # attackers for THIS blockers decision are the opp creatures with
     # ,attacking — but in this pattern, no opp creature has ,attacking.
     # We cannot determine the blocking assignment from ambiguous markers.
-    self_attacking = any(
-        _is_attacking(p["name"]) for p in row.get("battlefield_self", [])
-    )
-    opp_blocking = any(
-        _is_blocking(p["name"]) for p in row.get("battlefield_opp", [])
-    )
+    self_attacking = any(_is_attacking(p["name"]) for p in row.get("battlefield_self", []))
+    opp_blocking = any(_is_blocking(p["name"]) for p in row.get("battlefield_opp", []))
     if self_attacking and opp_blocking:
         return None, "block_reversed_markers_ambiguous"
 
@@ -480,8 +543,7 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
         # No blockers declared — opponent's attackers are known
         if not opp_attackers:
             return None, "block_no_attackers_either"
-        user = _user_prompt_block(row, blocker_pool,
-                                   opp_attackers, {})
+        user = _user_prompt_block(row, blocker_pool, opp_attackers, {})
         rec = {
             "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
             "system": _build_system("block"),
@@ -518,14 +580,11 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
         return None, f"block_{len(opp_attackers)}_attackers_cannot_pair"
 
     # Match declared blockers against the pool for correct disambiguation
-    declared_blockers = _match_declared_to_pool(
-        blocker_pool_raw, blocker_pool, self_blockers_raw
-    )
+    declared_blockers = _match_declared_to_pool(blocker_pool_raw, blocker_pool, self_blockers_raw)
     target_name = opp_attackers[0]
     assignments = {b: target_name for b in declared_blockers}
 
-    user = _user_prompt_block(row, blocker_pool,
-                               opp_attackers, assignments)
+    user = _user_prompt_block(row, blocker_pool, opp_attackers, assignments)
     rec = {
         "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
         "system": _build_system("block"),
@@ -584,27 +643,45 @@ def _class_histogram(
 
 
 def _check_class_share(
-    hist: list[tuple[str, int, float]], max_share: float, label: str
+    hist: list[tuple[str, int, float]],
+    max_share: float,
+    label: str,
+    guard_classes: frozenset[str] | None = None,
 ) -> None:
-    """Raise SystemExit if any class in *hist* exceeds *max_share*."""
+    """Raise SystemExit if a guard-eligible class in *hist* exceeds *max_share*.
+
+    Only classes in *guard_classes* trigger the fail-closed guard — these are
+    CONSTANT POLICIES (no_block, block_all, all_in, no_attack) whose share IS
+    the score a do-nothing model achieves.  Classes like proper_subset and
+    partial_block are reported but never abort the build.
+    """
     if not hist:
         return
-    max_item = hist[0]  # sorted descending
-    cls, n, share = max_item
-    if share > max_share:
-        lines = [
-            f"\nFAIL-CLOSED: {label} class '{cls}' is "
-            f"{share:.1%} ({n}/{sum(h[1] for h in hist)}) — "
-            f"exceeds --max-class-share={max_share:.0%}",
-            f"  Full histogram:",
-        ]
-        for c, nn, s in hist:
-            lines.append(f"    {c}: {nn} ({s:.1%})")
-        lines.append(
-            "  Pass --allow-skewed to build anyway, or use "
-            "--balance downsample."
-        )
-        raise SystemExit("\n".join(lines))
+    if guard_classes is None:
+        guard_classes = CONSTANT_POLICY_CLASSES
+
+    # Filter to guard-eligible classes, find the one with the highest share
+    eligible = [(c, n, s) for c, n, s in hist if c in guard_classes]
+    if not eligible:
+        return
+
+    culprit_cls, culprit_n, culprit_share = max(eligible, key=lambda x: x[2])
+    if culprit_share <= max_share:
+        return
+
+    total = sum(h[1] for h in hist)
+    lines = [
+        f"\nFAIL-CLOSED: {label} class '{culprit_cls}' is "
+        f"{culprit_share:.1%} ({culprit_n}/{total}) — "
+        f"exceeds --max-class-share={max_share:.0%}",
+        f"  Guard-eligible classes: {sorted(guard_classes)}",
+        "  Full histogram:",
+    ]
+    for c, nn, s in hist:
+        marker = " *" if c in guard_classes else ""
+        lines.append(f"    {c}: {nn:>4d} ({s:.1%}){marker}")
+    lines.append("  Pass --allow-skewed to build anyway, or use --balance downsample.")
+    raise SystemExit("\n".join(lines))
 
 
 def _downsample(
@@ -639,8 +716,7 @@ def _downsample(
         if max_share <= threshold:
             kept.extend(subset)
             print(
-                f"  [{kind_val}] no class exceeds {threshold:.0%}, "
-                f"keeping all {len(subset)}",
+                f"  [{kind_val}] no class exceeds {threshold:.0%}, keeping all {len(subset)}",
                 file=sys.stderr,
             )
             continue
@@ -657,14 +733,8 @@ def _downsample(
             kept.extend(subset)
             continue
 
-        majority_recs = [
-            r for r in subset
-            if r["meta"].get(meta_class_field, "") == max_class
-        ]
-        non_majority = [
-            r for r in subset
-            if r["meta"].get(meta_class_field, "") != max_class
-        ]
+        majority_recs = [r for r in subset if r["meta"].get(meta_class_field, "") == max_class]
+        non_majority = [r for r in subset if r["meta"].get(meta_class_field, "") != max_class]
 
         rng.shuffle(majority_recs)
         keep_count = len(majority_recs) - to_drop
@@ -680,6 +750,7 @@ def _downsample(
         kept.extend(keep_majority)
 
     return kept
+
 
 def _read_jsonl(path: Path) -> list[dict]:
     out: list[dict] = []
@@ -704,20 +775,32 @@ def main(argv: list[str] | None = None) -> int:
         description="Build combat-gate-shaped records from MageZero decisions JSONL.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--in", dest="input", type=Path, required=True,
-                        help="Path to decisions JSONL (MageZero schema)")
-    parser.add_argument("--out", dest="output", type=Path, required=True,
-                        help="Path to write training records JSONL")
-    parser.add_argument("--report", action="store_true",
-                        help="Print build report to stderr on completion")
-    parser.add_argument("--max-class-share", type=float, default=0.50,
-                        help="Maximum allowed share of any single class "
-                             "(default: 0.50).  Build aborts if exceeded.")
-    parser.add_argument("--allow-skewed", action="store_true",
-                        help="Skip the fail-closed class-share guard")
-    parser.add_argument("--balance", choices=("downsample",), default=None,
-                        help="Downsample the majority class toward the "
-                             "threshold (deterministic, seed=7)")
+    parser.add_argument(
+        "--in", dest="input", type=Path, required=True, help="Path to decisions JSONL (MageZero schema)"
+    )
+    parser.add_argument(
+        "--out", dest="output", type=Path, required=True, help="Path to write training records JSONL"
+    )
+    parser.add_argument("--report", action="store_true", help="Print build report to stderr on completion")
+    parser.add_argument(
+        "--max-class-share",
+        type=float,
+        default=0.50,
+        help="Maximum allowed share of any single class (default: 0.50).  Build aborts if exceeded.",
+    )
+    parser.add_argument("--allow-skewed", action="store_true", help="Skip the fail-closed class-share guard")
+    parser.add_argument(
+        "--guard-classes",
+        type=str,
+        default=None,
+        help="Comma-separated class names the guard checks (default: no_block,block_all,all_in,no_attack)",
+    )
+    parser.add_argument(
+        "--balance",
+        choices=("downsample",),
+        default=None,
+        help="Downsample the majority class toward the threshold (deterministic, seed=7)",
+    )
     args = parser.parse_args(argv)
 
     t0 = time.time()
@@ -758,30 +841,36 @@ def main(argv: list[str] | None = None) -> int:
     # ── Class-histogram guard -------------------------------------------------
 
     attack_hist = _class_histogram(
-        records, "attack_class",
+        records,
+        "attack_class",
         lambda r: r.get("kind") == "combat_attack",
     )
     block_hist = _class_histogram(
-        records, "block_class",
+        records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
 
     if not args.allow_skewed:
-        _check_class_share(attack_hist, args.max_class_share, "attack")
-        _check_class_share(block_hist, args.max_class_share, "block")
+        guard_classes = (
+            frozenset(args.guard_classes.split(",")) if args.guard_classes else CONSTANT_POLICY_CLASSES
+        )
+        _check_class_share(attack_hist, args.max_class_share, "attack", guard_classes=guard_classes)
+        _check_class_share(block_hist, args.max_class_share, "block", guard_classes=guard_classes)
 
     # ── Rebalance -------------------------------------------------------------
 
     if args.balance == "downsample":
-        records = _downsample(records, attack_hist, block_hist,
-                              args.max_class_share)
+        records = _downsample(records, attack_hist, block_hist, args.max_class_share)
         # Recompute histograms after downsample for accurate report
         attack_hist = _class_histogram(
-            records, "attack_class",
+            records,
+            "attack_class",
             lambda r: r.get("kind") == "combat_attack",
         )
         block_hist = _class_histogram(
-            records, "block_class",
+            records,
+            "block_class",
             lambda r: r.get("kind") == "combat_block",
         )
 
@@ -790,9 +879,17 @@ def main(argv: list[str] | None = None) -> int:
     logger.info(f"wrote {written} records -> {args.output}")
 
     if args.report:
-        _print_report(records, drops, skip_counts, read_count,
-                      args.input, args.output, elapsed,
-                      attack_hist=attack_hist, block_hist=block_hist)
+        _print_report(
+            records,
+            drops,
+            skip_counts,
+            read_count,
+            args.input,
+            args.output,
+            elapsed,
+            attack_hist=attack_hist,
+            block_hist=block_hist,
+        )
 
     return 0
 
@@ -810,10 +907,7 @@ def _print_report(
 ) -> None:
     attack_recs = [r for r in records if r.get("kind") == "combat_attack"]
     block_recs = [r for r in records if r.get("kind") == "combat_block"]
-    any_mcts = sum(
-        1 for r in records
-        if isinstance(r.get("meta"), dict) and r["meta"].get("mcts_chosen")
-    )
+    any_mcts = sum(1 for r in records if isinstance(r.get("meta"), dict) and r["meta"].get("mcts_chosen"))
 
     print(f"\n=== BUILD REPORT ===", file=sys.stderr)
     print(f"  Input:      {input_path} ({read_count} rows)", file=sys.stderr)
@@ -846,15 +940,21 @@ def _print_report(
         sample = attack_recs[0]
         print(f"    id: {sample['id']}", file=sys.stderr)
         print(f"    response: {sample['response']}", file=sys.stderr)
-        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('pool_size','chosen_size','chosen_names','attack_class')})}", file=sys.stderr)
+        print(
+            f"    meta: {json.dumps({k: sample['meta'][k] for k in ('pool_size', 'chosen_size', 'chosen_names', 'attack_class')})}",
+            file=sys.stderr,
+        )
     if block_recs:
         print(f"\n  Sample block response:", file=sys.stderr)
         sample = block_recs[0]
         print(f"    id: {sample['id']}", file=sys.stderr)
         print(f"    response: {sample['response']}", file=sys.stderr)
-        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('blocker_pool_size','n_attackers','n_blocks','block_class')})}", file=sys.stderr)
+        print(
+            f"    meta: {json.dumps({k: sample['meta'][k] for k in ('blocker_pool_size', 'n_attackers', 'n_blocks', 'block_class')})}",
+            file=sys.stderr,
+        )
 
-    print(f"  {'='*40}", file=sys.stderr)
+    print(f"  {'=' * 40}", file=sys.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The fail-closed skew guard trips on `proper_subset` (94.2%) which is NOT a trivial-policy risk — the model must still choose WHICH creatures, so a high share there is harmless. The genuine risk (`no_block` at 71.8%, exceeding the 69% `always_no_block` floor that blocked the previous combat candidate) was what the guard was built for.

## Changes

`CONSTANT_POLICY_CLASSES` = `{no_block, block_all, all_in, no_attack}` — classes whose share IS the score a do-nothing model achieves. `_check_class_share` now accepts `guard_classes=` and only raises SystemExit when a constant-policy class exceeds the threshold.

- `--guard-classes` CLI arg to override the default set (comma-separated)
- Both histograms remain in `--report`; `--allow-skewed` and `--balance downsample` unchanged
- `ruff format` applied to both changed files

## Test output

```
tests/test_combat_balance.py .........                                   [100%]
11 passed in 0.03s
```

## Acceptance verification

**On real corpus (9789 MageZero decisions):**

Guard now fires on `no_block` (the genuine risk), not `proper_subset`:

```
FAIL-CLOSED: block class 'no_block' is 71.8% (56/78) — exceeds --max-class-share=50%
  Guard-eligible classes: ['all_in', 'block_all', 'no_attack', 'no_block']
  Full histogram:
    no_block:   56 (71.8%) *
    partial_block:   17 (21.8%)
    block_all:    5 (6.4%) *
  Pass --allow-skewed to build anyway, or use --balance downsample.
```

With `--allow-skewed`, the attack class histogram (94.2% proper_subset) is still reported informationally.

## Tests added/changed

- `test_guard_ignores_proper_subset_skew` — guard does NOT fire on 94.2% proper_subset
- `test_guard_fires_on_no_block_skew` — guard fires on 71.8% no_block
- `test_guard_fires_on_skewed_block` — unchanged, still passes