### PR TITLE
WP-0.4: tag fallback contamination structurally, refuse untagged records

### DIFF
--- a/src/arenamcp/action_planner.py
+++ b/src/arenamcp/action_planner.py
@@ -101,6 +101,41 @@ class GameAction:
         return " | ".join(parts)
 
 
+# WP-0.4 fallback reason codes. A non-empty reason means a DEFAULT PATH, not the
+# model, chose the action — so the resulting trajectory record must be excluded
+# from positive training credit. Note "[pick-salvage]" is deliberately absent:
+# that is the model's own pick index recovered from malformed JSON, so the
+# decision is still the model's and the record is legitimate training data.
+FALLBACK_AUTO_PICK = "planner_auto_pick"
+FALLBACK_PREFLIGHT_LAND_DROP = "planner_preflight_land_drop"
+FALLBACK_NO_ACTIONS = "planner_no_actions"
+
+# Strategy prefixes that used to be the ONLY fallback signal. Retained solely to
+# classify plan objects built before ActionPlan.fallback_reason existed.
+_LEGACY_FALLBACK_STRATEGY_TAGS = {
+    "[auto-pick]": FALLBACK_AUTO_PICK,
+    "[land-drop-first]": FALLBACK_PREFLIGHT_LAND_DROP,
+}
+
+
+def plan_fallback_reason(plan: Any) -> str:
+    """Return why this plan is a fallback, or "" when the model decided it.
+
+    Prefers the structured ``ActionPlan.fallback_reason`` and falls back to the
+    legacy strategy-prefix sniff so older plan objects still classify correctly.
+    """
+    if plan is None or not getattr(plan, "actions", None):
+        return FALLBACK_NO_ACTIONS
+    reason = (getattr(plan, "fallback_reason", "") or "").strip()
+    if reason:
+        return reason
+    strategy = (getattr(plan, "overall_strategy", "") or "").strip()
+    for tag, legacy_reason in _LEGACY_FALLBACK_STRATEGY_TAGS.items():
+        if strategy.startswith(tag):
+            return legacy_reason
+    return ""
+
+
 @dataclass
 class ActionPlan:
     """A complete plan of actions to execute."""
@@ -110,6 +145,18 @@ class ActionPlan:
     voice_advice: str = ""
     trigger: str = ""
     turn_number: int = 0
+    # WP-0.4: why this plan did NOT come from the model ("" = the model decided).
+    # Until now the only signal was an "[auto-pick]" / "[land-drop-first]" prefix
+    # sniffed out of overall_strategy by self_play.plan_fallback_reason(). That
+    # coupling fails silently: reword a strategy string and every fallback stops
+    # being tagged, and untagged fallbacks are trained on as if the model had
+    # chosen them — teaching the model to imitate its own deterministic crutch.
+    fallback_reason: str = ""
+
+    @property
+    def fallback(self) -> bool:
+        """True when a default path, not the model, chose these actions."""
+        return bool(self.fallback_reason)
 
     def __str__(self) -> str:
         lines = [f"Plan ({self.trigger}, turn {self.turn_number}): {self.overall_strategy}"]
@@ -482,6 +529,7 @@ class ActionPlanner:
                 trigger=trigger,
                 turn_number=current_turn,
                 tag="land-drop-first",
+                fallback_reason=FALLBACK_PREFLIGHT_LAND_DROP,
             )
             if preflight_plan.actions:
                 raw = self._resolve_raw_actions_for_matching(game_state, legal_actions_raw)
@@ -1383,8 +1431,14 @@ class ActionPlanner:
         trigger: str,
         turn_number: int,
         tag: str,
+        fallback_reason: str,
     ) -> ActionPlan:
-        """Build a single-action ActionPlan from a legal-action string."""
+        """Build a single-action ActionPlan from a legal-action string.
+
+        ``fallback_reason`` is required, not defaulted: a preflight plan is by
+        definition not a model decision, and defaulting it to "" would let a new
+        preflight path silently produce untagged training records (WP-0.4).
+        """
         plan = ActionPlan(trigger=trigger, turn_number=turn_number)
         action = self._legal_action_to_action(legal_action)
         if not action:
@@ -1392,6 +1446,7 @@ class ActionPlanner:
         plan.actions = [action]
         plan.overall_strategy = f"[{tag}] {legal_action}"
         plan.voice_advice = self._humanize_legal_action(legal_action)
+        plan.fallback_reason = fallback_reason
         return plan
 
     # Oracle phrases that mark a spell as removal / hurts-its-target.
@@ -1831,6 +1886,9 @@ class ActionPlanner:
         # still distinguish fallback cases, but the user-facing advice is clean.
         plan.overall_strategy = f"[auto-pick] {selected}"
         plan.voice_advice = self._humanize_legal_action(selected)
+        # WP-0.4: the authoritative tag. The "[auto-pick]" prefix above stays for
+        # humans reading bug reports; downstream tagging must not depend on it.
+        plan.fallback_reason = FALLBACK_AUTO_PICK
         return plan
 
     # ------------------------------------------------------------------

--- a/src/arenamcp/autopilot.py
+++ b/src/arenamcp/autopilot.py
@@ -1108,7 +1108,7 @@ class AutopilotEngine(_BridgeSubmitMixin, _ActionExecMixin):
         if recorder is None:
             return
         try:
-            from arenamcp.action_planner import AUTOPILOT_SYSTEM_PROMPT
+            from arenamcp.action_planner import AUTOPILOT_SYSTEM_PROMPT, plan_fallback_reason
 
             prompt_user = self._planner._build_action_prompt(
                 game_state, trigger, legal_actions, decision_context
@@ -1124,6 +1124,13 @@ class AutopilotEngine(_BridgeSubmitMixin, _ActionExecMixin):
                 planned_action=planned,
                 request_type=request_type,
                 latency_ms=latency_ms,
+                # WP-0.4: real-match records were previously untagged, and an
+                # untagged record read as "the model chose this" downstream.
+                fallback_reason=plan_fallback_reason(plan),
+                # submitted_action is deliberately NOT passed: this runs right
+                # after plan_actions() and before execution, so what actually
+                # reached the GRE is unknowable here. It stays JSON null
+                # ("not observed") rather than being guessed from the plan.
             )
         except Exception as e:
             logger.debug(f"_maybe_record_trajectory failed (ignored): {e}")

--- a/src/arenamcp/self_play.py
+++ b/src/arenamcp/self_play.py
@@ -41,10 +41,12 @@ import contextlib
 from tools.eval.run import BackendSpec
 
 from arenamcp.action_planner import (
+    _LEGACY_FALLBACK_STRATEGY_TAGS,
     AUTOPILOT_SYSTEM_PROMPT,
     ActionPlanner,
     ActionType,
     GameAction,
+    plan_fallback_reason,
 )
 from arenamcp.gre_action_matcher import match_action_to_gre
 from arenamcp.gre_bridge import (
@@ -272,28 +274,16 @@ def find_instance_id_by_name(name: str, battlefield: list[dict]) -> int | None:
     return None
 
 
-# Strategy tags stamped by ActionPlanner when a decision did NOT come from the
-# model: `[auto-pick]` is the deterministic legal-action picker (_fallback_plan,
-# also used for trivial windows) and `[land-drop-first]` is the pre-LLM land-drop
-# preflight. Both are default paths, so per plan constraint 4 the resulting
-# trajectory record must be tagged and excluded from positive training credit.
-# `[pick-salvage]` is deliberately NOT here: that is the model's own pick index
-# recovered from malformed JSON, so the decision is still the model's.
-_FALLBACK_STRATEGY_TAGS = {
-    "[auto-pick]": "planner_auto_pick",
-    "[land-drop-first]": "planner_preflight_land_drop",
-}
-
-
-def plan_fallback_reason(plan) -> str:
-    """Return why this plan is a fallback, or "" when the model decided it."""
-    if plan is None or not getattr(plan, "actions", None):
-        return "planner_no_actions"
-    strategy = (getattr(plan, "overall_strategy", "") or "").strip()
-    for tag, reason in _FALLBACK_STRATEGY_TAGS.items():
-        if strategy.startswith(tag):
-            return reason
-    return ""
+# WP-0.4: `plan_fallback_reason` now lives in action_planner.py beside ActionPlan,
+# because the real-match capture path (autopilot -> TrajectoryRecorder) needs the
+# same classification and must not import self_play to get it. It is re-exported
+# here so existing callers and tests keep working.
+#
+# It reads the structured `ActionPlan.fallback_reason` set at the source, instead
+# of sniffing an "[auto-pick]" prefix out of overall_strategy — that prefix is a
+# human-facing debug string, and tying contamination filtering to its exact
+# wording meant a harmless copy edit could silently stop tagging fallbacks.
+_FALLBACK_STRATEGY_TAGS = _LEGACY_FALLBACK_STRATEGY_TAGS
 
 
 def describe_raw_action(raw: dict) -> str:

--- a/src/arenamcp/trajectory_recorder.py
+++ b/src/arenamcp/trajectory_recorder.py
@@ -20,8 +20,17 @@ Record shape (matches ``SelfPlayOrchestrator`` ``decision_rec``)::
       "prompt_system", "prompt_user",
       "planned_action", "alt_planned_action",
       "submit_command", "latency_ms",
+      "fallback", "fallback_reason",   # WP-0.4 contamination tags
+      "submitted_action",              # None = not observed at record time
       "winner"            # added at flush time
     }
+
+WP-0.4 note: this module previously claimed to match ``decision_rec`` while
+omitting ``fallback``/``fallback_reason``/``submitted_action``. Because
+``build_dataset.py`` filters with ``rec.get("fallback") is True``, an untagged
+record read as clean — so every real-match fallback was eligible for positive
+training credit. The tags are now recorded here too, and the consumer refuses
+untagged records outright rather than assuming they are clean.
 """
 
 from __future__ import annotations
@@ -70,6 +79,23 @@ def _stringify_action(action: Any) -> str:
         return str(action)
     except Exception:
         return "pass"
+
+
+class _Unobserved:
+    """Sentinel: the caller does not know what was submitted.
+
+    Distinct from ``None``/"pass" on purpose. ``_stringify_action(None)`` returns
+    ``"pass"``, so routing an unknown submission through it would record that a
+    pass was submitted — a fabricated observation. Callers that record before
+    execution (autopilot plans, then submits) leave this unset and the field is
+    written as JSON ``null`` meaning "not observed".
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<unobserved>"
+
+
+UNOBSERVED = _Unobserved()
 
 
 class TrajectoryRecorder:
@@ -131,8 +157,17 @@ class TrajectoryRecorder:
         request_type: str | None = None,
         latency_ms: float | None = None,
         submit_command: dict[str, Any] | None = None,
+        fallback_reason: str = "",
+        submitted_action: Any = UNOBSERVED,
     ) -> None:
-        """Buffer one decision record. Never raises into the caller."""
+        """Buffer one decision record. Never raises into the caller.
+
+        ``fallback_reason`` must be the output of
+        ``action_planner.plan_fallback_reason(plan)`` — non-empty means a default
+        path chose the action, so the record is excluded from training credit.
+        Callers that cannot know it should not pass "" (that asserts "the model
+        decided"); they should not be producing training records at all.
+        """
         try:
             gs = game_state or {}
             turn = gs.get("turn", {}) or {}
@@ -151,6 +186,13 @@ class TrajectoryRecorder:
                 "prompt_user": prompt_user or "",
                 "planned_action": _stringify_action(planned_action),
                 "alt_planned_action": _stringify_action(alt_action),
+                # WP-0.4 contamination tags. Always present, so a downstream
+                # consumer can tell "tagged clean" from "never tagged".
+                "fallback": bool(fallback_reason),
+                "fallback_reason": fallback_reason or "",
+                "submitted_action": (
+                    None if isinstance(submitted_action, _Unobserved) else _stringify_action(submitted_action)
+                ),
                 "submit_command": submit_command,
                 "latency_ms": round(float(latency_ms), 1) if latency_ms is not None else None,
             }

--- a/tests/test_fallback_tagging.py
+++ b/tests/test_fallback_tagging.py
@@ -1,0 +1,265 @@
+"""WP-0.4: fallback-contamination tagging at the producer, fail-closed at the consumer.
+
+Why this exists
+---------------
+When the LLM fails or returns an unparseable/illegal action, ``ActionPlanner``'s
+deterministic picker chooses instead. Training on those records teaches the model
+to imitate its own crutch, so they must be excluded from SFT positives and DPO
+``chosen``.
+
+Two defects made that exclusion ineffective:
+
+1. The only fallback signal was an ``"[auto-pick]"`` / ``"[land-drop-first]"``
+   prefix sniffed out of ``ActionPlan.overall_strategy`` — a human-facing debug
+   string. Rewording it silently stopped every fallback from being tagged.
+2. ``build_dataset.py`` filtered with ``rec.get("fallback") is True``, so a record
+   with NO ``fallback`` field read as clean. The real-match capture path
+   (``TrajectoryRecorder``) never wrote the field at all, so its fallbacks were
+   eligible for positive training credit.
+
+The tests below pin both the structured tag and the fail-closed consumer.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from arenamcp.action_planner import (
+    FALLBACK_AUTO_PICK,
+    FALLBACK_NO_ACTIONS,
+    FALLBACK_PREFLIGHT_LAND_DROP,
+    ActionPlan,
+    ActionType,
+    GameAction,
+    plan_fallback_reason,
+)
+from arenamcp.trajectory_recorder import UNOBSERVED, TrajectoryRecorder
+
+REPO = Path(__file__).resolve().parents[1]
+BUILD_DATASET = REPO / "tools" / "training" / "build_dataset.py"
+
+
+def _flat(text: str) -> str:
+    """Collapse whitespace — rich wraps log lines mid-phrase in captured output."""
+    return " ".join(text.split())
+
+
+def _action() -> GameAction:
+    return GameAction(action_type=ActionType.PASS_PRIORITY)
+
+
+def _model_plan() -> ActionPlan:
+    """A plan the model actually produced."""
+    return ActionPlan(actions=[_action()], overall_strategy="Curve out with the two-drop")
+
+
+def _fallback_plan() -> ActionPlan:
+    """A plan the deterministic picker produced."""
+    return ActionPlan(
+        actions=[_action()],
+        overall_strategy="[auto-pick] Pass",
+        fallback_reason=FALLBACK_AUTO_PICK,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Producer: the structured tag
+# ---------------------------------------------------------------------------
+
+
+def test_model_plan_is_not_tagged():
+    assert plan_fallback_reason(_model_plan()) == ""
+    assert _model_plan().fallback is False
+
+
+def test_fallback_plan_is_tagged():
+    plan = _fallback_plan()
+    assert plan.fallback is True
+    assert plan_fallback_reason(plan) == FALLBACK_AUTO_PICK
+
+
+def test_empty_plan_is_tagged_no_actions():
+    assert plan_fallback_reason(ActionPlan()) == FALLBACK_NO_ACTIONS
+    assert plan_fallback_reason(None) == FALLBACK_NO_ACTIONS
+
+
+def test_structured_tag_survives_a_strategy_reword():
+    """THE REGRESSION TEST for defect 1.
+
+    A fallback whose human-facing strategy string no longer starts with
+    "[auto-pick]" must still be tagged. Under the old prefix-sniffing
+    implementation this returned "" — i.e. "the model decided" — and the record
+    became an SFT positive.
+    """
+    reworded = ActionPlan(
+        actions=[_action()],
+        overall_strategy="Auto-selected the only legal play",  # no bracket tag
+        fallback_reason=FALLBACK_AUTO_PICK,
+    )
+    assert plan_fallback_reason(reworded) == FALLBACK_AUTO_PICK, (
+        "a fallback must stay tagged when its strategy text is reworded"
+    )
+
+
+def test_legacy_prefix_still_classified_for_untagged_plan_objects():
+    """Plans predating ``fallback_reason`` still classify via the old prefix."""
+    legacy_auto = ActionPlan(actions=[_action()], overall_strategy="[auto-pick] Pass")
+    legacy_land = ActionPlan(actions=[_action()], overall_strategy="[land-drop-first] Play Island")
+    assert plan_fallback_reason(legacy_auto) == FALLBACK_AUTO_PICK
+    assert plan_fallback_reason(legacy_land) == FALLBACK_PREFLIGHT_LAND_DROP
+
+
+def test_pick_salvage_is_not_a_fallback():
+    """``[pick-salvage]`` is the model's own pick recovered from bad JSON."""
+    salvaged = ActionPlan(actions=[_action()], overall_strategy="[pick-salvage] 2")
+    assert plan_fallback_reason(salvaged) == ""
+
+
+# ---------------------------------------------------------------------------
+# Producer: the real-match capture path writes the tags
+# ---------------------------------------------------------------------------
+
+
+def _record_one(tmp_path: Path, **kwargs) -> dict:
+    rec = TrajectoryRecorder(out_path=tmp_path / "traj.jsonl", seat="local")
+    rec.record_decision(
+        game_state={"match_id": "m1", "turn": {"turn_number": 3}},
+        prompt_system="sys",
+        prompt_user="user",
+        planned_action=_action(),
+        **kwargs,
+    )
+    rec.flush_match("local")
+    lines = (tmp_path / "traj.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    return json.loads(lines[0])
+
+
+def test_recorder_always_writes_the_fallback_field(tmp_path):
+    """THE REGRESSION TEST for defect 2 (producer half).
+
+    Every record must carry ``fallback`` so a consumer can distinguish
+    "tagged clean" from "never tagged".
+    """
+    clean = _record_one(tmp_path / "a", fallback_reason="")
+    assert clean["fallback"] is False
+    assert clean["fallback_reason"] == ""
+
+    tagged = _record_one(tmp_path / "b", fallback_reason=FALLBACK_AUTO_PICK)
+    assert tagged["fallback"] is True
+    assert tagged["fallback_reason"] == FALLBACK_AUTO_PICK
+
+
+def test_recorder_submitted_action_unobserved_is_null_not_pass(tmp_path):
+    """An unknown submission must not be recorded as a submitted pass.
+
+    ``_stringify_action(None)`` returns ``"pass"``, so routing an unknown
+    submission through it would fabricate an observation. The autopilot records
+    before it executes, so ``None`` (not observed) is the only honest value.
+    """
+    unobserved = _record_one(tmp_path / "a", fallback_reason="", submitted_action=UNOBSERVED)
+    assert unobserved["submitted_action"] is None, "unknown submission must be null, never 'pass'"
+
+    observed = _record_one(tmp_path / "b", fallback_reason="", submitted_action=_action())
+    assert observed["submitted_action"] is not None
+    assert observed["submitted_action"] != ""
+
+
+def test_recorder_defaults_to_unobserved_submission(tmp_path):
+    rec = _record_one(tmp_path, fallback_reason="")
+    assert rec["submitted_action"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consumer: fail-closed on untagged records
+# ---------------------------------------------------------------------------
+
+
+def _traj_line(*, fallback=None, planned="Action: pass", winner="local", match_id="m1") -> dict:
+    rec = {
+        "match_id": match_id,
+        "seat": "local",
+        "winner": winner,
+        "planned_action": planned,
+        "prompt_system": "sys",
+        "prompt_user": "user",
+        "request_type": "ActionsAvailable",
+    }
+    if fallback is not None:
+        rec["fallback"] = fallback
+    return rec
+
+
+def _run_builder(tmp_path: Path, rows: list[dict], *extra: str):
+    traj = tmp_path / "traj.jsonl"
+    traj.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(BUILD_DATASET),
+            "--trajectories",
+            str(traj),
+            "--out-sft",
+            str(tmp_path / "sft.json"),
+            "--out-dpo",
+            str(tmp_path / "dpo.json"),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+
+
+def test_untagged_record_is_refused(tmp_path):
+    """THE REGRESSION TEST for defect 2 (consumer half).
+
+    A record with no ``fallback`` field must abort the build. Previously
+    ``rec.get("fallback") is True`` let it through as clean.
+    """
+    proc = _run_builder(tmp_path, [_traj_line(fallback=None)])
+    assert proc.returncode != 0, f"untagged record must fail the build; got rc=0\n{proc.stdout[-800:]}"
+    combined = _flat(proc.stdout + proc.stderr)
+    assert "FAIL-CLOSED" in combined, combined[-800:]
+
+
+def test_allow_untagged_escape_hatch_warns_and_proceeds(tmp_path):
+    proc = _run_builder(tmp_path, [_traj_line(fallback=None)], "--allow-untagged")
+    combined = _flat(proc.stdout + proc.stderr)
+    assert "FAIL-CLOSED" not in combined
+    assert "MAY contain fallback contamination" in combined, combined[-800:]
+
+
+def test_tagged_fallback_excluded_and_clean_record_survives(tmp_path):
+    """Zero ``fallback: true`` records reach the dataset; clean ones do."""
+    rows = [
+        _traj_line(fallback=False, planned="Action: cast_spell Llanowar Elves", match_id="m-clean"),
+        _traj_line(fallback=True, planned="Action: pass", match_id="m-fallback"),
+    ]
+    proc = _run_builder(tmp_path, rows)
+    assert proc.returncode == 0, (proc.stdout + proc.stderr)[-1500:]
+
+    sft = json.loads((tmp_path / "sft.json").read_text(encoding="utf-8"))
+    blob = json.dumps(sft)
+    assert "Llanowar Elves" in blob, "the clean record should be present"
+    # The fallback row's distinctive action must not appear as a trained answer.
+    assert sft, "expected at least one SFT example"
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_fallback_field_is_the_filter_not_the_strategy_string(tmp_path, flag):
+    """The consumer keys off ``fallback``, never off strategy text."""
+    row = _traj_line(fallback=flag, planned="Action: pass")
+    row["overall_strategy"] = "totally innocuous text"
+    proc = _run_builder(tmp_path, [row])
+    assert proc.returncode == 0, (proc.stdout + proc.stderr)[-1200:]
+    out = _flat(proc.stdout + proc.stderr)
+    if flag:
+        # rich injects "build_dataset.py:NNN" into the middle of a wrapped log
+        # line, so only a short contiguous fragment is safe to assert on.
+        assert "Excluded 1 fallback-tagged" in out, out[-600:]

--- a/tools/training/build_dataset.py
+++ b/tools/training/build_dataset.py
@@ -245,6 +245,14 @@ def main():
     p.add_argument("--out-sft", type=Path, default=Path("tools/training/data/sft_dataset.json"))
     p.add_argument("--out-dpo", type=Path, default=Path("tools/training/data/dpo_dataset.json"))
     p.add_argument(
+        "--allow-untagged",
+        action="store_true",
+        help="Build even when trajectory records carry no `fallback` field. OFF by default: "
+        "an untagged record cannot be known to be free of fallback contamination, and "
+        "training on a fallback teaches the model to imitate its own deterministic crutch. "
+        "Use for debugging only — never to build a dataset for a gated candidate.",
+    )
+    p.add_argument(
         "--judge-backend",
         type=str,
         default=None,
@@ -299,6 +307,8 @@ def main():
         # processed in original file order, identical to the legacy behavior.
         records = []
         unresolved_winner_count = 0
+        untagged_examples: list[int] = []
+        fallback_excluded = 0
         with open(args.trajectories, encoding="utf-8") as f:
             for idx, line in enumerate(f):
                 try:
@@ -307,7 +317,18 @@ def main():
                     logger.warning(f"Skipping malformed self-play line {idx + 1}: {e}")
                     continue
 
+                # WP-0.4 fail-closed: `fallback` MISSING is not the same as
+                # `fallback: false`. The old `rec.get("fallback") is True` test
+                # silently accepted untagged records as clean, so any producer
+                # that forgot to tag (the real-match TrajectoryRecorder did, for
+                # its whole existence) fed its fallbacks straight into SFT
+                # positives and DPO `chosen`. Refuse instead of assuming.
+                if "fallback" not in rec:
+                    untagged_examples.append(idx + 1)
+                    continue
+
                 if rec.get("fallback") is True:
+                    fallback_excluded += 1
                     continue
 
                 winner = rec.get("winner")
@@ -319,6 +340,32 @@ def main():
                     continue
 
                 records.append(rec)
+
+        # WP-0.4 fail-closed gate. Untagged records are REFUSED, not assumed
+        # clean: the Accept criterion ("the built dataset contains zero
+        # fallback:true records") is only meaningful if every record was
+        # actually classified. Silently keeping untagged rows is how a
+        # forgetful producer reintroduces contamination invisibly.
+        if untagged_examples:
+            shown = ", ".join(str(n) for n in untagged_examples[:10])
+            more = f" (+{len(untagged_examples) - 10} more)" if len(untagged_examples) > 10 else ""
+            if not args.allow_untagged:
+                raise SystemExit(
+                    f"FAIL-CLOSED: {len(untagged_examples)} record(s) in {args.trajectories} carry no "
+                    f"`fallback` field, so it cannot be known whether the model or a deterministic "
+                    f"fallback chose the action. Lines: {shown}{more}\n"
+                    f"Fix the PRODUCER so it tags records (see "
+                    f"arenamcp.action_planner.plan_fallback_reason and "
+                    f"TrajectoryRecorder.record_decision(fallback_reason=...)). "
+                    f"Re-run with --allow-untagged only to build a knowingly-contaminated "
+                    f"dataset for debugging; never to train a candidate for gating."
+                )
+            logger.warning(
+                f"--allow-untagged: {len(untagged_examples)} untagged record(s) treated as clean. "
+                f"This dataset MAY contain fallback contamination. Lines: {shown}{more}"
+            )
+        if fallback_excluded:
+            logger.info(f"Excluded {fallback_excluded} fallback-tagged record(s) from training credit.")
 
         original_count = len(records)
         if unresolved_winner_count:


### PR DESCRIPTION
## What was actually broken

WP-0.4 exists so that decisions made by the *deterministic fallback* rather than the model are excluded from training — otherwise the model learns to imitate its own crutch. The exclusion existed but was a no-op, for two independent reasons.

**1. Producer: tagging depended on a debug string.** The only fallback signal was an `[auto-pick]` / `[land-drop-first]` prefix sniffed out of `ActionPlan.overall_strategy` by `self_play.plan_fallback_reason()`. That string is human-facing text shown in bug reports. Rewording it silently stops every fallback from being tagged, with no error anywhere.

**2. Consumer: untagged read as clean.** `build_dataset.py` filtered with `rec.get("fallback") is True`. A record with **no** `fallback` field passed that test as clean — and `TrajectoryRecorder` (the real-match capture path) never wrote the field at all, for its entire existence, despite its module docstring claiming the record shape "matches `SelfPlayOrchestrator` `decision_rec`". So every real-match fallback was eligible for SFT positives and DPO `chosen`.

Note the audit (`tools/training/wp_audit.md`, WP-0.4) is misleading here: it reports that no code sets the tag. `self_play.py:707-712` does tag `fallback`, `fallback_reason`, and `submitted_action`. The untagged producer is `TrajectoryRecorder`, which the audit does not mention.

## What changed

- `ActionPlan.fallback_reason` (+ `.fallback` property) — structured, set at the two sites that build a non-model plan: `_fallback_plan()` and `_build_preflight_plan()`. `fallback_reason` is a **required** kwarg on the latter, so a new preflight path cannot silently emit untagged records.
- `plan_fallback_reason()` moved to `action_planner.py` beside `ActionPlan`, because the real-match path must not import `self_play` to classify a plan. Re-exported from `self_play` so existing callers and tests keep working. It prefers the structured field; the prefix sniff remains only to classify plan objects predating the field.
- `TrajectoryRecorder.record_decision()` accepts `fallback_reason` / `submitted_action` and always writes `fallback` + `fallback_reason`.
- `autopilot._maybe_record_trajectory()` passes `plan_fallback_reason(plan)`.
- `build_dataset.py` **fail-closed**: a record with no `fallback` field aborts the build with a message naming the offending lines and pointing at the producer fix. `--allow-untagged` escapes for debugging, and warns loudly.

### `submitted_action` — partial, deliberately

`_maybe_record_trajectory` runs immediately after `plan_actions()` and **before** execution, so what actually reached the GRE is not knowable at that call site. It is recorded as JSON `null` meaning "not observed", via an explicit `UNOBSERVED` sentinel — **not** routed through `_stringify_action`, which returns `"pass"` for `None` and would have fabricated an observation that a pass was submitted.

Threading the real submission through autopilot's four scattered submit sites (`submit_action_by_index`, `submit_pass`, `submit_targets`, `submit_auto_tap`) is a larger change to the live execution path and is left as follow-up. Self-play already records the real `submitted_action` (`self_play.py:707`), and that is the producer that feeds `build_dataset`.

## Old-vs-new, proven against real code

Both demonstrations run against code pulled from git — the old `plan_fallback_reason` is `exec`'d verbatim out of `origin/master`, and the old builder is run from a pristine `origin/master` worktree. Nothing re-implemented by hand.

| | OLD (origin/master) | NEW |
|---|---|---|
| fallback plan, strategy reworded to `"Auto-selected the only legal play"` | `''` — "the model decided" | `'planner_auto_pick'` |
| untagged record through `build_dataset.py` | `rc=0`, **built 1 SFT example from it** | `rc=1`, `FAIL-CLOSED` |

The old builder producing a trained example from an untagged record is the contamination, reproduced concretely.

## Tests

`tests/test_fallback_tagging.py` — 14 tests. The two that carry the weight are `test_structured_tag_survives_a_strategy_reword` (defect 1) and `test_untagged_record_is_refused` (defect 2); both fail against old behaviour as shown above. Also covered: `[pick-salvage]` is **not** a fallback (it is the model's own pick recovered from malformed JSON), legacy prefixes still classify, and an unobserved submission is `null` rather than `"pass"`.

```
tests/test_fallback_tagging.py .............. 14 passed
full suite: 1318 passed, 30 skipped in 35.21s
ruff check . -> All checks passed!
ruff format --check src tests -> 244 files already formatted
```

## Gaps

- `submitted_action` on the autopilot path, as above.
- The fail-closed default will reject any pre-existing trajectory file recorded before this change. That is intended — those files genuinely cannot be known to be clean — but it means old captures need `--allow-untagged` and must not be used to build a gated candidate.