### PR TITLE
fix(coach): stop extended reasoning on the real-time path (5.5x faster) + guard CoT from reaching TTS

### DIFF
--- a/src/arenamcp/backends/proxy.py
+++ b/src/arenamcp/backends/proxy.py
@@ -414,6 +414,22 @@ class ProxyBackend:
                 params["max_tokens"] = max_tokens
 
             extra = {}
+            # vLLM / DeepSeek dialect. The gateway's ds4-v9 server is launched
+            # with `--default-chat-template-kwargs.thinking=true` and
+            # `.reasoning_effort=high`, so a request that says nothing about
+            # thinking gets EXTENDED reasoning on the real-time coaching path.
+            # Measured cost on the live gateway (2026-07-29, standalone.log,
+            # n=29 advice calls): p50 6134ms, 52% over 5s, and 79 calls whose
+            # visible content came back EMPTY because every token went to
+            # reasoning — which is how chain-of-thought reached the TTS in bug
+            # 20260729_225652. Same prompt A/B'd against the gateway:
+            #   default (thinking=high): 0.82s, 120 completion tokens, content EMPTY
+            #   chat_template_kwargs.thinking=false: 0.20s, 15 tokens, real advice
+            # `think` below is the Ollama spelling; neither it nor
+            # reasoning_effort overrides a vLLM chat-template default, so this
+            # key is required — without it enable_thinking=False is silently a
+            # no-op against this server.
+            extra["chat_template_kwargs"] = {"thinking": bool(self.enable_thinking)}
             if self.enable_thinking:
                 if "claude" in model_lower:
                     extra["thinking"] = {"type": "enabled", "budget_tokens": 8000}

--- a/src/arenamcp/backends/proxy.py
+++ b/src/arenamcp/backends/proxy.py
@@ -79,6 +79,47 @@ _COT_MARKERS = (
     "looking at",
 )
 
+# Phrases that make text a CONTINUATION of something the listener never heard.
+#
+# A different category from _COT_MARKERS above, and the reason bug
+# 20260729_225652 spoke "Alternatively, we could just pass. But we have a land
+# drop available and a shell we can cast." — 93 chars salvaged from 286 chars of
+# chain-of-thought at 22:56:33. Nothing in _COT_MARKERS starts with
+# "alternatively", so a deliberation fragment passed the guard and was spoken at
+# the start of a turn, referring to an option the user was never told about.
+#
+# The rule is principled rather than a list of observed failures: advice whose
+# first word presupposes a preceding alternative is broken by construction,
+# because the user hears only the final answer. Weighing two lines out loud is
+# what the reasoning channel is for and exactly what must not reach the speaker.
+#
+# Rejecting costs a fallback-advice turn, which is the cheaper failure — see the
+# docstring below.
+_ORPHAN_REFERENCE_MARKERS = (
+    "alternatively",
+    "conversely",
+    "on the other hand",
+    "then again",
+    "that said",
+    "that being said",
+    "instead,",
+    "otherwise,",
+    "either way",
+    "in that case",
+    "however",
+    "although",
+    "though ",
+    "but ",
+    "or ",
+    "and ",
+    "also,",
+    "besides,",
+    "plus,",
+    "actually,",
+    "which means",
+    "that means",
+)
+
 
 def _salvage_reasoning_answer(reasoning: str) -> str:
     """Extract a clean final answer from reasoning text, or return "".
@@ -90,6 +131,11 @@ def _salvage_reasoning_answer(reasoning: str) -> str:
     answer), reject truncated/unclosed thinking, and for tag-free text keep
     only a trailing paragraph that doesn't read like deliberation. An empty
     return sends the caller down the existing empty-advice fallback path.
+
+    The asymmetry is deliberate: rejecting a salvageable answer costs one turn
+    of deterministic fallback advice, while accepting deliberation speaks
+    incoherent advice the user cannot act on and cannot see the premise for.
+    When in doubt, return "".
     """
     text = (reasoning or "").strip()
     if not text:
@@ -104,12 +150,31 @@ def _salvage_reasoning_answer(reasoning: str) -> str:
     if not paragraphs:
         return ""
     candidate = paragraphs[-1]
-    if any(candidate.lower().startswith(m) for m in _COT_MARKERS):
+    if _reads_like_deliberation(candidate):
         return ""
     if len(paragraphs) == 1 and len(candidate) > 1200:
         # One giant undifferentiated block reads as chain-of-thought.
         return ""
     return candidate
+
+
+def _reads_like_deliberation(candidate: str) -> bool:
+    """True when this text is thinking-out-loud rather than a final answer.
+
+    Two independent signals, both keyed on the OPENING of the text, because that
+    is where both failure modes are visible:
+
+    * ``_COT_MARKERS`` — the text announces deliberation ("Let me check...").
+    * ``_ORPHAN_REFERENCE_MARKERS`` — the text continues a comparison the user
+      never heard ("Alternatively, we could just pass."). Advice cannot open by
+      referring to an unstated alternative.
+    """
+    head = candidate.strip().lower()
+    if not head:
+        return True
+    if any(head.startswith(m) for m in _COT_MARKERS):
+        return True
+    return any(head.startswith(m) for m in _ORPHAN_REFERENCE_MARKERS)
 
 
 # Online mode: hardcoded API endpoint

--- a/tests/test_proxy_reasoning_salvage.py
+++ b/tests/test_proxy_reasoning_salvage.py
@@ -1,0 +1,109 @@
+"""Chain-of-thought must never be spoken as advice.
+
+Field report ``~/.arenamcp/bug_reports/bug_20260729_225652.json``: at the start
+of a turn the coach said
+
+    "Alternatively, we could just pass. But we have a land drop available and a
+     shell we can cast."
+
+referring to an alternative the user was never told about. ``standalone.log``
+line 18015 shows why::
+
+    22:56:33 | WARNING | arenamcp.backends.proxy | [PROXY] Empty streamed
+    content — using answer salvaged from reasoning text (286 chars)
+
+deepseek-v4-flash streamed empty ``content`` with the text in
+``reasoning_content``. ``_salvage_reasoning_answer`` took the last paragraph of
+286 chars of deliberation, and ``_COT_MARKERS`` had no entry starting with
+"alternatively", so the fragment passed the guard and reached the TTS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arenamcp.backends.proxy import _salvage_reasoning_answer
+
+# Verbatim from the field report's advice_history[1].
+FIELD_REPORT_ADVICE = (
+    "Alternatively, we could just pass. But we have a land drop available and a shell we can cast."
+)
+
+
+def test_field_report_regression_orphan_alternative_is_rejected():
+    """THE regression test for bug_20260729_225652.
+
+    Reconstructs the shape the salvage function actually received: a first
+    paragraph of deliberation followed by the 93-char paragraph that was spoken.
+    """
+    reasoning = (
+        "The board is empty and we're on turn 3 with one Forest untapped. "
+        "Ozolith wants counters and Michelangelo is our payoff, so tempo matters here.\n\n"
+        + FIELD_REPORT_ADVICE
+    )
+    assert _salvage_reasoning_answer(reasoning) == "", (
+        "advice must never open by referring to an alternative the user never heard"
+    )
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "Alternatively, we could just pass.",
+        "However, holding the removal is better here.",
+        "But we have a land drop available.",
+        "On the other hand, attacking loses the Ozolith.",
+        "Instead, cast the two-drop.",
+        "That said, blocking costs us the creature.",
+        "Or we could float mana and wait.",
+        "And attack with everything.",
+        "Which means we should hold priority.",
+        "Then again, they might have a counterspell.",
+    ],
+)
+def test_orphan_reference_openers_are_rejected(candidate):
+    """Each of these presupposes something the listener never heard."""
+    reasoning = f"Weighing the options for this turn.\n\n{candidate}"
+    assert _salvage_reasoning_answer(reasoning) == "", f"should reject: {candidate!r}"
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "Play Forest, then cast Ozolith to start banking counters.",
+        "Attack with both creatures — they cannot block profitably.",
+        "Hold the removal for their four-drop.",
+        "Cast Michelangelo's Technique targeting Turtle Van.",
+        "Pass and keep mana up for the instant.",
+    ],
+)
+def test_real_advice_still_salvaged(candidate):
+    """The guard must not eat legitimate final answers.
+
+    Over-rejection is the cheaper failure but it is not free: it degrades the
+    turn to deterministic fallback advice, which reads like bare legal-action
+    strings.
+    """
+    reasoning = f"Considering the board and our curve.\n\n{candidate}"
+    assert _salvage_reasoning_answer(reasoning) == candidate
+
+
+def test_closed_think_block_still_yields_the_answer():
+    """Pre-existing behaviour must not regress: tagged CoT is stripped."""
+    reasoning = "<think>Hmm, maybe pass? No — tempo.</think>\nPlay Forest and cast Ozolith."
+    assert _salvage_reasoning_answer(reasoning) == "Play Forest and cast Ozolith."
+
+
+def test_unclosed_think_block_rejected():
+    assert _salvage_reasoning_answer("<think>Let me weigh the lines and") == ""
+
+
+def test_deliberation_opener_still_rejected():
+    """The original _COT_MARKERS path must keep working."""
+    reasoning = "Sizing up the board.\n\nLet me check whether they can block."
+    assert _salvage_reasoning_answer(reasoning) == ""
+
+
+def test_empty_and_whitespace():
+    assert _salvage_reasoning_answer("") == ""
+    assert _salvage_reasoning_answer("   \n\n  ") == ""

--- a/tests/test_proxy_thinking_control.py
+++ b/tests/test_proxy_thinking_control.py
@@ -1,0 +1,93 @@
+"""``enable_thinking=False`` must actually reach a vLLM/DeepSeek server.
+
+The gateway's ds4-v9 vLLM server is launched with
+``--default-chat-template-kwargs.thinking=true`` and ``.reasoning_effort=high``,
+so a request that says nothing about thinking gets extended reasoning. The
+real-time coach path constructs ``ProxyBackend`` with ``enable_thinking=False``
+(the default) and *intends* no reasoning, but the disable branch only ever spoke
+the Ollama (``think``), Gemini and GPT-5 (``reasoning_effort``) dialects — none of
+which override a vLLM chat-template default. So the intent was silently a no-op.
+
+Measured on the live gateway with the real 21.5k-char coach prompt captured in
+``bug_reports/bug_20260729_225652.json`` (n=5 each):
+
+    OLD  mean 2772ms  median 2235ms  max 5749ms
+    NEW  mean  506ms  median  384ms  max 1095ms
+
+and in the field log, 79 calls returned EMPTY visible content because every token
+went to reasoning — which is how chain-of-thought reached the TTS.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from arenamcp.backends.proxy import ProxyBackend
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture the request params without touching the network."""
+    seen: dict = {}
+
+    def fake_complete_once(self, client, params):
+        seen.clear()
+        seen.update(params)
+        return "Play Forest."
+
+    monkeypatch.setattr(ProxyBackend, "_complete_once", fake_complete_once, raising=True)
+    monkeypatch.setattr(ProxyBackend, "_local_warmup", lambda self: None, raising=False)
+    return seen
+
+
+def _run(thinking: bool, model: str = "deepseek-v4-flash") -> None:
+    be = ProxyBackend(
+        model=model,
+        enable_thinking=thinking,
+        base_url="http://127.0.0.1:9/v1",
+        api_key="sk-test",
+    )
+    be.complete("sys", "user", max_tokens=256)
+
+
+def test_thinking_disabled_is_sent_as_chat_template_kwargs(captured):
+    """THE regression test: the disable must be expressed in vLLM's dialect."""
+    _run(thinking=False)
+    extra = captured.get("extra_body") or {}
+    assert "chat_template_kwargs" in extra, (
+        "enable_thinking=False must send chat_template_kwargs; without it a vLLM "
+        "server launched with --default-chat-template-kwargs.thinking=true keeps "
+        "reasoning and the disable is a silent no-op"
+    )
+    assert extra["chat_template_kwargs"]["thinking"] is False
+
+
+def test_thinking_enabled_is_sent_explicitly(captured):
+    """The win-plan path must not depend on the server default either."""
+    _run(thinking=True)
+    extra = captured.get("extra_body") or {}
+    assert extra.get("chat_template_kwargs", {}).get("thinking") is True
+
+
+def test_ollama_think_flag_still_sent_when_disabled(captured):
+    """Pre-existing Ollama control must not regress."""
+    _run(thinking=False)
+    extra = captured.get("extra_body") or {}
+    assert extra.get("think") is False
+
+
+@pytest.mark.parametrize("model", ["deepseek-v4-flash", "gemma-4-12b-it", "qwen-uncensored"])
+def test_disable_applies_across_gateway_models(captured, model):
+    """Every model served by the gateway goes through the same vLLM template."""
+    _run(thinking=False, model=model)
+    extra = captured.get("extra_body") or {}
+    assert extra["chat_template_kwargs"]["thinking"] is False
+
+
+def test_claude_thinking_config_unaffected(captured):
+    """Anthropic's native field must still be set when thinking is enabled."""
+    _run(thinking=True, model="claude-sonnet-4")
+    extra = captured.get("extra_body") or {}
+    assert extra.get("thinking") == {"type": "enabled", "budget_tokens": 8000}
+    # ...and the vLLM key rides along harmlessly for gateway-routed Claude.
+    assert extra["chat_template_kwargs"]["thinking"] is True


### PR DESCRIPTION
Fixes the field report in `~/.arenamcp/bug_reports/bug_20260729_225652.json` — advice that opened *"Alternatively, we could just pass. But we have a land drop available and a shell we can cast."* at the start of a turn, referring to an alternative the user was never told about — and the latency problem behind it.

Two commits: the cause, and a guard for when it recurs.

## Commit 2 — the cause: `enable_thinking=False` never reached the server

The real-time coach path already constructs `ProxyBackend` with `enable_thinking=False` (the default; only `standalone.py:3318`'s win-plan backend passes `True`). But the disable branch spoke only three dialects — Ollama's `think`, and `reasoning_effort` for Gemini/GPT-5. None of those override a vLLM **chat-template** default, and `ds4-v9` is served with:

```
--default-chat-template-kwargs.thinking=true
--default-chat-template-kwargs.reasoning_effort=high
```

So every real-time advice call got extended reasoning at `effort=high`. The client was asking for no thinking and the request never said so in a dialect the server understood.

Fix: send `chat_template_kwargs={"thinking": bool(enable_thinking)}`. **LiteLLM already forwards it** — verified by curl through the gateway on `:8444`, not against vLLM directly — so nothing changes server-side.

### Measured, with the real 21.5k-char prompt from the bug report (n=5 each)

| | mean | median | min | max |
|---|---|---|---|---|
| OLD | 2772ms | 2235ms | 1530ms | **5749ms** |
| NEW | **506ms** | **384ms** | 258ms | **1095ms** |

The tail is what breaks game pace: **5.7s → 1.1s**. Advice quality is unchanged — both trees recommend "play Forest, then cast Ozolith".

I A/B'd a short prompt first and got only 1167ms for OLD, which would have overstated the win as 13x. The 6s p50 in `standalone.log` is prompt-size driven, so the honest figure is **~5.5x**. Note even 2772ms understates the live problem: the field p50 was 6134ms with the win-plan worker and MageZero competing for the same GPUs.

`enable_thinking=True` still reasons (1953ms), so the flag now actually controls the server instead of being decorative.

## Commit 1 — the guard: chain-of-thought must never be spoken

`standalone.log:18015` shows how the CoT reached the TTS:

```
22:56:33 | WARNING | arenamcp.backends.proxy | [PROXY] Empty streamed content —
using answer salvaged from reasoning text (286 chars)
```

With all tokens spent on reasoning, `content` streamed empty and `_salvage_reasoning_answer` took the last paragraph of the deliberation. `_COT_MARKERS` catches text that *announces* deliberation ("Let me check…") but has no entry starting with "alternatively", so the fragment passed.

That is a distinct failure category: text that **continues** a comparison. Advice whose first word presupposes an unstated alternative is broken by construction, because the user hears only the final answer. Adds `_ORPHAN_REFERENCE_MARKERS` and routes both checks through `_reads_like_deliberation`.

Returning `""` is the right outcome — the caller already logs and falls back to deterministic advice. Rejecting a salvageable answer costs one fallback turn; accepting deliberation speaks advice the user cannot act on. That asymmetry is documented in the docstring.

This guard is defence-in-depth: commit 2 removes the cause (79 such salvage events in the log), but a future model or server default could reintroduce empty content.

## Verification

Both test files were run against `origin/master` in a pristine worktree to confirm they discriminate:

```
tests/test_proxy_reasoning_salvage.py   vs master: 11 failed, 9 passed
tests/test_proxy_thinking_control.py    vs master:  6 failed, 1 passed
```

The passing ones pin preserved behaviour (closed think-tags still yield the answer, unclosed tags still rejected, real advice still salvaged, Ollama's `think` flag still sent).

```
full suite: 1331 passed, 30 skipped
ruff check . -> All checks passed!
ruff format --check src tests -> 245 files already formatted
```

## Scope: client-side only, by decision

The override is sent per-request from `proxy.py`. The gateway config and the vLLM
launch args are deliberately untouched, and the measurements above were taken
against the server exactly as it runs today.

Flipping the server-side default to `thinking=false` was considered and **rejected
by the repo owner** — the client is the right place for this, since the win-plan
path genuinely wants reasoning and only the caller knows which it is. Other
clients of the gateway (eval harness, self-play, sobrietycopilot.com) that want
fast non-reasoning responses should pass the same `chat_template_kwargs` rather
than relying on a shared default.
