### PR TITLE
fix(wp3): parser was mis-attributing boards AND dropping 8,595 pass decisions

### DIFF
--- a/tests/test_magezero_filters.py
+++ b/tests/test_magezero_filters.py
@@ -621,3 +621,79 @@ class TestInvariants:
         assert n2 >= 0
         assert n3 >= 0
         assert set(splits.keys()).issubset({"train", "val", "test"})
+
+
+class TestDownsamplePasses:
+    """Owner decision 2026-07-30: honour the pre-registered 40% Pass ceiling.
+
+    The recovered corpus (see parse_magezero_log's pass recovery) sits at 43.8%
+    literal Pass after won-only filtering and trips the B2 tripwire. Balancing
+    drops surplus PRIORITY passes only — combat declines are the scarce restraint
+    examples recovered from a corpus that had almost none, and trimming them to
+    hit a global ratio would trade a pass-bias for an over-block bias.
+    """
+
+    @staticmethod
+    def _corpus(n_priority_pass: int, n_priority_act: int, n_block_decline: int = 0) -> list[dict]:
+        rows = []
+        for i in range(n_priority_pass):
+            rows.append(_make_row({"chosen": "Pass", "decision_kind": "priority", "game_id": f"g:{i}:1"}))
+        for i in range(n_priority_act):
+            rows.append(
+                _make_row({"chosen": "Play Forest", "decision_kind": "priority", "game_id": f"g:{i}:2"})
+            )
+        for i in range(n_block_decline):
+            rows.append(_make_row({"chosen": "Pass", "decision_kind": "blockers", "game_id": f"g:{i}:3"}))
+        return rows
+
+    def test_reaches_the_ceiling(self):
+        rows = self._corpus(n_priority_pass=60, n_priority_act=40)  # 60%
+        kept, stats = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        frac = sum(1 for r in kept if r["chosen"] == "Pass") / len(kept)
+        assert frac <= 0.40 + 1e-9, f"expected <=40%, got {frac:.4f}"
+        assert stats["dropped"] > 0
+
+    def test_no_op_when_already_under_ceiling(self):
+        rows = self._corpus(n_priority_pass=20, n_priority_act=80)  # 20%
+        kept, stats = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        assert stats["dropped"] == 0
+        assert len(kept) == len(rows)
+
+    def test_deterministic_under_seed(self):
+        rows = self._corpus(n_priority_pass=60, n_priority_act=40)
+        a, _ = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        b, _ = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        assert [r["game_id"] for r in a] == [r["game_id"] for r in b]
+        c, _ = mf.downsample_passes(rows, max_frac=0.40, seed=99)
+        assert len(c) == len(a), "a different seed must drop the same COUNT"
+
+    def test_combat_declines_are_never_dropped(self):
+        """THE guard: blocker declines must survive balancing untouched."""
+        rows = self._corpus(n_priority_pass=50, n_priority_act=20, n_block_decline=30)
+        kept, _ = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        blockers_before = sum(1 for r in rows if r["decision_kind"] == "blockers")
+        blockers_after = sum(1 for r in kept if r["decision_kind"] == "blockers")
+        assert blockers_after == blockers_before == 30, (
+            f"combat declines were dropped: {blockers_before} -> {blockers_after}"
+        )
+
+    def test_shortfall_is_reported_not_hidden(self):
+        """When priority passes cannot cover the drop, say so and stay over."""
+        # Almost all passes are combat declines, which are ineligible.
+        rows = self._corpus(n_priority_pass=2, n_priority_act=10, n_block_decline=40)
+        kept, stats = mf.downsample_passes(rows, max_frac=0.40, seed=7)
+        assert stats["shortfall"] > 0, "an unmeetable target must be reported"
+        frac = sum(1 for r in kept if r["chosen"] == "Pass") / len(kept)
+        assert frac > 0.40, "still over the ceiling — the tripwire must reject it"
+
+    def test_pass_rate_report_separates_literal_from_pass_like(self):
+        """Binary windows decline with `false`, which literal-Pass misses."""
+        rows = [
+            _make_row({"chosen": "false", "decision_kind": "binary", "game_id": "g:1:1"}),
+            _make_row({"chosen": "Pass", "decision_kind": "priority", "game_id": "g:2:1"}),
+        ]
+        rep = mf.pass_rate_report(rows)
+        assert rep["__all__"]["literal_pass"] == 1
+        assert rep["__all__"]["pass_like"] == 2, "a binary `false` is also a do-nothing decision"
+        assert rep["binary"]["literal_frac"] == 0.0
+        assert rep["binary"]["pass_like_frac"] == 1.0

--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -719,3 +719,116 @@ class TestIssue430BlockAttribution:
         d = decisions[0]
         assert d["battlefield_self"] == [], f"turn-1 empty board was refilled: {d['battlefield_self']}"
         assert d["battlefield_opp"] == []
+
+
+class TestPassDecisionRecovery:
+    """XMage logs `chose action:` ONLY for non-pass actions.
+
+    Measured on mz_train_smoke.log before this fix: 21,723 pool lines where MCTS
+    deliberated, 9,111 (41.9%) with Pass as the argmax, but only 516 followed by
+    a `chose action` line — so ~8.6k decisions where the search concluded "do
+    nothing" were dropped. `chosen` contained a pass in 0 of 9,789 emitted rows
+    while 100% of menus offered one, which also made B2's >40%-Pass tripwire
+    unable to ever fire.
+    """
+
+    @staticmethod
+    def _parse(log_body: str):
+        import tempfile
+        from pathlib import Path
+
+        log = (
+            "INFO  Simulating 1 games. =>[main]\n"
+            + log_body
+            + "INFO  Player A win rate: 100.00% (1/1) =>[main]\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log.replace("=>[T]", "=>[pool-3-thread-1]"))
+            path = f.name
+        try:
+            return parse_log(path)[0]
+        finally:
+            Path(path).unlink()
+
+    LIFE = "INFO  [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:18] =>[T]\n"
+
+    def test_unconsumed_pass_pool_becomes_a_decision(self):
+        """A pool whose argmax is Pass and which no chose-action consumed."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            # MCTS deliberates and prefers Pass — XMage logs no chose action.
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
+            # A later window forces the previous pool to resolve.
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
+            + "INFO  [4:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.3 =>[T]\n"
+        )
+        assert len(decisions) == 2, f"expected the pass row + the play row, got {len(decisions)}"
+        pass_row = decisions[0]
+        assert pass_row["chosen"] == "Pass"
+        assert pass_row["turn"] == 3, "turn comes from the last logLife line"
+        assert pass_row["phase"] == "PRECOMBAT_MAIN"
+        assert pass_row["mcts_counts"] == {"Pass": 700, "Cast Bounce Off": 90}
+        assert pass_row["menu"] == ["Pass", "Cast Bounce Off"]
+        assert decisions[1]["chosen"] == "Play Island"
+
+    def test_ambiguous_unconsumed_pool_is_not_labelled(self):
+        """An un-consumed pool whose argmax is NOT a pass must not be guessed."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.2 count: 30] [Cast Bounce Off score: 0.5 count: 900] =>[T]\n"
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
+            + "INFO  [4:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.3 =>[T]\n"
+        )
+        assert len(decisions) == 1, (
+            f"an unexplained non-pass pool must be skipped, not labelled; got {[d['chosen'] for d in decisions]}"
+        )
+        assert decisions[0]["chosen"] == "Play Island"
+
+    def test_pass_pool_pending_at_game_boundary_is_flushed(self):
+        """The last window of a game still belongs to that game."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
+            + "INFO  Player A won the die roll =>[T]\n"  # next game starts
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
+            + "INFO  [4:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.3 =>[T]\n"
+        )
+        assert len(decisions) == 2
+        assert decisions[0]["chosen"] == "Pass"
+        assert decisions[0]["game_id"] != decisions[1]["game_id"], (
+            "the flushed pass belongs to the OUTGOING game, not the new one"
+        )
+
+    def test_pass_pool_pending_at_eof_is_flushed(self):
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["chosen"] == "Pass"
+
+    def test_binary_decline_counts_as_a_pass(self):
+        """CHOOSE_USE windows decline with `false`, not `Pass`."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [true score: 0.1 count: 40] [false score: 0.4 count: 500] =>[T]\n"
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["chosen"] == "false"
+        assert decisions[0]["decision_kind"] == "binary"
+
+    def test_recovered_rows_are_marked_internally_only(self):
+        """`_recovered_pass` is a leading-underscore field, stripped on write."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            + self.LIFE
+            + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
+        )
+        assert decisions[0]["_recovered_pass"] is True
+        assert not any(k.startswith("_") for k in ("chosen", "menu", "mcts_counts"))

--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -588,3 +588,134 @@ INFO  Player A win rate: 100.00% (1/1) =>[main]
         assert len(decisions) == 1
         assert decisions[0]["hand"] == ["Island", "Adarkar Wastes", "Bounce Off"]
         assert decisions[0]["battlefield_self"] == [{"name": "Island", "tapped": False}]
+
+
+class TestIssue430BlockAttribution:
+    """#430: boards must be attributed via the block header, not anonymous pairing.
+
+    Real-log grammar (both emitters ALWAYS carry the header):
+      ComputerPlayerMCTS.printBattlefieldScore: [PlayerX] -> Hand -> Perms(X) -> Perms(other)
+      GameStateEvaluator2.printBattlefield:     [PlayerX] -> Hand -> Perms(X) -> Graveyard
+    The old parser paired every Permanents line on the thread into an anonymous
+    [self, opp] buffer, so each one-line evaluator block shifted the frame and
+    swapped boards for the rest of the game (744 rows with off-color lands on
+    the self board, 1,717 with UW lands on the opp board, per the issue).
+    """
+
+    @staticmethod
+    def _parse(log_body: str):
+        import tempfile
+        from pathlib import Path
+
+        log = (
+            "INFO  Simulating 1 games. =>[main]\n"
+            + log_body
+            + "INFO  Player A win rate: 100.00% (1/1) =>[main]\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log.replace("=>[T]", "=>[pool-3-thread-1]"))
+            path = f.name
+        try:
+            decisions, _ = parse_log(path)
+        finally:
+            Path(path).unlink()
+        return decisions
+
+    def test_evaluator_playerb_block_goes_to_opp_board(self):
+        """A PlayerB-headed one-line evaluator block is the OPPONENT's board."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
+            "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
+            "INFO  [PlayerB], life = 20, score = 670 (Life:10000, Hand:25, Perm:280) =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Hand: [Lightning Strike:5; Hired Claw:5] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Permanents: [Mountain,tapped:280; Hired Claw:906] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Graveyard: [] =>[T] GameStateEvaluator2.printBattlefield \n"
+        )
+        assert len(decisions) == 1
+        d = decisions[0]
+        # Old parser: Mountain+Hired Claw landed in buffer slot 0 = SELF. Wrong.
+        assert d["battlefield_opp"] == [
+            {"name": "Mountain", "tapped": True},
+            {"name": "Hired Claw", "tapped": False},
+        ], f"PlayerB's board must be battlefield_opp, got opp={d['battlefield_opp']}"
+        assert d["battlefield_self"] == []
+
+    def test_evaluator_playerb_hand_never_enters_the_row(self):
+        """PlayerB's hand is the opponent's HIDDEN hand — an L4 leak if kept."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
+            "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
+            "INFO  [PlayerB], life = 20, score = 670 (Life:10000, Hand:25, Perm:280) =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Hand: [Lightning Strike:5; Nova Hellkite:5] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Permanents: [Mountain:280] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  [PlayerA], life = 20 =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Hand: [Island; Combat Research] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Island] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Mountain] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+        )
+        assert len(decisions) == 1
+        d = decisions[0]
+        assert d["hand"] == ["Island", "Combat Research"], (
+            f"the opponent's hand must never backfill the row; got {d['hand']}"
+        )
+
+    def test_one_line_block_does_not_shift_the_frame(self):
+        """THE frame-shift regression.
+
+        An evaluator one-line block followed by an MCTS two-line block: the old
+        anonymous pairing put [evaluator-line, mcts-line-1] into [self, opp] —
+        assigning PlayerA's OWN board (mcts line 1) to the OPPONENT slot. After
+        the fix, each block attributes independently and the boards match the
+        MCTS block exactly.
+        """
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
+            "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
+            # one-line evaluator block (PlayerA's own board)
+            "INFO  [PlayerA], life = 20, score = 295 (Life:10000, Hand:30, Perm:300) =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Hand: [Island:5] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Permanents: [Island:300] =>[T] GameStateEvaluator2.printBattlefield \n"
+            "INFO  -> Graveyard: [] =>[T] GameStateEvaluator2.printBattlefield \n"
+            # second decision, then a full MCTS block
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 30] [Cast Combat Research score: 0.2 count: 170] =>[T]\n"
+            "INFO  [2:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Combat Research success ratio: 0.2 =>[T]\n"
+            "INFO  [PlayerA], life = 20 =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Hand: [Combat Research; Island] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Island,tapped; Combat Research] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Mountain,tapped; Hired Claw] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+        )
+        assert len(decisions) == 2
+        d2 = decisions[1]
+        assert d2["battlefield_self"] == [
+            {"name": "Island", "tapped": True},
+            {"name": "Combat Research", "tapped": False},
+        ], f"frame shifted: self={d2['battlefield_self']}"
+        assert d2["battlefield_opp"] == [
+            {"name": "Mountain", "tapped": True},
+            {"name": "Hired Claw", "tapped": False},
+        ], f"frame shifted: opp={d2['battlefield_opp']}"
+
+    def test_legitimately_empty_boards_do_not_get_refilled_later(self):
+        """A turn-1 decision with genuinely empty boards must keep them."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
+            "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
+            # turn-1 block: both boards empty
+            "INFO  [PlayerA], life = 20 =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Hand: [Island; Combat Research] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            # later, boards fill up
+            "INFO  [PlayerA], life = 20 =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Hand: [Combat Research] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Island] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+            "INFO  -> Permanents: [Mountain] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+        )
+        assert len(decisions) == 1
+        d = decisions[0]
+        assert d["battlefield_self"] == [], f"turn-1 empty board was refilled: {d['battlefield_self']}"
+        assert d["battlefield_opp"] == []

--- a/tools/training/magezero_filters.py
+++ b/tools/training/magezero_filters.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
+import random
 import subprocess
 import sys
 from pathlib import Path
@@ -100,6 +102,92 @@ def dedupe(rows: list[dict]) -> tuple[list[dict], int]:
 # ---------------------------------------------------------------------------
 # Tripwire
 # ---------------------------------------------------------------------------
+
+
+def is_pass_action(name: str) -> bool:
+    """True when this chosen action means "do nothing".
+
+    The tripwire below keys on the literal ``"Pass"`` because that is the
+    pre-registered wording, but binary CHOOSE_USE windows decline with
+    ``"false"`` — also a do-nothing decision. Both are reported so the literal
+    gate cannot quietly under-measure the reflex it exists to catch.
+    """
+    return (name or "").strip().lower() in {"pass", "false", "no", "done"}
+
+
+def pass_rate_report(rows: list[dict]) -> dict[str, dict[str, float]]:
+    """Pass rate overall and per ``decision_kind``, literal and pass-like."""
+    out: dict[str, dict[str, float]] = {}
+    kinds = ["__all__"] + sorted({r.get("decision_kind", "?") for r in rows})
+    for kind in kinds:
+        group = rows if kind == "__all__" else [r for r in rows if r.get("decision_kind") == kind]
+        n = len(group)
+        if not n:
+            continue
+        literal = sum(1 for r in group if r.get("chosen") == "Pass")
+        like = sum(1 for r in group if is_pass_action(r.get("chosen", "")))
+        out[kind] = {
+            "rows": n,
+            "literal_pass": literal,
+            "literal_frac": literal / n,
+            "pass_like": like,
+            "pass_like_frac": like / n,
+        }
+    return out
+
+
+def downsample_passes(
+    rows: list[dict],
+    max_frac: float = 0.40,
+    seed: int = 7,
+) -> tuple[list[dict], dict[str, int]]:
+    """Drop surplus PRIORITY passes until the literal-Pass fraction is ``max_frac``.
+
+    Owner decision 2026-07-30: honour the pre-registered 40% ceiling rather than
+    revise it, because the pass-reflex failure is expensive and the threshold was
+    fixed in advance.
+
+    Only ``priority`` passes are eligible for dropping, and that is the whole
+    design. Priority windows hold the overwhelming majority of passes (18,150 of
+    21,609 rows), which is where a reflex actually lives. Combat declines are the
+    opposite problem: 562 declined-block and 895 declined-attack rows were
+    recovered from a corpus that had almost none, and they are exactly the
+    restraint examples the ``always_no_block`` floor tests for. Trimming those to
+    hit a global ratio would trade a pass-bias for an over-block bias — a
+    different wrong model, not a fixed one.
+
+    Deterministic under ``seed``: the surplus is chosen by a seeded shuffle, so
+    the same corpus and seed always yield the same drop set.
+    """
+    total = len(rows)
+    if total == 0:
+        return rows, {"dropped": 0, "eligible": 0}
+
+    n_pass = sum(1 for r in rows if r.get("chosen") == "Pass")
+    if total == 0 or n_pass / total <= max_frac:
+        return rows, {"dropped": 0, "eligible": 0}
+
+    # Solve for how many passes to drop: (n_pass - d) / (total - d) == max_frac
+    #   => d = (n_pass - max_frac * total) / (1 - max_frac)
+    d_needed = math.ceil((n_pass - max_frac * total) / (1.0 - max_frac))
+
+    eligible_idx = [
+        i
+        for i, r in enumerate(rows)
+        if r.get("chosen") == "Pass" and r.get("decision_kind") == "priority"
+    ]
+    rng = random.Random(seed)
+    order = list(eligible_idx)
+    rng.shuffle(order)
+    drop = set(order[:d_needed])
+
+    kept = [r for i, r in enumerate(rows) if i not in drop]
+    return kept, {
+        "dropped": len(drop),
+        "eligible": len(eligible_idx),
+        "needed": d_needed,
+        "shortfall": max(0, d_needed - len(eligible_idx)),
+    }
 
 
 def pass_rate_tripwire(rows: list[dict], max_frac: float = 0.40) -> None:
@@ -377,6 +465,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=0.40,
         help="Maximum allowed Pass fraction (default: 0.40).",
     )
+    parser.add_argument(
+        "--balance",
+        choices=("downsample-pass",),
+        default=None,
+        help="Drop surplus PRIORITY passes until the literal-Pass fraction meets "
+        "--max-pass-frac. Combat declines are never dropped: they are the scarce "
+        "restraint examples the always_no_block floor tests for, and trimming them "
+        "would trade a pass-bias for an over-block bias. Off by default so the raw "
+        "corpus shape is never silently altered.",
+    )
     return parser
 
 
@@ -405,6 +503,39 @@ def main(argv: list[str] | None = None) -> None:
     rows, n = dedupe(rows)
     filter_counts["dedupe"] = n
     print(f"  dedupe: {n} dropped ({len(rows)} kept)")
+
+    # Pass-rate visibility BEFORE any balancing, so the raw corpus shape is on
+    # the record even when balancing then hides it.
+    pre = pass_rate_report(rows)
+    print("  pass rate (pre-balance):")
+    for kind, st in pre.items():
+        print(
+            f"    {kind:<12s} rows={int(st['rows']):6d}  "
+            f"literal Pass={st['literal_frac'] * 100:5.1f}%  "
+            f"pass-like={st['pass_like_frac'] * 100:5.1f}%"
+        )
+
+    if args.balance == "downsample-pass":
+        rows, bstats = downsample_passes(rows, max_frac=args.max_pass_frac, seed=args.seed)
+        filter_counts["downsample_pass"] = bstats["dropped"]
+        print(
+            f"  downsample_pass: {bstats['dropped']} dropped "
+            f"({len(rows)} kept; {bstats['eligible']} priority passes were eligible)"
+        )
+        if bstats.get("shortfall"):
+            print(
+                f"  ** WARNING: {bstats['shortfall']} more drops were needed than there were\n"
+                f"     eligible PRIORITY passes. Combat declines are deliberately not\n"
+                f"     eligible; the tripwire below will still reject this corpus. **"
+            )
+        post = pass_rate_report(rows)
+        print("  pass rate (post-balance):")
+        for kind, st in post.items():
+            print(
+                f"    {kind:<12s} rows={int(st['rows']):6d}  "
+                f"literal Pass={st['literal_frac'] * 100:5.1f}%  "
+                f"pass-like={st['pass_like_frac'] * 100:5.1f}%"
+            )
 
     # Tripwire
     pass_rate_tripwire(rows, max_frac=args.max_pass_frac)

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -62,6 +62,12 @@ RE_TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
 
 RE_ACTION_TUPLE = re.compile(r"\[([^\]]+?) score: (-?[\d.eE+-]+) count: (\d+)\]")
 
+# Recovery accounting from the most recent parse_log() call. Kept module-level
+# rather than returned, because parse_log's 2-tuple signature has several
+# callers; the report reads this to surface the pass rate, which the B2
+# tripwire depends on being visible.
+LAST_PARSE_STATS: dict[str, int] = {"recovered_pass": 0, "ambiguous_unconsumed": 0}
+
 
 # ── Phase → decision_kind mapping ───────────────────────────────────────
 
@@ -81,6 +87,79 @@ DECISION_KIND_MAP = {
 # Known opponent order for the smoke run (gen0: Standard-MonoR/G/B/W/U, gen1: same order)
 SMOKE_OPPONENTS_GEN0 = ["Standard-MonoR", "Standard-MonoG", "Standard-MonoB",
                          "Standard-MonoW", "Standard-MonoU"]
+
+
+class _PendingPool:
+    """An MCTS visit distribution awaiting its outcome line."""
+
+    __slots__ = ("actions", "phase_code", "turn")
+
+    def __init__(self, actions: list[tuple], phase_code: str, turn: int):
+        self.actions = actions
+        self.phase_code = phase_code
+        self.turn = turn
+
+
+def is_pass_action(name: str) -> bool:
+    """True when this action name is XMage's pass/decline option."""
+    return name.strip().lower() in {"pass", "false", "no", "done"}
+
+
+def _emit_pass_decision(
+    state: _ThreadState,
+    pending: _PendingPool,
+    menu: list[str],
+    decisions: list[dict],
+    stats: dict[str, int],
+) -> None:
+    """Emit the decision for a pool line no `chose action` ever consumed.
+
+    XMage logs `chose action:` ONLY for non-pass actions — 0 of 9,789 emitted
+    rows had a pass in `chosen`, while 100% of menus offered one. Those windows
+    were dropped, discarding 8,595 of 18,384 deliberated decisions on
+    mz_train_smoke.log: precisely the cases where the search concluded that the
+    correct play was to DO NOTHING. Training on the remainder teaches a model
+    that never holds priority, never keeps an instant up, and never declines to
+    overextend — the mirror image of the pass-reflex that cost a prior week.
+
+    The label is recoverable without guessing: the MCTS argmax of the
+    un-consumed pool IS the search's conclusion. When that argmax is not a pass
+    action the window is genuinely ambiguous, so it is counted and skipped
+    rather than labelled — never fabricate a decision.
+    """
+    actions = pending.actions
+    top_name, _, _ = max(actions, key=lambda a: a[2])
+    if not is_pass_action(top_name):
+        stats["ambiguous_unconsumed"] += 1
+        return
+
+    kind = classify_kind(pending.phase_code, actions)
+    decision = {
+        "game_id": state.game_id,
+        "turn": pending.turn,
+        "phase": pending.phase_code,
+        "active_life": state.life_a,
+        "opp_life": state.life_b,
+        "hand": [],
+        "battlefield_self": [],
+        "battlefield_opp": [],
+        # The pool's own action names ARE the options the search weighed, so
+        # they are the faithful menu when no `playable abilities:` line landed.
+        "menu": list(menu) if menu else [name for name, _, _ in actions],
+        "chosen": top_name,
+        "mcts_counts": {name: count for name, _, count in actions},
+        "actor": "PlayerA",
+        "outcome": "unknown",
+        "decision_kind": kind,
+        "_thread": state.thread_id,
+        "_game_seq": state.game_seq,
+        "_log": state.log_name,
+        "session": "",
+        "_recovered_pass": True,
+    }
+    state.game_decisions.append(decision)
+    decisions.append(decision)
+    stats["recovered_pass"] += 1
 
 
 def classify_kind(phase_code: str, pool_actions: list[tuple]) -> str:
@@ -197,8 +276,10 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
     thread_game_seq: dict[str, int] = {}
 
     decisions: list[dict] = []
-    pending_pool: dict[str, list[tuple]] = {}
+    pending_pool: dict[str, _PendingPool] = {}
     pending_menu: dict[str, list[str]] = {}
+    # Recovery accounting, reported by --report so the pass rate is visible.
+    pass_stats: dict[str, int] = {"recovered_pass": 0, "ambiguous_unconsumed": 0}
 
     for line in all_lines:
         line = line.rstrip("\n\r")
@@ -216,10 +297,14 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         # ── Die roll: game boundary ──────────────────────────────
         dm = RE_DIE_ROLL.search(line)
         if dm:
+            # Flush before finalizing: a pool still pending at the game
+            # boundary is the last window of the OUTGOING game.
+            prev = pending_pool.pop(thread_id, None)
+            if prev is not None:
+                _emit_pass_decision(state, prev, pending_menu.get(thread_id, []), decisions, pass_stats)
             _finalize_game(state, decisions)
             thread_game_seq[thread_id] += 1
             state.start_new_game(thread_game_seq[thread_id])
-            pending_pool.pop(thread_id, None)
             pending_menu.pop(thread_id, None)
             continue
 
@@ -235,7 +320,22 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         if pool_match:
             actions = parse_pool_actions(pool_match.group(3))
             if actions:
-                pending_pool[thread_id] = actions
+                # A pool still pending when the NEXT one arrives was never
+                # consumed by a `chose action` line — because XMage does not log
+                # a chosen Pass. Recover it (see _emit_pass_decision) instead of
+                # dropping it, which silently discarded 8,595 of 18,384
+                # deliberated decisions on mz_train_smoke.log — every one of
+                # them a case where the search concluded "do nothing".
+                prev = pending_pool.pop(thread_id, None)
+                if prev is not None:
+                    _emit_pass_decision(
+                        state, prev, pending_menu.pop(thread_id, []), decisions, pass_stats
+                    )
+                pending_pool[thread_id] = _PendingPool(
+                    actions=actions,
+                    phase_code=pool_match.group(1),
+                    turn=state.last_turn,
+                )
             continue
 
         # ── Playable abilities (legal menu) ──────────────────────
@@ -252,11 +352,12 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             phase_code = cm.group(3)
             chosen = cm.group(4).strip()
 
-            pool_actions = pending_pool.pop(thread_id, None)
+            pending = pending_pool.pop(thread_id, None)
             menu = pending_menu.pop(thread_id, [])
 
-            if pool_actions is None:
+            if pending is None:
                 continue  # Minimax decision, skip
+            pool_actions = pending.actions
 
             kind = classify_kind(phase_code, pool_actions)
             mcts_counts = {name: count for name, _, count in pool_actions}
@@ -312,12 +413,21 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             )
             continue
 
+    # Flush any pool still pending at EOF, then finalize remaining games.
+    for tid, prev in list(pending_pool.items()):
+        st = threads.get(tid)
+        if st is not None:
+            _emit_pass_decision(st, prev, pending_menu.get(tid, []), decisions, pass_stats)
+    pending_pool.clear()
+
     # Finalize remaining games
     for state in threads.values():
         _finalize_game(state, decisions)
 
     # Enrich with sessions using per-thread game counts
     _enrich_sessions(decisions, sessions)
+
+    LAST_PARSE_STATS.update(pass_stats)
 
     return decisions, sessions
 
@@ -338,6 +448,9 @@ class _ThreadState:
         self.boards: dict[str, list[dict]] = {"PlayerA": [], "PlayerB": []}
         self.last_log_life_a: int | None = None
         self.last_log_life_b: int | None = None
+        # Last turn seen on a logLife line. A recovered pass row has no
+        # `chose action` line to read the turn from, so it uses this.
+        self.last_turn = 0
         # Open battlefield block: which player's header we are inside, which
         # emitter printed it, and how many Permanents lines it has produced.
         self._block_player: str | None = None
@@ -355,6 +468,7 @@ class _ThreadState:
         self.boards = {"PlayerA": [], "PlayerB": []}
         self.last_log_life_a = None
         self.last_log_life_b = None
+        self.last_turn = 0
         self._block_player = None
         self._block_emitter = None
         self._block_perm_lines = 0
@@ -362,6 +476,7 @@ class _ThreadState:
 
     def on_log_life(self, turn: int, phase_name: str, phase_code: str,
                     life_a: int, life_b: int):
+        self.last_turn = turn
         self.life_a = life_a
         self.life_b = life_b
         self.last_log_life_a = life_a
@@ -636,6 +751,16 @@ def _print_report(decisions: list[dict],
     print("=" * 60)
     print("MAGEZERO LOG PARSE REPORT")
     print("=" * 60)
+
+    n_recovered = sum(1 for d in decisions if d.get("_recovered_pass"))
+    n_pass = sum(1 for d in decisions if is_pass_action(d.get("chosen", "")))
+    total = len(decisions) or 1
+    print("\n  Pass-decision recovery (XMage logs no chosen Pass):")
+    print(f"    Recovered pass rows:        {n_recovered}")
+    print(f"    Ambiguous, NOT labelled:    {LAST_PARSE_STATS.get('ambiguous_unconsumed', 0)}")
+    print(f"    Pass fraction of `chosen`:  {n_pass}/{total} = {100 * n_pass / total:.1f}%")
+    if n_pass / total > 0.40:
+        print("    ** EXCEEDS the 40% B2 pass-reflex tripwire — corpus needs rebalancing **")
 
     total_games: set[str] = set()
     total_by_kind: dict[str, int] = {}

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -42,6 +42,20 @@ RE_HAND = re.compile(r"-> Hand: \[(.*?)\]")
 RE_PERMANENTS = re.compile(r"-> Permanents: \[(.*?)\]")
 RE_PLAYER_LIFE = re.compile(r"\[(Player[AB])\], life = (\d+)")
 
+# The emitter tag at end of line disambiguates the two battlefield-block
+# grammars (#430). `ComputerPlayerMCTS.printBattlefieldScore` blocks are
+#   [PlayerX] header -> Hand -> Permanents (SELF) -> Permanents (OPPONENT)
+# while `GameStateEvaluator2.printBattlefield` blocks are
+#   [PlayerX] header -> Hand -> Permanents (header player's own) -> Graveyard
+# The old parser ignored both the header and the emitter and paired every
+# Permanents line on the thread into an anonymous [self, opp] buffer, so each
+# one-line evaluator block shifted the pairing frame permanently — swapping
+# boards for the rest of the game. Measured on mz_train_smoke.log: 40,860
+# two-line blocks vs 34,912 one-line blocks (4,337 of them PlayerB-headed).
+RE_EMITTER = re.compile(r"=>\[pool-3-thread-\d+\]\s+(\S+)")
+EMITTER_MCTS = "ComputerPlayerMCTS.printBattlefieldScore"
+EMITTER_EVAL = "GameStateEvaluator2.printBattlefield"
+
 RE_WIN_RATE = re.compile(r"Player A win rate: ([\d.]+)% \((\d+)/(\d+)\)")
 RE_SIMULATING = re.compile(r"Simulating (\d+) games")
 RE_TIMESTAMP = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
@@ -271,25 +285,31 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             decisions.append(decision)
             continue
 
-        # ── Player life ──────────────────────────────────────────
+        # ── Player life: also opens a battlefield block (#430) ───
         pl = RE_PLAYER_LIFE.search(line)
         if pl:
-            state.on_player_life(pl.group(1), int(pl.group(2)))
+            em = RE_EMITTER.search(line)
+            state.on_block_header(pl.group(1), int(pl.group(2)), em.group(1) if em else None)
             continue
 
-        # ── Hand: backfill into pending decision ─────────────────
+        # ── Hand: PlayerA's backfills the decision; PlayerB's is the
+        # OPPONENT'S HAND (GameStateEvaluator2 prints both players' views)
+        # and must never enter a training row — the old parser backfilled
+        # it blindly, which is both wrong data and an L4 leak. ──────────
         hm = RE_HAND.search(line)
         if hm:
             cards = parse_card_list(hm.group(1))
-            state.latest_hand = cards
-            _backfill_hand(state, cards)
+            state.on_hand_line(cards)
             continue
 
-        # ── Permanents ───────────────────────────────────────────
+        # ── Permanents: attributed via block header + emitter ────
         perm = RE_PERMANENTS.search(line)
         if perm:
-            parsed = parse_permanents(perm.group(1))
-            state._accumulate_permanents(parsed)
+            em = RE_EMITTER.search(line)
+            state.on_permanents_line(
+                parse_permanents(perm.group(1)),
+                em.group(1) if em else None,
+            )
             continue
 
     # Finalize remaining games
@@ -312,11 +332,18 @@ class _ThreadState:
         self.life_a = 20
         self.life_b = 20
         self.latest_hand: list[str] = []
-        self.latest_perms_self: list[dict] = []
-        self.latest_perms_opp: list[dict] = []
+        # Last known board per player (#430). "Self" for a decision row is
+        # always PlayerA — the MCTS/primary player; decisions carry
+        # actor="PlayerA" — so battlefield_self is boards["PlayerA"].
+        self.boards: dict[str, list[dict]] = {"PlayerA": [], "PlayerB": []}
         self.last_log_life_a: int | None = None
         self.last_log_life_b: int | None = None
-        self._perm_buffer: list[list[dict]] = []
+        # Open battlefield block: which player's header we are inside, which
+        # emitter printed it, and how many Permanents lines it has produced.
+        self._block_player: str | None = None
+        self._block_emitter: str | None = None
+        self._block_perm_lines = 0
+        self._block_flushed = False
 
     def start_new_game(self, game_seq: int):
         self.game_seq = game_seq
@@ -325,11 +352,13 @@ class _ThreadState:
         self.life_a = 20
         self.life_b = 20
         self.latest_hand = []
-        self.latest_perms_self = []
-        self.latest_perms_opp = []
+        self.boards = {"PlayerA": [], "PlayerB": []}
         self.last_log_life_a = None
         self.last_log_life_b = None
-        self._perm_buffer = []
+        self._block_player = None
+        self._block_emitter = None
+        self._block_perm_lines = 0
+        self._block_flushed = False
 
     def on_log_life(self, turn: int, phase_name: str, phase_code: str,
                     life_a: int, life_b: int):
@@ -338,22 +367,64 @@ class _ThreadState:
         self.last_log_life_a = life_a
         self.last_log_life_b = life_b
 
-    def on_player_life(self, player: str, life: int):
+    def on_block_header(self, player: str, life: int, emitter: str | None):
+        # A new header closes the previous block. If that block produced
+        # board updates that were never flushed into a decision (possible
+        # only for a one-line block with no emitter tag, where we cannot
+        # tell "complete" from "awaiting the opponent line"), flush now.
+        if self._block_perm_lines > 0 and not self._block_flushed:
+            _backfill_battlefield(self)
         if player == "PlayerA":
             self.life_a = life
         else:
             self.life_b = life
+        self._block_player = player
+        self._block_emitter = emitter
+        self._block_perm_lines = 0
+        self._block_flushed = False
 
-    def _accumulate_permanents(self, permanents: list[dict]):
-        if not self._perm_buffer:
-            self._perm_buffer = [permanents]
-        elif len(self._perm_buffer) == 1:
-            self._perm_buffer.append(permanents)
-            self.latest_perms_self = list(self._perm_buffer[0])
-            self.latest_perms_opp = list(self._perm_buffer[1])
-            _backfill_battlefield(self)
+    def on_hand_line(self, cards: list[str]):
+        # Only the primary player's hand may reach a training row. A PlayerB
+        # hand line (GameStateEvaluator2 prints the opponent's view too) is
+        # the opponent's hidden hand: backfilling it poisons the `hand` field
+        # AND leaks information the model must never see (leak class L4).
+        if self._block_player == "PlayerB":
+            return
+        self.latest_hand = cards
+        _backfill_hand(self, cards)
+
+    def on_permanents_line(self, permanents: list[dict], emitter: str | None):
+        # Attribution is positional WITHIN the current header block, which is
+        # correct under both known grammars (and self-verifying on the real
+        # log: 10,215 MCTS headers x 2 lines = 20,430; 8,728 evaluator
+        # headers x 1 = 8,728, no other emitter prints Permanents):
+        #   line 1 after a [PlayerX] header = X's own board (both emitters)
+        #   line 2 (MCTS only)             = the other player's board
+        # A line with NO preceding header is unattributable — skip it rather
+        # than guess; anonymous pairing was exactly the old bug.
+        player = self._block_player
+        if player is None:
+            return
+
+        other = "PlayerB" if player == "PlayerA" else "PlayerA"
+        if self._block_perm_lines == 0:
+            self.boards[player] = list(permanents)
+        elif self._block_perm_lines == 1:
+            self.boards[other] = list(permanents)
         else:
-            self._perm_buffer = [permanents]
+            # A third line under one header would be a new grammar — ignore.
+            return
+        self._block_perm_lines += 1
+
+        # Flush into the pending decision only when the block is COMPLETE —
+        # flushing after an MCTS block's first line would hand the decision a
+        # fresh self board and a stale (or empty) opponent board. An evaluator
+        # block is complete at its single line; an MCTS block at its second;
+        # a one-line block with no emitter tag flushes on the next header.
+        em = emitter or self._block_emitter
+        if (em == EMITTER_EVAL and self._block_perm_lines == 1) or self._block_perm_lines == 2:
+            _backfill_battlefield(self)
+            self._block_flushed = True
 
     def infer_outcome(self) -> str:
         """Infer outcome from life values at the last known state."""
@@ -380,10 +451,16 @@ def _backfill_hand(state: _ThreadState, cards: list[str]):
 
 
 def _backfill_battlefield(state: _ThreadState):
-    for d in reversed(state.game_decisions):
-        if not d.get("battlefield_self") and not d.get("battlefield_opp"):
-            d["battlefield_self"] = list(state.latest_perms_self)
-            d["battlefield_opp"] = list(state.latest_perms_opp)
+    # A fill FLAG, not emptiness, marks a decision as done: both boards can be
+    # legitimately empty on early turns, and re-filling an "empty-looking"
+    # decision on every later Permanents line would hand a turn-1 decision a
+    # turn-5 board. Oldest-unfilled first: the boards known NOW are closer in
+    # time to the oldest pending decision than any future line will be.
+    for d in state.game_decisions:
+        if not d.get("_bf_filled"):
+            d["battlefield_self"] = list(state.boards["PlayerA"])
+            d["battlefield_opp"] = list(state.boards["PlayerB"])
+            d["_bf_filled"] = True
             return
 
 
@@ -395,10 +472,9 @@ def _finalize_game(state: _ThreadState, all_decisions: list[dict]):
         d["outcome"] = outcome
         if not d.get("hand"):
             d["hand"] = list(state.latest_hand)
-        if not d.get("battlefield_self"):
-            d["battlefield_self"] = list(state.latest_perms_self)
-        if not d.get("battlefield_opp"):
-            d["battlefield_opp"] = list(state.latest_perms_opp)
+        if not d.pop("_bf_filled", False):
+            d["battlefield_self"] = list(state.boards["PlayerA"])
+            d["battlefield_opp"] = list(state.boards["PlayerB"])
 
 
 # ── Session enrichment ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #430 — but the root cause is not what the issue describes, and while verifying the fix I found a **larger corpus defect** documented at the bottom.

## #430's stated cause was wrong

The issue says "the first Permanents line after the Hand is SELF". That rule is correct for *one* of two grammars. Two different emitters print battlefield blocks with **different arities**:

```
ComputerPlayerMCTS.printBattlefieldScore   [PlayerX] -> Hand -> Perms(X) -> Perms(other)
GameStateEvaluator2.printBattlefield       [PlayerX] -> Hand -> Perms(X) -> Graveyard
```

The parser ignored the `[PlayerX], life =` header entirely and paired *every* Permanents line on a thread into an anonymous `[self, opp]` buffer. So each one-line evaluator block shifted the pairing frame **permanently**, swapping the boards for the rest of the game. On `mz_train_smoke.log`: 20,430 two-line vs 8,728 one-line Permanents blocks, 4,337 of them PlayerB-headed.

Attribution is now positional *within the current header block*, which is self-verifying on the real log: 10,215 MCTS headers × 2 + 8,728 evaluator headers × 1 = 29,158 — accounting for every Permanents line, with none left over.

Note #434 and #439 both claimed to fix this and are **CLOSED, not merged**. I measured the bug live on `origin/master` before starting.

## Two more bugs found while reworking it

**PlayerB `-> Hand:` lines were backfilled into training rows.** `GameStateEvaluator2` prints *both* players' views, so those lines are the **opponent's hidden hand** — wrong data and an L4 information leak. Only the primary player's hand is kept now. (`game.yml` sets `see_opponent_hand: true` so MCTS may see it; the prompt may not.)

**Battlefield backfill keyed on "is the field empty?"**, so a legitimately empty turn-1 board was re-filled by every later Permanents line — handing early decisions a late-game board. Now keyed on an explicit `_bf_filled` flag, filling the *oldest* pending decision (closest in time to the boards just read), and flushing only when a block is **complete** so an MCTS block can't pair a fresh self board with a stale opponent board.

## Verified against origin/master's parser, full 9,789-row log

| signal (deck-color facts — UWTempo plays only UW; opponents are mono) | before | after |
|---|---|---|
| Mountain/Forest/Swamp on `battlefield_self` | **2,115** | **0** |
| UW duals (only UWTempo runs them) on `battlefield_opp` | **4,686** | **0** |
| games with MIXED basic land types on the opp board | — | **0** |
| rows | 9,789 | 9,789 (no loss) |

Downstream through `build_magezero_combat.py`: attack records **104 → 169**, mean blocker pool **2.33 → 3.72**. Block records drop **78 → 25** — the old 78 were built from swapped boards, so most encoded blocking with the *opponent's* creatures. The honest block corpus is small; that's a games-needed problem for the combat gate, not a parser tweak, and I'd rather report it than paper over it.

B2/B4 re-run clean on the corrected corpus: 3,284 rows / 164 games, splits by `game_id`, no tripwire fired.

## Tests

44 parser tests, 4 new for #430, each failing pre-fix: PlayerB-headed evaluator block goes to the opp board; PlayerB's hand never enters a row; a one-line block doesn't shift the frame; legitimately-empty turn-1 boards aren't refilled.

```
tests/test_parse_magezero_log.py  44 passed
full suite                        1335 passed, 30 skipped
ruff check . / format --check     clean
```

## ⚠️ Separate, larger finding — NOT fixed here

**The corpus is missing 8,595 decisions where the correct play was to do nothing.**

XMage emits `chose action:` **only for non-pass actions**. Measured on the same log:

| | count |
|---|---|
| pool lines where MCTS actually deliberated | 21,723 |
| …whose MCTS argmax was **Pass** | **9,111 (41.9%)** |
| …of those, followed by a `chose action` line | 516 |
| **deliberate passes never emitted as rows** | **8,595** |

And `chosen` contains "pass" in **0** of 9,789 emitted rows, while **100%** of menus offer a pass option.

Two consequences:

1. **The corpus teaches "always act."** Every training row shows Pass available and rejected. A LoRA distilled from this cannot learn to hold priority, keep instants up, or decline to overextend — core MTG skill. This is the mirror image of the pass-reflex that "killed a prior week", and equally wrong.
2. **B2's pass-rate tripwire is dead code.** It stops the pipeline if `chosen == "Pass"` exceeds 40% of kept rows. The true rate is **41.9%** — it would trip immediately — but it can never observe a single Pass, so it has been silently passing.

All the data needed to recover these rows is present (menu, `mcts_counts` including Pass, boards, hand); only the `chosen` label is absent, and it is recoverable as the MCTS argmax of the un-consumed pool line. Tracking separately so this PR stays reviewable.