### PR TITLE
wp3: menu parity — pool-anchored menu segmentation (chosen_not_in_menu 816 -> 0)

### DIFF
--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -842,3 +842,140 @@ class TestPassDecisionRecovery:
         )
         assert decisions[0]["_recovered_pass"] is True
         assert not any(k.startswith("_") for k in ("chosen", "menu", "mcts_counts"))
+
+
+class TestSegmentMenu:
+    """Menu segmentation with pool-name anchors (menu-parity fix).
+
+    XMage prints `playable abilities` as List.toString() — entries joined with
+    ", " and no quoting — while card names ("Cast Malcolm, Alluring Scoundrel")
+    and ability text ("{T}: Draw a card, then discard a card.") contain ", "
+    themselves. A plain comma split shattered those entries and every chose
+    action with a comma-named card was then dropped as chosen_not_in_menu:
+    816 of 5,835 post-filter rows (14.0%) on mz_train_smoke.log.
+    """
+
+    def test_comma_card_name_merged_when_pool_confirms(self):
+        from parse_magezero_log import segment_menu
+
+        raw = "Cast Malcolm, Alluring Scoundrel, Pass"
+        vocab = ["Cast Malcolm, Alluring Scoundrel", "Pass"]
+        assert segment_menu(raw, vocab) == ["Cast Malcolm, Alluring Scoundrel", "Pass"]
+
+    def test_ability_text_with_comma_merged(self):
+        from parse_magezero_log import segment_menu
+
+        raw = "{T}: Draw a card, then discard a card., Pass"
+        vocab = ["{T}: Draw a card, then discard a card.", "Pass"]
+        assert segment_menu(raw, vocab) == [
+            "{T}: Draw a card, then discard a card.",
+            "Pass",
+        ]
+
+    def test_real_log_window_line_3369(self):
+        """The exact raw payload from mz_train_smoke.log line 3369."""
+        from parse_magezero_log import segment_menu
+
+        raw = ("Cast Bounce Off, Cast Combat Research, Cast Kitsa, Otterball Elite, "
+               "Cast Skrelv, Defector Mite, {1}{U}: Untap {this}., Pass")
+        vocab = ["Cast Combat Research", "Cast Kitsa, Otterball Elite",
+                 "Cast Skrelv, Defector Mite", "Pass"]
+        assert segment_menu(raw, vocab) == [
+            "Cast Bounce Off",
+            "Cast Combat Research",
+            "Cast Kitsa, Otterball Elite",
+            "Cast Skrelv, Defector Mite",
+            "{1}{U}: Untap {this}.",
+            "Pass",
+        ]
+
+    def test_unconfirmed_comma_entry_stays_split(self):
+        """Fail closed: no pool-confirmed name, no merge."""
+        from parse_magezero_log import segment_menu
+
+        raw = "Cast Malcolm, Alluring Scoundrel, Pass"
+        vocab = ["Pass"]  # pool never confirmed the comma name
+        assert segment_menu(raw, vocab) == ["Cast Malcolm", "Alluring Scoundrel", "Pass"]
+
+    def test_duplicate_entries_preserved(self):
+        from parse_magezero_log import segment_menu
+
+        raw = "Play Island, Play Island, Pass"
+        vocab = ["Play Island", "Pass"]
+        assert segment_menu(raw, vocab) == ["Play Island", "Play Island", "Pass"]
+
+    def test_empty_raw(self):
+        from parse_magezero_log import segment_menu
+
+        assert segment_menu("", ["Pass"]) == []
+
+    def test_longest_match_wins(self):
+        """A vocab name that is a prefix of another must not steal the match."""
+        from parse_magezero_log import segment_menu
+
+        raw = "Cast Combat Research, Cast Combat Research II, Pass"
+        vocab = ["Cast Combat Research", "Cast Combat Research II", "Pass"]
+        assert segment_menu(raw, vocab) == [
+            "Cast Combat Research",
+            "Cast Combat Research II",
+            "Pass",
+        ]
+
+
+class TestCommaMenuEndToEnd:
+    """A chose action with a comma-named card must survive to the decision row
+    with its menu entry intact (this was the chosen_not_in_menu drop class)."""
+
+    @staticmethod
+    def _parse(log_body: str):
+        log = (
+            "INFO  Simulating 1 games. =>[main]\n"
+            + log_body
+            + "INFO  Player A win rate: 100.00% (1/1) =>[main]\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log.replace("=>[T]", "=>[pool-3-thread-1]"))
+            path = f.name
+        try:
+            return parse_log(path)[0]
+        finally:
+            Path(path).unlink()
+
+    def test_comma_named_cast_matches_menu(self):
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [2:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:20] =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] "
+            "[Cast Skrelv, Defector Mite score: 0.2 count: 500] =>[T]\n"
+            "INFO  playable abilities: [Cast Skrelv, Defector Mite, Pass] =>[T]\n"
+            "INFO  [2:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Skrelv, Defector Mite "
+            "success ratio: 0.2 =>[T]\n"
+        )
+        assert len(decisions) == 1
+        d = decisions[0]
+        assert d["chosen"] == "Cast Skrelv, Defector Mite"
+        assert d["menu"] == ["Cast Skrelv, Defector Mite", "Pass"]
+        assert d["chosen"] in d["menu"]
+        assert d["mcts_counts"]["Cast Skrelv, Defector Mite"] == 500
+
+    def test_recovered_pass_window_menu_segmented(self):
+        """An unconsumed pass pool whose playable-abilities line landed."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:18] =>[T]\n"
+            # Window 1: menu + comma-named cast.
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] "
+            "[Cast Kitsa, Otterball Elite score: 0.2 count: 500] =>[T]\n"
+            "INFO  playable abilities: [Cast Kitsa, Otterball Elite, Pass] =>[T]\n"
+            "INFO  [3:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Kitsa, Otterball Elite "
+            "success ratio: 0.2 =>[T]\n"
+            # Window 2: search prefers Pass; no playable/chose lines follow (EOF flush).
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] "
+            "[Cast Kitsa, Otterball Elite score: 0.1 count: 90] =>[T]\n"
+        )
+        assert len(decisions) == 2
+        assert decisions[0]["menu"] == ["Cast Kitsa, Otterball Elite", "Pass"]
+        pass_row = decisions[1]
+        assert pass_row["chosen"] == "Pass"
+        # No playable line landed for window 2 -> pool names are the menu.
+        assert pass_row["menu"] == ["Pass", "Cast Kitsa, Otterball Elite"]

--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -876,10 +876,11 @@ class TestSegmentMenu:
         """The exact raw payload from mz_train_smoke.log line 3369."""
         from parse_magezero_log import segment_menu
 
-        raw = ("Cast Bounce Off, Cast Combat Research, Cast Kitsa, Otterball Elite, "
-               "Cast Skrelv, Defector Mite, {1}{U}: Untap {this}., Pass")
-        vocab = ["Cast Combat Research", "Cast Kitsa, Otterball Elite",
-                 "Cast Skrelv, Defector Mite", "Pass"]
+        raw = (
+            "Cast Bounce Off, Cast Combat Research, Cast Kitsa, Otterball Elite, "
+            "Cast Skrelv, Defector Mite, {1}{U}: Untap {this}., Pass"
+        )
+        vocab = ["Cast Combat Research", "Cast Kitsa, Otterball Elite", "Cast Skrelv, Defector Mite", "Pass"]
         assert segment_menu(raw, vocab) == [
             "Cast Bounce Off",
             "Cast Combat Research",

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -105,10 +105,62 @@ def is_pass_action(name: str) -> bool:
     return name.strip().lower() in {"pass", "false", "no", "done"}
 
 
+def segment_menu(raw: str, vocab: list[str]) -> list[str]:
+    """Split a raw `playable abilities: [...]` payload into menu entries.
+
+    XMage prints the menu as List.toString() — entries joined with ", " and no
+    quoting — so the split points are ambiguous from the menu line alone: card
+    names ("Cast Malcolm, Alluring Scoundrel") and ability text ("{T}: Draw a
+    card, then discard a card.") contain ", " themselves. A plain comma split
+    shattered those entries, and every `chose action` whose name contains a
+    comma then failed the exact-match against the menu — 816 of 5,835
+    post-filter rows (14.0%) dropped as chosen_not_in_menu on
+    mz_train_smoke.log, all of them casts of comma-named cards.
+
+    The MCTS pool line of the SAME thread-paired window is bracket-delimited
+    ([<name> score: X count: N]) and therefore comma-safe: its action names are
+    verbatim ground truth for what the entries can be. Segmentation anchors on
+    those names (longest first) at ", " boundaries. Any stretch that matches no
+    vocab name falls back to the plain comma split — the old behavior — so a
+    merge is only ever produced when the pool confirms the merged form
+    verbatim. Never guess.
+    """
+    raw = raw.strip()
+    if not raw:
+        return []
+    names = sorted({v for v in vocab if v}, key=len, reverse=True)
+    segs: list[str] = []
+    i, n = 0, len(raw)
+    while i < n:
+        matched = False
+        for v in names:
+            end = i + len(v)
+            if raw.startswith(v, i) and (end == n or raw.startswith(", ", end)):
+                segs.append(v)
+                i = end + 2 if end < n else end
+                matched = True
+                break
+        if matched:
+            continue
+        # Unknown stretch: consume up to the next ", " exactly like the old
+        # comma split did. Fail closed — no pool-confirmed name, no merge.
+        j = raw.find(", ", i)
+        if j == -1:
+            seg = raw[i:].strip()
+            if seg:
+                segs.append(seg)
+            break
+        seg = raw[i:j].strip()
+        if seg:
+            segs.append(seg)
+        i = j + 2
+    return segs
+
+
 def _emit_pass_decision(
     state: _ThreadState,
     pending: _PendingPool,
-    menu: list[str],
+    menu_raw: str,
     decisions: list[dict],
     stats: dict[str, int],
 ) -> None:
@@ -134,6 +186,8 @@ def _emit_pass_decision(
         return
 
     kind = classify_kind(pending.phase_code, actions)
+    pool_names = [name for name, _, _ in actions]
+    menu = segment_menu(menu_raw, pool_names)
     decision = {
         "game_id": state.game_id,
         "turn": pending.turn,
@@ -145,7 +199,7 @@ def _emit_pass_decision(
         "battlefield_opp": [],
         # The pool's own action names ARE the options the search weighed, so
         # they are the faithful menu when no `playable abilities:` line landed.
-        "menu": list(menu) if menu else [name for name, _, _ in actions],
+        "menu": menu if menu else list(pool_names),
         "chosen": top_name,
         "mcts_counts": {name: count for name, _, count in actions},
         "actor": "PlayerA",
@@ -321,7 +375,10 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
 
     decisions: list[dict] = []
     pending_pool: dict[str, _PendingPool] = {}
-    pending_menu: dict[str, list[str]] = {}
+    # Raw `playable abilities` payloads, one per thread. Kept UNSPLIT: the
+    # entries are comma-joined and comma-containing, so the split needs the
+    # paired pool's action names as anchors (see segment_menu).
+    pending_menu: dict[str, str] = {}
     # Recovery accounting, reported by --report so the pass rate is visible.
     pass_stats: dict[str, int] = {"recovered_pass": 0, "ambiguous_unconsumed": 0}
 
@@ -345,7 +402,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             # boundary is the last window of the OUTGOING game.
             prev = pending_pool.pop(thread_id, None)
             if prev is not None:
-                _emit_pass_decision(state, prev, pending_menu.get(thread_id, []), decisions, pass_stats)
+                _emit_pass_decision(state, prev, pending_menu.get(thread_id, ""), decisions, pass_stats)
             _finalize_game(state, decisions)
             thread_game_seq[thread_id] += 1
             state.start_new_game(thread_game_seq[thread_id])
@@ -373,7 +430,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 prev = pending_pool.pop(thread_id, None)
                 if prev is not None:
                     _emit_pass_decision(
-                        state, prev, pending_menu.pop(thread_id, []), decisions, pass_stats
+                        state, prev, pending_menu.pop(thread_id, ""), decisions, pass_stats
                     )
                 pending_pool[thread_id] = _PendingPool(
                     actions=actions,
@@ -385,8 +442,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         # ── Playable abilities (legal menu) ──────────────────────
         pm = RE_PLAYABLE.search(line)
         if pm:
-            menu = [m.strip() for m in pm.group(1).split(",")]
-            pending_menu[thread_id] = menu
+            pending_menu[thread_id] = pm.group(1)
             continue
 
         # ── Chose action (the decision label) ────────────────────
@@ -397,11 +453,18 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             chosen = cm.group(4).strip()
 
             pending = pending_pool.pop(thread_id, None)
-            menu = pending_menu.pop(thread_id, [])
+            menu_raw = pending_menu.pop(thread_id, "")
 
             if pending is None:
                 continue  # Minimax decision, skip
             pool_actions = pending.actions
+
+            # The chosen name comes from the (comma-safe) `chose action` line;
+            # add it to the anchors in case the paired pool is a sub-decision
+            # pool ("(top: X)pool=") whose names are not the menu's entries.
+            menu = segment_menu(
+                menu_raw, [name for name, _, _ in pool_actions] + [chosen]
+            )
 
             kind = classify_kind(phase_code, pool_actions)
             mcts_counts = {name: count for name, _, count in pool_actions}
@@ -461,7 +524,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
     for tid, prev in list(pending_pool.items()):
         st = threads.get(tid)
         if st is not None:
-            _emit_pass_decision(st, prev, pending_menu.get(tid, []), decisions, pass_stats)
+            _emit_pass_decision(st, prev, pending_menu.get(tid, ""), decisions, pass_stats)
     pending_pool.clear()
 
     # Finalize remaining games

--- a/tools/training/wp3/PROGRESS-wp3-menu-parity.md
+++ b/tools/training/wp3/PROGRESS-wp3-menu-parity.md
@@ -1,0 +1,121 @@
+# PROGRESS: wp3-menu-parity — chosen_not_in_menu diagnosis and fix
+
+Date: 2026-07-30
+Branch: wp3-menu-parity
+Source log: /home/joshu/mz_train_smoke.log (201 MB, 594 games)
+Pipeline command (both runs):
+`run_wp3_pipeline.py --log /home/joshu/mz_train_smoke.log --balance downsample-pass`
+(without `--balance` the run aborts at the 40% pass-rate tripwire before the
+render stage, so the drop is only observable on the balanced path).
+
+## Reproduction (current numbers — the 745 measurement had shifted)
+
+| Metric | Before fix | After fix |
+|---|---|---|
+| Raw decisions parsed | 21,609 | 21,609 |
+| Post-filter rows | 5,835 | 5,835 |
+| chosen_not_in_menu drops | **816** (14.0% of post-filter) | **0** |
+| decision_kind_binary drops | 359 | 359 |
+| Training records (train+val+test) | 4,660 | 5,476 (+816) |
+| Pass rate | 40.0% | 40.0% |
+| Leak scan | PASS | PASS |
+
+The task brief's 745 (12.8%) was measured before the recovered-pass and
+combat-classifier changes landed; the reproduced baseline on current master
+(48a47ac) is 816 (14.0%).
+
+## Root cause (single bucket — 816 of 816 drops)
+
+`parse_magezero_log.py` split the `playable abilities: [...]` payload on
+commas. XMage prints that list as Java `List.toString()` — entries joined
+with `", "` and no quoting — while menu entries themselves contain `", "`:
+
+- comma-named cards: `Cast Malcolm, Alluring Scoundrel`, `Cast Skrelv,
+  Defector Mite`, `Cast Kitsa, Otterball Elite`
+- ability text: `{T}: Draw a card, then discard a card.`
+
+The split shattered those entries, and `build_magezero_bridge._resolve_answer`
+does an exact `menu.index(chosen)` — so every `chose action` whose name
+contains a comma failed the match and was dropped.
+
+### Bucketing method
+
+Every one of the 816 dropped rows was re-segmented using the row's own
+MCTS-pool action names (bracket-delimited in the log, therefore comma-safe)
+as anchors; the chosen action then appeared verbatim in the re-segmented
+menu in **816/816 cases**. Buckets that came back EMPTY: pass-not-in-menu
+(0), menu truncation (0), cross-thread window bleed (0), land-play phrasing
+(0), mana-ability phrasing (0).
+
+### Three raw-log examples (grep -n citations into mz_train_smoke.log)
+
+1. Lines 1747-1748 (thread-1, game 1, turn 2):
+   `playable abilities: [Cast Skrelv, Defector Mite, Cast Skrelv, Defector Mite, Pass]`
+   `chose action:Cast Skrelv, Defector Mite`
+   Old menu: `['Cast Skrelv', 'Defector Mite', 'Cast Skrelv', 'Defector Mite', 'Pass']` — chosen not found.
+   New menu: `['Cast Skrelv, Defector Mite', 'Cast Skrelv, Defector Mite', 'Pass']` (two castable copies).
+2. Lines 3368-3370 (thread-6, game 1, turn 5):
+   `playable abilities: [Cast Bounce Off, Cast Combat Research, Cast Kitsa, Otterball Elite, Cast Skrelv, Defector Mite, {1}{U}: Untap {this}., Pass]`
+   `chose action:Cast Skrelv, Defector Mite`
+   New menu (verified in decisions.jsonl): `['Cast Bounce Off', 'Cast Combat Research', 'Cast Kitsa, Otterball Elite', 'Cast Skrelv, Defector Mite', '{1}{U}: Untap {this}.', 'Pass']`.
+3. Line 2747 (thread-5, turn 6): `chose action:Cast Kitsa, Otterball Elite`
+   with menu line `playable abilities: [... Cast Kitsa, Otterball Elite, ...]` —
+   same shatter, same recovery.
+
+## Fix (parser-side, fail closed)
+
+`parse_magezero_log.segment_menu(raw, vocab)`: the raw (unsplit) menu payload
+is now stored per thread and segmented at decision-emission time using the
+paired window's pool action names (plus the chose-action name) as anchors,
+longest-first, only at `", "` boundaries. Any stretch matching no anchor
+falls back to the old plain comma split — a merge is only ever produced when
+the pool confirms the merged form verbatim. No guessing; pairing stays
+thread-tag + same-window, per the existing pending_pool/pending_menu model
+(log order per window is pool -> playable -> chose; pass windows emit only a
+pool line and take pool names as the menu, unchanged).
+
+## Guardrail (records only grow, no kept record changes its choice)
+
+Compared rendered corpora before/after keyed on
+`(game_id, turn, phase, session, outcome, chosen-action-string)` as a
+multiset, with the chosen string re-derived from `meta.answer_pick` against
+the numbered menu inside the final rendered prompt:
+
+- records before: 4,660; after: 5,476
+- previously-kept records missing after fix: **0**
+- gained: **816**, of which 816/816 have a comma in the chosen action
+
+Note `answer_pick` indices legitimately shift for kept records whose menus
+contained shattered third-party entries (the menu is now shorter/correct);
+the chosen action string at the picked index is unchanged for all 4,660.
+
+## Secondary measured effect
+
+Suspect shattered fragments across post-filter menus (entries with no
+action-shaped prefix, e.g. orphaned `then discard a card.` / `Alluring
+Scoundrel`): 1,841 of 20,044 entries before -> 336 of 18,142 after.
+
+## Not fixed (documented, needs a judgement call)
+
+1. **336 residual shattered fragments** in kept rows' menus: windows where
+   the comma-named entry was never expanded by the paired pool (or the paired
+   pool is a sub-decision pool), so no anchor confirms the merge. A global
+   (cross-window) vocabulary of pool-confirmed action names would merge most
+   of them, but that trades the tight same-window pairing for a corpus-wide
+   assumption; recommend deciding explicitly whether menu cosmetics justify
+   it. The chosen action is unaffected (it is always pool-confirmed).
+2. **Sub-decision pools** (`PHASE1 (top: X)pool=`): a `chose action` that
+   follows a sub-pool gets that sub-pool as its `mcts_counts` (targets, not
+   top-level actions), so `meta.mcts_chosen_visits` is 0 for those rows.
+   Pre-existing, out of scope here; menu segmentation defends against it by
+   adding the chosen name to the anchor set.
+
+## Verification
+
+- tests/test_parse_magezero_log.py: 59 passed (50 existing + 9 new:
+  TestSegmentMenu x7, TestCommaMenuEndToEnd x2).
+- Full WP-3 suite (test_parse_magezero_log, test_run_wp3_pipeline,
+  test_magezero_bridge_leaks, test_magezero_card_map, test_magezero_combat,
+  test_magezero_filters): 156 passed, 2 skipped.
+- Rendered records eyeballed against raw log lines 1747-1748 and 3368-3370:
+  menus match the log verbatim.


### PR DESCRIPTION
## Problem

The WP-3 pipeline dropped decisions as `chosen_not_in_menu` when the MCTS-chosen action failed an exact match against the reconstructed legal-actions menu. Reproduced baseline on `mz_train_smoke.log` at 48a47ac (`--balance downsample-pass`, the only path that reaches the render stage): **816 drops, 14.0% of 5,835 post-filter rows** (the task's 745/12.8% figure predates the recovered-pass and combat-classifier changes).

## Diagnosis — one bucket, 816 of 816

`parse_magezero_log.py` split `playable abilities: [...]` on commas, but XMage prints that list as `List.toString()` — entries joined with `", "` — while entries themselves contain `", "`: card names (`Cast Skrelv, Defector Mite`) and ability text (`{T}: Draw a card, then discard a card.`). Shattered entries then failed `build_magezero_bridge._resolve_answer`'s `menu.index(chosen)`.

Buckets measured EMPTY: pass-not-in-menu (0), menu truncation (0), cross-thread window bleed (0), land-play phrasing (0), mana-ability phrasing (0). All 816 drops re-segment cleanly using the row's own pool action names; raw-log citations (line numbers in `mz_train_smoke.log`): 1747-1748, 3368-3370, 2747 — full examples in `tools/training/wp3/PROGRESS-wp3-menu-parity.md`.

## Fix (parser-side, fail closed)

Store the raw menu payload per thread; segment at decision emission with `segment_menu(raw, vocab)` using the same thread-paired window's MCTS pool action names (bracket-delimited in the log, therefore comma-safe) + the chose-action name as anchors, longest-first, at `", "` boundaries only. Unmatched stretches keep the old comma split — a merge is only produced when the pool confirms the merged form verbatim.

## Measured results (before -> after)

| Metric | Before | After |
|---|---|---|
| chosen_not_in_menu drops | 816 | 0 |
| Training records | 4,660 | 5,476 (+816) |
| Post-filter rows / pass rate | 5,835 / 40.0% | 5,835 / 40.0% |
| Shattered menu fragments (post-filter menus) | 1,841 / 20,044 entries | 336 / 18,142 |
| Leak scan | PASS | PASS |

Guardrail: rendered corpora compared as multisets keyed on `(game_id, turn, phase, session, outcome, chosen-action string)`, chosen re-derived from `meta.answer_pick` against the rendered numbered menu — **0 previously-kept records lost or changed**, gained exactly 816, all with comma-named chosen actions.

## Not fixed (documented in PROGRESS, judgement calls)

- 336 residual shattered fragments where no same-window pool name confirms the merge (a global vocabulary would fix most, at the cost of the tight same-window pairing).
- Sub-decision pools (`(top: X)pool=`) pair a chose action with target-level `mcts_counts` (pre-existing; `mcts_chosen_visits`=0 for those rows).

## Tests

`test_parse_magezero_log.py`: 59 passed (9 new: `TestSegmentMenu`, `TestCommaMenuEndToEnd`). WP-3 suite (parse/pipeline/bridge-leaks/card-map/combat/filters): 156 passed, 2 skipped.