### PR TITLE
WP-3: B5 gate eval runner — runnable tonight, CPU-validated

### DIFF
--- a/tools/training/wp3/PROGRESS-wp3-gate-eval-prep.md
+++ b/tools/training/wp3/PROGRESS-wp3-gate-eval-prep.md
@@ -1,0 +1,143 @@
+# PROGRESS — wp3-gate-eval-prep
+
+Goal: make the gate evaluation RUNNABLE for the B5 LoRA
+(`tools/training/checkpoints/wp3_gemma12b_b5_smoke`, base
+`google/gemma-4-12B-it`) finishing tonight, with zero GPU usage during prep.
+
+## What the gate actually is (mapped, not assumed)
+
+The pre-registered "strategic gate >47.27" traces to
+`tools/training/data/gate_report_strategic_v1.json` (verdict BLOCKED,
+git_sha 1644f26): baseline arm `openai-compat:gemma-4-31b-it-base` scored
+**overall accuracy 0.4727 (260/550)** on
+`tools/training/data/gate_strategic_decisions_test.jsonl` (n=550, real MTGA
+menus, `#perm`-suffixed permuted twin alongside). The scorer is
+`tools/training/gate_play_decisions.py gate` (G1-G7, fail-closed, exit 0/2).
+`tools/training/build_gate_corpus_v2.py` / `gate_prompts.jsonl` (400 rows)
+belong to the older mulligan Stage-0 gate (`gate_stage0.py`) — NOT the
+strategic gate; not used tonight.
+
+End-to-end command sequence (proven previously as the `pd-gate-lora` flow,
+docs/rl-training-status.md sections 21 and 23.8):
+
+1. **serve** — vLLM (`/home/joshu/venv-serve/bin/python3`, vllm
+   0.22.1rc1.dev596) serves `google/gemma-4-12B-it` bf16 with
+   `--enable-lora --max-lora-rank 8 --lora-modules b5=<adapter dir>`.
+2. **generate** — `tools.eval.run` replays corpus + permuted twin through
+   `openai-compatible|http://127.0.0.1:8003/v1|{b5, google/gemma-4-12B-it}`
+   (temperature 0.0 and max_tokens 400 come from the corpus records).
+3. **score** — `gate_play_decisions.py gate` on the three response files
+   (candidate identity, candidate permuted, baseline identity — the gate
+   takes no baseline-permuted arm).
+4. **compare** — pre-registered legs L1/L2/L3 read from the report.
+
+All four steps are wrapped in **`tools/training/wp3/run_b5_gate_eval.py`**
+(new). One command after the GPU frees (~18:35):
+
+    /home/joshu/venv-train/bin/python3 -m tools.training.wp3.run_b5_gate_eval --gpu 0
+
+CPU-only preflight (safe any time):
+
+    /home/joshu/venv-train/bin/python3 -m tools.training.wp3.run_b5_gate_eval --dry-run
+
+## Can the scorer consume a PEFT adapter directory?
+
+The scorer itself is model-free (consumes response JSONL). Generation is the
+model-touching step, and **vLLM consumes the PEFT adapter dir directly — no
+merge needed**. Verified compatibility evidence: the B5 checkpoints'
+`adapter_config.json` (`peft_type` LORA, r=8, alpha=16, regex
+`target_modules` `(.*language_model.*(q_proj|...|down_proj))`) is
+byte-for-byte the same *shape* as
+`/home/joshu/checkpoints/play_decisions_v2_gemma31b_lora/adapter_config.json`,
+which was served exactly this way for the section-21 gate run. transformers+
+peft direct load (venv-train has peft 0.19.1) would also work but is slower
+and was not the proven path; not used.
+
+Adapter dir layout expected by the runner (fail-closed checks):
+`adapter_config.json` + `adapter_model.safetensors` (>= 1 MB), config
+`base_model_name_or_path == google/gemma-4-12B-it`, `peft_type == LORA`.
+Checkpoint resolution: candidates = root itself (final trainer save) plus
+`checkpoint-N/` subdirs; a candidate is complete only if those files exist
+and are untouched for `--min-age-s` (90 s) — this is how the runner avoids
+grabbing a checkpoint mid-write while the trainer is live. Newest complete
+`adapter_model.safetensors` mtime wins.
+
+## Pre-registered legs, encoded in the runner
+
+- **L1** candidate overall accuracy strictly > 0.4727. Recorded honestly in
+  the summary: that floor was measured with the **31B** base arm; tonight's
+  baseline arm is the 12B base (the LoRA's actual base), and the summary
+  carries both the absolute floor check and the same-base paired-bootstrap
+  delta.
+- **L2** candidate `legality_rate >= baseline legality_rate`.
+- **L3** combat slice: **VACUOUS tonight** — `combat_gate_*.jsonl` are stale
+  (built from the old colliding-id corpus, section 23.8) and the runner
+  prints VACUOUS, never PASS.
+- The full G1-G7 verdict is produced alongside (it is stricter; e.g. G7
+  requires the strategic-subset delta CI to exclude 0 vs the 12B base).
+  Exit code of the runner reflects L1 and L2 only; both verdicts are in
+  `gate_b5_smoke_summary.json`.
+
+## Tripwires (#443)
+
+`gate_play_decisions.py` does NOT support the tripwire fixtures (different
+response contract: `action_type` schema, not `{"pick": N}`) — that remains
+the "wire tripwires into a gate" backlog item as a *hard gate leg*. What IS
+wired tonight: **`tools/training/wp3/score_tripwires.py`** (new) scores a
+responses JSONL against the 55 fixtures by reusing the existing
+`build_tripwires.run_tripwire_eval` (no scoring logic re-implemented;
+ordering skew between fixtures and the evaluator is asserted). The runner
+regenerates the fixtures (the checked-out `tripwire_fixtures.jsonl` had only
+50 rows — stale; `build_tripwires.py` deterministically emits 55 to
+`tripwire_fixtures_55.jsonl`), generates both arms, and records per-category
+histograms in the summary as an ADVISORY slice. Missing/errored responses
+are scored as failed AND counted separately (never silently dropped).
+
+## Measured / verified (all CPU, no GPU touched)
+
+- Dry-run preflight: PASS end-to-end. Resolved adapter live while the
+  trainer was writing: picked `checkpoint-150` (complete), skipped the
+  incomplete root dir. Corpora: 550 + 550 records, id sets equal modulo
+  `#perm` suffix.
+- `py_compile` clean on both new files; `--help` (full import chain incl.
+  arenamcp) exits 0 for `tools.eval.run`, `tools.training.gate_play_decisions`,
+  `tools.training.wp3.score_tripwires`.
+- Real `gate` command executed on CPU with the runner's exact labels using
+  `simulate`-generated responses (`land_else_first` candidate vs `first`
+  baseline, n=550, 2000 bootstraps): verdict BLOCKED on G6/G7 as expected
+  for reflex policies; every report field the verdict code reads
+  (`candidate.overall.accuracy`, `legality_rate`, `paired_bootstrap*`,
+  `verdict`, `failures`) present with expected shapes.
+- Tripwire scorer: oracle arm 55/55 (100.0%), broken arm 0/55 with
+  missing=3 / errored=2 accounted; category histogram printed
+  (15 keep / 15 mull / 10 lethal / 10 counter / 2 develop / 2 attack /
+  1 pass).
+- Harness regression tests: `tests/test_gate_play_decisions.py`,
+  `test_gate_stats.py`, `test_temperature_fallback.py` — 46 passed,
+  4 skipped.
+- vllm 0.22.1rc1.dev596 importable from venv-serve;
+  `models--google--gemma-4-12B-it` present in the HF hub cache.
+
+## Could NOT verify (needs the GPU)
+
+- The single GPU step: vLLM serving `google/gemma-4-12B-it` +
+  `--lora-modules b5=<checkpoint>` on this exact vllm build (LoRA loading of
+  THIS adapter has not been exercised; the shape-identical 31B sibling was).
+- `--max-model-len 49152` headroom: chosen to cover the 32.4k-token prompt
+  that 400'd the v1 run; not re-measured against this vllm build.
+- End-to-end generation latency (550 x 3 arms + 55 x 2 tripwires).
+
+## Known concerns for whoever runs it
+
+- The corpus `system` prompt (7907 chars) no longer equals the current
+  `AUTOPILOT_SYSTEM_PROMPT` (8262 chars) — the prompt changed after the
+  corpus was built at 1644f26. Generation uses the system stored IN the
+  corpus records (comparable with the 47.27 measurement, which is what
+  pre-registration requires), and the equality assert lives in `build`,
+  not `gate`, so nothing blocks. A future corpus rebuild resets the floor.
+- The 47.27 floor is a 31B-base number; beating it with a 12B+LoRA is a
+  strictly harder ask than beating its own base. Both comparisons are in
+  the summary so the verdict cannot be quoted without that context.
+- The trainer's final top-level save (`adapter_model.safetensors` in the
+  root) will outrank checkpoint-N by mtime once written — that is the
+  intended behavior of "last complete checkpoint".

--- a/tools/training/wp3/run_b5_gate_eval.py
+++ b/tools/training/wp3/run_b5_gate_eval.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""B5 gate evaluation runner — base vs LoRA adapter on the strategic gate.
+
+Pre-registered gate for the wp3_gemma12b_b5_smoke LoRA
+(google/gemma-4-12B-it, WP-3 priority decisions):
+
+  L1  beat the base model on the strategic gate: candidate overall
+      accuracy STRICTLY > 0.4727 (the 47.27% base-arm number from
+      tools/training/data/gate_report_strategic_v1.json, n=550, corpus
+      tools/training/data/gate_strategic_decisions_test.jsonl).
+      NOTE recorded honestly: that 47.27 was measured with
+      google/gemma-4-31B-it as the base arm. Tonight's baseline arm is
+      google/gemma-4-12B-it (the LoRA's actual base), so the report
+      carries BOTH comparisons: the pre-registered absolute floor and the
+      same-base paired delta.
+  L2  legality >= base: candidate legality_rate >= baseline legality_rate.
+  L3  no combat-slice regression — VACUOUS tonight: the combat gate
+      corpus is stale/empty (docs/rl-training-status.md section 23.8:
+      combat_gate_*.jsonl were built from the old colliding-id corpus and
+      must be regenerated). This leg is printed as VACUOUS, never PASS.
+
+The full G1-G7 verdict from tools/training/gate_play_decisions.py is run
+and reported alongside; it is a separate (stricter) verdict from the three
+pre-registered legs above.
+
+Pipeline (matches the proven pd-gate-lora flow, section 21/23.8):
+
+  serve   vLLM (venv-serve) serves google/gemma-4-12B-it bf16 with
+          --enable-lora --lora-modules b5=<adapter dir>. vLLM consumes the
+          PEFT adapter directory DIRECTLY — no merge needed. The identical
+          adapter_config shape (regex target_modules, r=8, from
+          tools/training/train.py) was served this way for
+          play_decisions_v2_gemma31b_lora.                    [GPU STEP]
+  generate tools.eval.run replays the corpus through both arms
+          (openai-compat|http://127.0.0.1:<port>/v1|{b5, base}).
+  score   tools.training.gate_play_decisions gate  (CPU) +
+          tools/training/wp3/score_tripwires.py for the 55 tripwire
+          fixtures (#443) as an ADVISORY slice (not a pre-registered leg).
+  verdict this script reads the gate report and prints/records L1-L3.
+
+Checkpoint selection: --checkpoint-root may still be written by the live
+trainer. The runner picks the LAST COMPLETE save: any of {root itself,
+root/checkpoint-N} that contains adapter_config.json + a non-trivial
+adapter_model.safetensors whose newest file is older than --min-age-s.
+Among complete candidates the newest adapter_model.safetensors mtime wins
+(the trainer writes checkpoints in order; a final top-level save is
+written last). Fail closed if none qualify.
+
+CPU-only preflight (safe while the GPU is busy):
+
+    /home/joshu/venv-train/bin/python3 tools/training/wp3/run_b5_gate_eval.py --dry-run
+
+Full run (needs the GPU — only after the training run frees it, ~18:35):
+
+    /home/joshu/venv-train/bin/python3 tools/training/wp3/run_b5_gate_eval.py --gpu 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shlex
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+DEFAULT_CHECKPOINT_ROOT = REPO / "tools" / "training" / "checkpoints" / "wp3_gemma12b_b5_smoke"
+DEFAULT_DATA_DIR = REPO / "tools" / "training" / "data"
+DEFAULT_BASE_MODEL = "google/gemma-4-12B-it"
+DEFAULT_SERVE_PYTHON = "/home/joshu/venv-serve/bin/python3"
+DEFAULT_PORT = 8003
+LORA_NAME = "b5"
+
+# Pre-registered absolute floor (L1). Source: gate_report_strategic_v1.json,
+# baseline arm openai-compat:gemma-4-31b-it-base, overall accuracy 0.4727
+# (260/550) on gate_strategic_decisions_test.jsonl. Strictly greater-than.
+PREREG_STRATEGIC_FLOOR = 0.4727
+
+REQUIRED_ADAPTER_FILES = ("adapter_config.json", "adapter_model.safetensors")
+MIN_ADAPTER_BYTES = 1_000_000  # a real r=8 12B adapter is tens of MB; refuse stubs
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"FAIL-CLOSED: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def log(msg: str) -> None:
+    print(f"[b5-gate] {msg}", flush=True)
+
+
+# --------------------------------------------------------------------------
+# Checkpoint resolution
+# --------------------------------------------------------------------------
+
+
+def _is_complete_adapter(d: Path, min_age_s: float) -> bool:
+    for name in REQUIRED_ADAPTER_FILES:
+        if not (d / name).is_file():
+            return False
+    st = (d / "adapter_model.safetensors").stat()
+    if st.st_size < MIN_ADAPTER_BYTES:
+        return False
+    newest = max((d / name).stat().st_mtime for name in REQUIRED_ADAPTER_FILES)
+    if time.time() - newest < min_age_s:
+        return False  # possibly still being written by the live trainer
+    return True
+
+
+def resolve_adapter(root: Path, explicit: Path | None, min_age_s: float, base_model: str) -> Path:
+    if explicit is not None:
+        if not _is_complete_adapter(explicit, min_age_s=0):
+            die(f"--adapter {explicit} is not a complete PEFT adapter dir "
+                f"(needs {REQUIRED_ADAPTER_FILES}, safetensors >= {MIN_ADAPTER_BYTES} B)")
+        chosen = explicit
+    else:
+        if not root.is_dir():
+            die(f"checkpoint root does not exist: {root}")
+        candidates = [root] + sorted(
+            (p for p in root.glob("checkpoint-*") if p.is_dir()),
+            key=lambda p: int(p.name.split("-")[-1]) if p.name.split("-")[-1].isdigit() else -1,
+        )
+        complete = [c for c in candidates if _is_complete_adapter(c, min_age_s)]
+        if not complete:
+            die(
+                f"no COMPLETE adapter found under {root} "
+                f"(complete = {REQUIRED_ADAPTER_FILES} present, safetensors >= "
+                f"{MIN_ADAPTER_BYTES} B, untouched for {min_age_s:.0f}s). "
+                "The trainer may still be mid-write — retry later or pass --adapter."
+            )
+        chosen = max(complete, key=lambda c: (c / "adapter_model.safetensors").stat().st_mtime)
+        skipped = [str(c) for c in candidates if c not in complete]
+        if skipped:
+            log(f"skipped incomplete/too-fresh candidates: {skipped}")
+
+    cfg = json.loads((chosen / "adapter_config.json").read_text(encoding="utf-8"))
+    got_base = cfg.get("base_model_name_or_path", "")
+    if got_base != base_model:
+        die(f"adapter {chosen} was trained on {got_base!r}, expected {base_model!r}")
+    if cfg.get("peft_type") != "LORA":
+        die(f"adapter {chosen} peft_type={cfg.get('peft_type')!r}, expected LORA")
+    log(f"resolved adapter: {chosen} (r={cfg.get('r')}, alpha={cfg.get('lora_alpha')})")
+    return chosen
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Preflight (CPU-only)
+# --------------------------------------------------------------------------
+
+
+def check_corpora(corpus: Path, permuted: Path) -> int:
+    def load_ids(p: Path) -> list[str]:
+        if not p.is_file():
+            die(f"gate corpus missing: {p}")
+        ids = []
+        with open(p, encoding="utf-8") as f:
+            for i, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError as e:
+                    die(f"malformed corpus line {p}:{i}: {e}")
+                for key in ("id", "system", "user", "meta"):
+                    if key not in rec:
+                        die(f"corpus record {p}:{i} missing key {key!r}")
+                if "menu_size" not in rec["meta"]:
+                    die(f"corpus record {p}:{i} meta missing menu_size")
+                ids.append(str(rec["id"]))
+        return ids
+
+    ids_a, ids_b = load_ids(corpus), load_ids(permuted)
+    if len(ids_a) != len(set(ids_a)):
+        die(f"duplicate ids in {corpus}")
+    # Permuted-twin ids carry a '#perm' suffix by design (prevents response
+    # files from cross-contaminating between the identity and permuted arms).
+    not_suffixed = [i for i in ids_b if not i.endswith("#perm")]
+    if not_suffixed:
+        die(f"{len(not_suffixed)} permuted ids lack the '#perm' suffix in {permuted.name}")
+    if set(ids_a) != {i[: -len("#perm")] for i in ids_b}:
+        die(f"id sets differ between {corpus.name} and {permuted.name} (modulo '#perm')")
+    log(f"corpora OK: {len(ids_a)} decisions, identity/permuted id sets equal (modulo '#perm')")
+    return len(ids_a)
+
+
+def check_cli_importable(python: str, module: str, *help_args: str) -> None:
+    r = subprocess.run(
+        [python, "-m", module, *help_args, "--help"],
+        cwd=REPO, capture_output=True, text=True, timeout=180,
+    )
+    if r.returncode != 0:
+        die(f"`{python} -m {module} --help` failed:\n{r.stderr[-2000:]}")
+    log(f"CLI import OK: {module}")
+
+
+def check_port_free(port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError:
+            die(f"port {port} is already in use — is another vLLM running? "
+                "Use --skip-serve to target it, or pick --port.")
+
+
+def regen_tripwires(python: str, out: Path) -> None:
+    r = subprocess.run(
+        [python, str(REPO / "tools" / "training" / "build_tripwires.py"), "--output", str(out)],
+        cwd=REPO, capture_output=True, text=True, timeout=300,
+    )
+    if r.returncode != 0:
+        die(f"tripwire fixture generation failed:\n{r.stderr[-2000:]}")
+    n = sum(1 for line in open(out, encoding="utf-8") if line.strip())
+    if n != 55:
+        die(f"regenerated tripwire fixture count {n} != 55 ({out})")
+    log(f"tripwire fixtures OK: 55 at {out}")
+
+
+# --------------------------------------------------------------------------
+# Serve (THE GPU STEP)
+# --------------------------------------------------------------------------
+
+
+def serve_cmd(args: argparse.Namespace, adapter: Path) -> list[str]:
+    cfg = json.loads((adapter / "adapter_config.json").read_text(encoding="utf-8"))
+    max_lora_rank = max(8, int(cfg.get("r", 8)))
+    cmd = [
+        args.serve_python, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", args.base_model,
+        "--served-model-name", args.base_model,
+        "--port", str(args.port),
+        "--dtype", "bfloat16",
+        "--max-model-len", str(args.max_model_len),
+        "--gpu-memory-utilization", str(args.gpu_mem_util),
+        "--enable-lora",
+        "--max-lora-rank", str(max_lora_rank),
+        "--lora-modules", f"{LORA_NAME}={adapter}",
+    ]
+    cmd += args.extra_serve_arg or []
+    return cmd
+
+
+def wait_for_server(port: int, timeout_s: float) -> None:
+    url = f"http://127.0.0.1:{port}/v1/models"
+    deadline = time.time() + timeout_s
+    last_err = "never reached"
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+            names = {m.get("id") for m in data.get("data", [])}
+            if LORA_NAME in names:
+                log(f"server up, models: {sorted(names)}")
+                return
+            last_err = f"lora module {LORA_NAME!r} not in served models {sorted(names)}"
+        except Exception as e:  # noqa: BLE001 - poll loop
+            last_err = str(e)
+        time.sleep(5)
+    die(f"vLLM server not healthy after {timeout_s:.0f}s: {last_err}")
+
+
+# --------------------------------------------------------------------------
+# Generation + accounting
+# --------------------------------------------------------------------------
+
+
+def run_arm(args: argparse.Namespace, prompts: Path, responses: Path, model: str) -> None:
+    backend = f"openai-compatible|http://127.0.0.1:{args.port}/v1|{model}"
+    cmd = [
+        sys.executable, "-m", "tools.eval.run",
+        "--prompts", str(prompts),
+        "--responses", str(responses),
+        "--backend", backend,
+        "--timeout-s", str(args.request_timeout_s),
+        "--concurrency", str(args.concurrency),
+    ]
+    log("RUN " + shlex.join(cmd))
+    r = subprocess.run(cmd, cwd=REPO)
+    if r.returncode != 0:
+        die(f"generation failed for {model} on {prompts.name} (exit {r.returncode})")
+
+
+def assert_arm_complete(responses: Path, label: str, expected_n: int) -> None:
+    ok = errors = 0
+    with open(responses, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if row.get("backend") != label:
+                continue
+            if row.get("error"):
+                errors += 1
+            else:
+                ok += 1
+    if errors or ok < expected_n:
+        die(
+            f"arm {label!r} in {responses.name}: {ok} ok / {errors} errored, "
+            f"expected {expected_n} clean rows. tools.eval.run is idempotent — "
+            "fix the server condition and re-run; errored rows must be "
+            "investigated, not scored (a server outage must not read as a "
+            "wrong answer)."
+        )
+    log(f"arm complete: {label} {ok}/{expected_n}, 0 errors")
+
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--checkpoint-root", type=Path, default=DEFAULT_CHECKPOINT_ROOT)
+    p.add_argument("--adapter", type=Path, default=None,
+                   help="explicit PEFT adapter dir (skips last-checkpoint resolution)")
+    p.add_argument("--min-age-s", type=float, default=90.0,
+                   help="a checkpoint written more recently than this is treated as in-flight")
+    p.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
+    p.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
+    p.add_argument("--corpus", type=Path, default=None,
+                   help="default: <data-dir>/gate_strategic_decisions_test.jsonl")
+    p.add_argument("--permuted-corpus", type=Path, default=None)
+    p.add_argument("--run-id", default="b5_smoke")
+    p.add_argument("--serve-python", default=DEFAULT_SERVE_PYTHON)
+    p.add_argument("--port", type=int, default=DEFAULT_PORT)
+    p.add_argument("--gpu", default="0", help="CUDA_VISIBLE_DEVICES for the vLLM server")
+    p.add_argument("--max-model-len", type=int, default=49152,
+                   help="must cover the longest corpus prompt (~33k tokens observed) + output")
+    p.add_argument("--gpu-mem-util", type=float, default=0.85)
+    p.add_argument("--extra-serve-arg", action="append", default=None)
+    p.add_argument("--serve-timeout-s", type=float, default=900.0)
+    p.add_argument("--request-timeout-s", type=float, default=180.0)
+    p.add_argument("--concurrency", type=int, default=8)
+    p.add_argument("--bootstraps", type=int, default=10000)
+    p.add_argument("--skip-serve", action="store_true",
+                   help="assume a healthy server on --port already serves base + lora")
+    p.add_argument("--keep-server", action="store_true",
+                   help="do not stop the vLLM server on exit")
+    p.add_argument("--skip-tripwires", action="store_true")
+    p.add_argument("--dry-run", action="store_true",
+                   help="CPU-only preflight: resolve adapter, validate corpora/CLIs, "
+                        "print the exact GPU command, then exit")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    data = args.data_dir
+    corpus = args.corpus or (data / "gate_strategic_decisions_test.jsonl")
+    permuted = args.permuted_corpus or (data / "gate_strategic_decisions_test_permuted.jsonl")
+
+    cand_label = f"openai-compat:{LORA_NAME}"
+    base_label = f"openai-compat:{args.base_model}"
+
+    out = {
+        "cand_test": data / f"gate_{args.run_id}_candidate_test.jsonl",
+        "cand_perm": data / f"gate_{args.run_id}_candidate_test_permuted.jsonl",
+        "base_test": data / f"gate_{args.run_id}_baseline_test.jsonl",
+        "tripwires_fixtures": data / "tripwire_fixtures_55.jsonl",
+        "tripwires_resp": data / f"gate_{args.run_id}_tripwires.jsonl",
+        "tripwires_cand_score": data / f"gate_{args.run_id}_tripwires_candidate_score.json",
+        "tripwires_base_score": data / f"gate_{args.run_id}_tripwires_baseline_score.json",
+        "report": data / f"gate_report_{args.run_id}.json",
+        "summary": data / f"gate_{args.run_id}_summary.json",
+        "serve_log": data / f"gate_{args.run_id}_vllm.log",
+    }
+
+    # ---- preflight (CPU-only) --------------------------------------------
+    adapter = resolve_adapter(args.checkpoint_root, args.adapter, args.min_age_s, args.base_model)
+    n = check_corpora(corpus, permuted)
+    check_cli_importable(sys.executable, "tools.eval.run")
+    check_cli_importable(sys.executable, "tools.training.gate_play_decisions")
+    check_cli_importable(sys.executable, "tools.training.wp3.score_tripwires")
+    r = subprocess.run([args.serve_python, "-c", "import vllm; print(vllm.__version__)"],
+                       capture_output=True, text=True, timeout=300)
+    if r.returncode != 0:
+        die(f"vllm not importable from {args.serve_python}:\n{r.stderr[-1000:]}")
+    log(f"vllm {r.stdout.strip()} available in {args.serve_python}")
+    hub = Path.home() / ".cache" / "huggingface" / "hub"
+    cache_name = "models--" + args.base_model.replace("/", "--")
+    if not (hub / cache_name).exists():
+        log(f"WARNING: {args.base_model} not in HF cache ({hub / cache_name}); "
+            "vLLM will try to download it")
+    if not args.skip_tripwires:
+        regen_tripwires(sys.executable, out["tripwires_fixtures"])
+    if not args.skip_serve and not args.dry_run:
+        check_port_free(args.port)
+
+    gpu_cmd = serve_cmd(args, adapter)
+    log("=" * 72)
+    log(f"GPU STEP (the ONLY step that touches the GPU; CUDA_VISIBLE_DEVICES={args.gpu}):")
+    log(f"  CUDA_VISIBLE_DEVICES={args.gpu} " + shlex.join(gpu_cmd))
+    log("=" * 72)
+
+    if args.dry_run:
+        log("dry-run: preflight PASSED; stopping before the GPU step.")
+        return 0
+
+    # ---- serve -----------------------------------------------------------
+    server = None
+    if not args.skip_serve:
+        env = dict(os.environ, CUDA_VISIBLE_DEVICES=str(args.gpu))
+        log(f"starting vLLM (log: {out['serve_log']})")
+        server = subprocess.Popen(
+            gpu_cmd, cwd=REPO, env=env,
+            stdout=open(out["serve_log"], "ab"), stderr=subprocess.STDOUT,
+        )
+    try:
+        wait_for_server(args.port, args.serve_timeout_s)
+
+        # ---- generate ----------------------------------------------------
+        run_arm(args, corpus, out["cand_test"], LORA_NAME)
+        run_arm(args, permuted, out["cand_perm"], LORA_NAME)
+        run_arm(args, corpus, out["base_test"], args.base_model)
+        assert_arm_complete(out["cand_test"], cand_label, n)
+        assert_arm_complete(out["cand_perm"], cand_label, n)
+        assert_arm_complete(out["base_test"], base_label, n)
+
+        tripwire_scores = {}
+        if not args.skip_tripwires:
+            run_arm(args, out["tripwires_fixtures"], out["tripwires_resp"], LORA_NAME)
+            run_arm(args, out["tripwires_fixtures"], out["tripwires_resp"], args.base_model)
+            for label, score_path in (
+                (cand_label, out["tripwires_cand_score"]),
+                (base_label, out["tripwires_base_score"]),
+            ):
+                rr = subprocess.run(
+                    [sys.executable, "-m", "tools.training.wp3.score_tripwires",
+                     "--fixtures", str(out["tripwires_fixtures"]),
+                     "--responses", str(out["tripwires_resp"]),
+                     "--backend-label", label,
+                     "--out", str(score_path)],
+                    cwd=REPO,
+                )
+                if rr.returncode != 0:
+                    die(f"tripwire scoring failed for {label}")
+                s = json.loads(score_path.read_text(encoding="utf-8"))
+                tripwire_scores[label] = {
+                    "pass_rate": s["pass_rate"],
+                    "passed": s["passed"],
+                    "total": s["total_fixtures"],
+                    "categories": {k: v for k, v in s["categories"].items()},
+                }
+    finally:
+        if server is not None and not args.keep_server:
+            log("stopping vLLM server")
+            server.terminate()
+            try:
+                server.wait(timeout=60)
+            except subprocess.TimeoutExpired:
+                server.kill()
+
+    # ---- full G1-G7 gate (CPU) ------------------------------------------
+    gate_cmd = [
+        sys.executable, "-m", "tools.training.gate_play_decisions", "gate",
+        "--corpus", str(corpus),
+        "--permuted-corpus", str(permuted),
+        "--responses", str(out["cand_test"]),
+        "--permuted-responses", str(out["cand_perm"]),
+        "--baseline-responses", str(out["base_test"]),
+        "--backend-label", cand_label,
+        "--baseline-label", base_label,
+        "--bootstraps", str(args.bootstraps),
+        "--report", str(out["report"]),
+    ]
+    log("RUN " + shlex.join(gate_cmd))
+    gate_rc = subprocess.run(gate_cmd, cwd=REPO).returncode
+    if gate_rc not in (0, 2):
+        die(f"gate_play_decisions crashed (exit {gate_rc})")
+    if not out["report"].exists():
+        die("gate report was not written")
+    report = json.loads(out["report"].read_text(encoding="utf-8"))
+
+    # ---- pre-registered verdict L1-L3 ------------------------------------
+    cand_overall = report["candidate"]["overall"]["accuracy"]
+    cand_legality = report["candidate"]["legality_rate"]
+    base_overall = report["baseline"]["overall"]["accuracy"]
+    base_legality = report["baseline"]["legality_rate"]
+
+    l1 = cand_overall is not None and cand_overall > PREREG_STRATEGIC_FLOOR
+    l2 = (cand_legality is not None and base_legality is not None
+          and cand_legality >= base_legality)
+
+    summary = {
+        "run_id": args.run_id,
+        "adapter": str(adapter),
+        "adapter_sha256": sha256_file(adapter / "adapter_model.safetensors"),
+        "base_model": args.base_model,
+        "corpus": str(corpus),
+        "corpus_n": n,
+        "prereg": {
+            "L1_strategic_gt_floor": {
+                "floor": PREREG_STRATEGIC_FLOOR,
+                "floor_provenance": "gate_report_strategic_v1.json baseline arm "
+                                    "(openai-compat:gemma-4-31b-it-base, 260/550)",
+                "candidate_overall": cand_overall,
+                "pass": l1,
+            },
+            "L2_legality_ge_base": {
+                "candidate_legality": cand_legality,
+                "baseline_legality": base_legality,
+                "pass": l2,
+            },
+            "L3_combat_no_regression": {
+                "status": "VACUOUS",
+                "reason": "combat gate corpus stale/empty tonight "
+                          "(rl-training-status section 23.8); leg not evaluable",
+            },
+        },
+        "same_base_comparison": {
+            "baseline_overall_gemma12b": base_overall,
+            "paired_bootstrap": report.get("paired_bootstrap"),
+            "paired_bootstrap_strategic": report.get("paired_bootstrap_strategic"),
+        },
+        "full_gate_verdict_g1_g7": report.get("verdict"),
+        "full_gate_failures": report.get("failures"),
+        "tripwires_advisory": tripwire_scores if not args.skip_tripwires else "skipped",
+        "gate_report": str(out["report"]),
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+    out["summary"].write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+    log("=" * 72)
+    log(f"pre-registered L1 (overall > {PREREG_STRATEGIC_FLOOR}): "
+        f"candidate {cand_overall} -> {'PASS' if l1 else 'FAIL'}")
+    log(f"pre-registered L2 (legality >= base): "
+        f"{cand_legality} vs {base_legality} -> {'PASS' if l2 else 'FAIL'}")
+    log("pre-registered L3 (combat slice): VACUOUS tonight (empty/stale corpus)")
+    log(f"same-base (12B) comparison: base overall {base_overall}, "
+        f"paired delta CI {report.get('paired_bootstrap')}")
+    log(f"full G1-G7 gate verdict: {report.get('verdict')} (exit {gate_rc})")
+    log(f"summary: {out['summary']}")
+    log("=" * 72)
+
+    return 0 if (l1 and l2) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/training/wp3/run_b5_gate_eval.py
+++ b/tools/training/wp3/run_b5_gate_eval.py
@@ -14,10 +14,17 @@ Pre-registered gate for the wp3_gemma12b_b5_smoke LoRA
       carries BOTH comparisons: the pre-registered absolute floor and the
       same-base paired delta.
   L2  legality >= base: candidate legality_rate >= baseline legality_rate.
-  L3  no combat-slice regression — VACUOUS tonight: the combat gate
-      corpus is stale/empty (docs/rl-training-status.md section 23.8:
-      combat_gate_*.jsonl were built from the old colliding-id corpus and
-      must be regenerated). This leg is printed as VACUOUS, never PASS.
+  L3  no combat-slice regression: candidate non-degenerate accuracy on
+      the combat gate test corpus >= 0.393 (the 07-28 baseline arm's
+      non_degenerate accuracy from
+      gate_combat_report_combat_v1_gemma31b_lora.json, n=2,557). The
+      combat gate corpus is CLEAN and current — rebuilt 2026-07-27
+      (combat_gate_manifest.json: 96,131/96,131 distinct ids, leak check
+      clean) and consumed 07-28; the earlier stale-corpus note in
+      rl-training-status section 23.8 was superseded by 23.9. As with L1
+      the floor arm was 31B-lora-era; the report also records the
+      same-base 12B paired delta so neither number is quoted alone.
+      --skip-combat marks the leg SKIPPED (loudly, never silently).
 
 The full G1-G7 verdict from tools/training/gate_play_decisions.py is run
 and reported alongside; it is a separate (stricter) verdict from the three
@@ -83,6 +90,12 @@ LORA_NAME = "b5"
 # (260/550) on gate_strategic_decisions_test.jsonl. Strictly greater-than.
 PREREG_STRATEGIC_FLOOR = 0.4727
 
+# Pre-registered combat floor (L3). Source:
+# gate_combat_report_combat_v1_gemma31b_lora.json baseline.non_degenerate
+# .accuracy = 0.393 (n=2,557 non-degenerate combat decisions). Candidate
+# must be >= (no regression against the recorded slice baseline).
+PREREG_COMBAT_FLOOR = 0.393
+
 REQUIRED_ADAPTER_FILES = ("adapter_config.json", "adapter_model.safetensors")
 MIN_ADAPTER_BYTES = 1_000_000  # a real r=8 12B adapter is tens of MB; refuse stubs
 
@@ -117,8 +130,10 @@ def _is_complete_adapter(d: Path, min_age_s: float) -> bool:
 def resolve_adapter(root: Path, explicit: Path | None, min_age_s: float, base_model: str) -> Path:
     if explicit is not None:
         if not _is_complete_adapter(explicit, min_age_s=0):
-            die(f"--adapter {explicit} is not a complete PEFT adapter dir "
-                f"(needs {REQUIRED_ADAPTER_FILES}, safetensors >= {MIN_ADAPTER_BYTES} B)")
+            die(
+                f"--adapter {explicit} is not a complete PEFT adapter dir "
+                f"(needs {REQUIRED_ADAPTER_FILES}, safetensors >= {MIN_ADAPTER_BYTES} B)"
+            )
         chosen = explicit
     else:
         if not root.is_dir():
@@ -163,7 +178,12 @@ def sha256_file(path: Path) -> str:
 # --------------------------------------------------------------------------
 
 
-def check_corpora(corpus: Path, permuted: Path) -> int:
+def check_corpora(
+    corpus: Path,
+    permuted: Path,
+    perm_suffix: str = "#perm",
+    require_menu_size: bool = True,
+) -> int:
     def load_ids(p: Path) -> list[str]:
         if not p.is_file():
             die(f"gate corpus missing: {p}")
@@ -180,7 +200,7 @@ def check_corpora(corpus: Path, permuted: Path) -> int:
                 for key in ("id", "system", "user", "meta"):
                     if key not in rec:
                         die(f"corpus record {p}:{i} missing key {key!r}")
-                if "menu_size" not in rec["meta"]:
+                if require_menu_size and "menu_size" not in rec["meta"]:
                     die(f"corpus record {p}:{i} meta missing menu_size")
                 ids.append(str(rec["id"]))
         return ids
@@ -188,12 +208,13 @@ def check_corpora(corpus: Path, permuted: Path) -> int:
     ids_a, ids_b = load_ids(corpus), load_ids(permuted)
     if len(ids_a) != len(set(ids_a)):
         die(f"duplicate ids in {corpus}")
-    # Permuted-twin ids carry a '#perm' suffix by design (prevents response
-    # files from cross-contaminating between the identity and permuted arms).
-    not_suffixed = [i for i in ids_b if not i.endswith("#perm")]
+    # Permuted-twin ids carry a suffix by design (prevents response files
+    # from cross-contaminating between the identity and permuted arms).
+    # Strategic corpora use '#perm'; the combat gate corpora use '-perm'.
+    not_suffixed = [i for i in ids_b if not i.endswith(perm_suffix)]
     if not_suffixed:
-        die(f"{len(not_suffixed)} permuted ids lack the '#perm' suffix in {permuted.name}")
-    if set(ids_a) != {i[: -len("#perm")] for i in ids_b}:
+        die(f"{len(not_suffixed)} permuted ids lack the {perm_suffix!r} suffix in {permuted.name}")
+    if set(ids_a) != {i[: -len(perm_suffix)] for i in ids_b}:
         die(f"id sets differ between {corpus.name} and {permuted.name} (modulo '#perm')")
     log(f"corpora OK: {len(ids_a)} decisions, identity/permuted id sets equal (modulo '#perm')")
     return len(ids_a)
@@ -202,7 +223,10 @@ def check_corpora(corpus: Path, permuted: Path) -> int:
 def check_cli_importable(python: str, module: str, *help_args: str) -> None:
     r = subprocess.run(
         [python, "-m", module, *help_args, "--help"],
-        cwd=REPO, capture_output=True, text=True, timeout=180,
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=180,
     )
     if r.returncode != 0:
         die(f"`{python} -m {module} --help` failed:\n{r.stderr[-2000:]}")
@@ -214,14 +238,19 @@ def check_port_free(port: int) -> None:
         try:
             s.bind(("127.0.0.1", port))
         except OSError:
-            die(f"port {port} is already in use — is another vLLM running? "
-                "Use --skip-serve to target it, or pick --port.")
+            die(
+                f"port {port} is already in use — is another vLLM running? "
+                "Use --skip-serve to target it, or pick --port."
+            )
 
 
 def regen_tripwires(python: str, out: Path) -> None:
     r = subprocess.run(
         [python, str(REPO / "tools" / "training" / "build_tripwires.py"), "--output", str(out)],
-        cwd=REPO, capture_output=True, text=True, timeout=300,
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        timeout=300,
     )
     if r.returncode != 0:
         die(f"tripwire fixture generation failed:\n{r.stderr[-2000:]}")
@@ -240,16 +269,26 @@ def serve_cmd(args: argparse.Namespace, adapter: Path) -> list[str]:
     cfg = json.loads((adapter / "adapter_config.json").read_text(encoding="utf-8"))
     max_lora_rank = max(8, int(cfg.get("r", 8)))
     cmd = [
-        args.serve_python, "-m", "vllm.entrypoints.openai.api_server",
-        "--model", args.base_model,
-        "--served-model-name", args.base_model,
-        "--port", str(args.port),
-        "--dtype", "bfloat16",
-        "--max-model-len", str(args.max_model_len),
-        "--gpu-memory-utilization", str(args.gpu_mem_util),
+        args.serve_python,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        args.base_model,
+        "--served-model-name",
+        args.base_model,
+        "--port",
+        str(args.port),
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        str(args.max_model_len),
+        "--gpu-memory-utilization",
+        str(args.gpu_mem_util),
         "--enable-lora",
-        "--max-lora-rank", str(max_lora_rank),
-        "--lora-modules", f"{LORA_NAME}={adapter}",
+        "--max-lora-rank",
+        str(max_lora_rank),
+        "--lora-modules",
+        f"{LORA_NAME}={adapter}",
     ]
     cmd += args.extra_serve_arg or []
     return cmd
@@ -282,12 +321,19 @@ def wait_for_server(port: int, timeout_s: float) -> None:
 def run_arm(args: argparse.Namespace, prompts: Path, responses: Path, model: str) -> None:
     backend = f"openai-compatible|http://127.0.0.1:{args.port}/v1|{model}"
     cmd = [
-        sys.executable, "-m", "tools.eval.run",
-        "--prompts", str(prompts),
-        "--responses", str(responses),
-        "--backend", backend,
-        "--timeout-s", str(args.request_timeout_s),
-        "--concurrency", str(args.concurrency),
+        sys.executable,
+        "-m",
+        "tools.eval.run",
+        "--prompts",
+        str(prompts),
+        "--responses",
+        str(responses),
+        "--backend",
+        backend,
+        "--timeout-s",
+        str(args.request_timeout_s),
+        "--concurrency",
+        str(args.concurrency),
     ]
     log("RUN " + shlex.join(cmd))
     r = subprocess.run(cmd, cwd=REPO)
@@ -326,39 +372,70 @@ def assert_arm_complete(responses: Path, label: str, expected_n: int) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--checkpoint-root", type=Path, default=DEFAULT_CHECKPOINT_ROOT)
-    p.add_argument("--adapter", type=Path, default=None,
-                   help="explicit PEFT adapter dir (skips last-checkpoint resolution)")
-    p.add_argument("--min-age-s", type=float, default=90.0,
-                   help="a checkpoint written more recently than this is treated as in-flight")
+    p.add_argument(
+        "--adapter",
+        type=Path,
+        default=None,
+        help="explicit PEFT adapter dir (skips last-checkpoint resolution)",
+    )
+    p.add_argument(
+        "--min-age-s",
+        type=float,
+        default=90.0,
+        help="a checkpoint written more recently than this is treated as in-flight",
+    )
     p.add_argument("--base-model", default=DEFAULT_BASE_MODEL)
     p.add_argument("--data-dir", type=Path, default=DEFAULT_DATA_DIR)
-    p.add_argument("--corpus", type=Path, default=None,
-                   help="default: <data-dir>/gate_strategic_decisions_test.jsonl")
+    p.add_argument(
+        "--corpus", type=Path, default=None, help="default: <data-dir>/gate_strategic_decisions_test.jsonl"
+    )
     p.add_argument("--permuted-corpus", type=Path, default=None)
     p.add_argument("--run-id", default="b5_smoke")
     p.add_argument("--serve-python", default=DEFAULT_SERVE_PYTHON)
     p.add_argument("--port", type=int, default=DEFAULT_PORT)
     p.add_argument("--gpu", default="0", help="CUDA_VISIBLE_DEVICES for the vLLM server")
-    p.add_argument("--max-model-len", type=int, default=49152,
-                   help="must cover the longest corpus prompt (~33k tokens observed) + output")
+    p.add_argument(
+        "--max-model-len",
+        type=int,
+        default=49152,
+        help="must cover the longest corpus prompt (~33k tokens observed) + output",
+    )
     p.add_argument("--gpu-mem-util", type=float, default=0.85)
     p.add_argument("--extra-serve-arg", action="append", default=None)
     p.add_argument("--serve-timeout-s", type=float, default=900.0)
     p.add_argument("--request-timeout-s", type=float, default=180.0)
     p.add_argument("--concurrency", type=int, default=8)
     p.add_argument("--bootstraps", type=int, default=10000)
-    p.add_argument("--skip-serve", action="store_true",
-                   help="assume a healthy server on --port already serves base + lora")
-    p.add_argument("--keep-server", action="store_true",
-                   help="do not stop the vLLM server on exit")
+    p.add_argument(
+        "--skip-serve",
+        action="store_true",
+        help="assume a healthy server on --port already serves base + lora",
+    )
+    p.add_argument("--keep-server", action="store_true", help="do not stop the vLLM server on exit")
     p.add_argument("--skip-tripwires", action="store_true")
-    p.add_argument("--dry-run", action="store_true",
-                   help="CPU-only preflight: resolve adapter, validate corpora/CLIs, "
-                        "print the exact GPU command, then exit")
+    p.add_argument(
+        "--combat-corpus", type=Path, default=None, help="default: <data-dir>/combat_gate_test.jsonl"
+    )
+    p.add_argument(
+        "--combat-permuted-corpus",
+        type=Path,
+        default=None,
+        help="default: <data-dir>/combat_gate_test_permuted.jsonl",
+    )
+    p.add_argument(
+        "--skip-combat",
+        action="store_true",
+        help="skip the L3 combat leg; the verdict records SKIPPED "
+        "loudly (never silently) and the exit code ignores L3",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="CPU-only preflight: resolve adapter, validate corpora/CLIs, "
+        "print the exact GPU command, then exit",
+    )
     return p
 
 
@@ -371,7 +448,14 @@ def main(argv: list[str] | None = None) -> int:
     cand_label = f"openai-compat:{LORA_NAME}"
     base_label = f"openai-compat:{args.base_model}"
 
+    combat_corpus = args.combat_corpus or (data / "combat_gate_test.jsonl")
+    combat_permuted = args.combat_permuted_corpus or (data / "combat_gate_test_permuted.jsonl")
+
     out = {
+        "combat_cand": data / f"gate_{args.run_id}_combat_candidate_test.jsonl",
+        "combat_cand_perm": data / f"gate_{args.run_id}_combat_candidate_test_permuted.jsonl",
+        "combat_base": data / f"gate_{args.run_id}_combat_baseline_test.jsonl",
+        "combat_report": data / f"gate_report_{args.run_id}_combat.json",
         "cand_test": data / f"gate_{args.run_id}_candidate_test.jsonl",
         "cand_perm": data / f"gate_{args.run_id}_candidate_test_permuted.jsonl",
         "base_test": data / f"gate_{args.run_id}_baseline_test.jsonl",
@@ -390,16 +474,26 @@ def main(argv: list[str] | None = None) -> int:
     check_cli_importable(sys.executable, "tools.eval.run")
     check_cli_importable(sys.executable, "tools.training.gate_play_decisions")
     check_cli_importable(sys.executable, "tools.training.wp3.score_tripwires")
-    r = subprocess.run([args.serve_python, "-c", "import vllm; print(vllm.__version__)"],
-                       capture_output=True, text=True, timeout=300)
+    combat_n = 0
+    if not args.skip_combat:
+        check_cli_importable(sys.executable, "tools.training.gate_combat_decisions")
+        combat_n = check_corpora(
+            combat_corpus, combat_permuted, perm_suffix="-perm", require_menu_size=False
+        )
+        log(f"combat gate corpus: {combat_n} records ({combat_corpus.name})")
+    r = subprocess.run(
+        [args.serve_python, "-c", "import vllm; print(vllm.__version__)"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
     if r.returncode != 0:
         die(f"vllm not importable from {args.serve_python}:\n{r.stderr[-1000:]}")
     log(f"vllm {r.stdout.strip()} available in {args.serve_python}")
     hub = Path.home() / ".cache" / "huggingface" / "hub"
     cache_name = "models--" + args.base_model.replace("/", "--")
     if not (hub / cache_name).exists():
-        log(f"WARNING: {args.base_model} not in HF cache ({hub / cache_name}); "
-            "vLLM will try to download it")
+        log(f"WARNING: {args.base_model} not in HF cache ({hub / cache_name}); vLLM will try to download it")
     if not args.skip_tripwires:
         regen_tripwires(sys.executable, out["tripwires_fixtures"])
     if not args.skip_serve and not args.dry_run:
@@ -421,8 +515,11 @@ def main(argv: list[str] | None = None) -> int:
         env = dict(os.environ, CUDA_VISIBLE_DEVICES=str(args.gpu))
         log(f"starting vLLM (log: {out['serve_log']})")
         server = subprocess.Popen(
-            gpu_cmd, cwd=REPO, env=env,
-            stdout=open(out["serve_log"], "ab"), stderr=subprocess.STDOUT,
+            gpu_cmd,
+            cwd=REPO,
+            env=env,
+            stdout=open(out["serve_log"], "ab"),
+            stderr=subprocess.STDOUT,
         )
     try:
         wait_for_server(args.port, args.serve_timeout_s)
@@ -435,6 +532,14 @@ def main(argv: list[str] | None = None) -> int:
         assert_arm_complete(out["cand_perm"], cand_label, n)
         assert_arm_complete(out["base_test"], base_label, n)
 
+        if not args.skip_combat:
+            run_arm(args, combat_corpus, out["combat_cand"], LORA_NAME)
+            run_arm(args, combat_permuted, out["combat_cand_perm"], LORA_NAME)
+            run_arm(args, combat_corpus, out["combat_base"], args.base_model)
+            assert_arm_complete(out["combat_cand"], cand_label, combat_n)
+            assert_arm_complete(out["combat_cand_perm"], cand_label, combat_n)
+            assert_arm_complete(out["combat_base"], base_label, combat_n)
+
         tripwire_scores = {}
         if not args.skip_tripwires:
             run_arm(args, out["tripwires_fixtures"], out["tripwires_resp"], LORA_NAME)
@@ -444,11 +549,19 @@ def main(argv: list[str] | None = None) -> int:
                 (base_label, out["tripwires_base_score"]),
             ):
                 rr = subprocess.run(
-                    [sys.executable, "-m", "tools.training.wp3.score_tripwires",
-                     "--fixtures", str(out["tripwires_fixtures"]),
-                     "--responses", str(out["tripwires_resp"]),
-                     "--backend-label", label,
-                     "--out", str(score_path)],
+                    [
+                        sys.executable,
+                        "-m",
+                        "tools.training.wp3.score_tripwires",
+                        "--fixtures",
+                        str(out["tripwires_fixtures"]),
+                        "--responses",
+                        str(out["tripwires_resp"]),
+                        "--backend-label",
+                        label,
+                        "--out",
+                        str(score_path),
+                    ],
                     cwd=REPO,
                 )
                 if rr.returncode != 0:
@@ -471,16 +584,28 @@ def main(argv: list[str] | None = None) -> int:
 
     # ---- full G1-G7 gate (CPU) ------------------------------------------
     gate_cmd = [
-        sys.executable, "-m", "tools.training.gate_play_decisions", "gate",
-        "--corpus", str(corpus),
-        "--permuted-corpus", str(permuted),
-        "--responses", str(out["cand_test"]),
-        "--permuted-responses", str(out["cand_perm"]),
-        "--baseline-responses", str(out["base_test"]),
-        "--backend-label", cand_label,
-        "--baseline-label", base_label,
-        "--bootstraps", str(args.bootstraps),
-        "--report", str(out["report"]),
+        sys.executable,
+        "-m",
+        "tools.training.gate_play_decisions",
+        "gate",
+        "--corpus",
+        str(corpus),
+        "--permuted-corpus",
+        str(permuted),
+        "--responses",
+        str(out["cand_test"]),
+        "--permuted-responses",
+        str(out["cand_perm"]),
+        "--baseline-responses",
+        str(out["base_test"]),
+        "--backend-label",
+        cand_label,
+        "--baseline-label",
+        base_label,
+        "--bootstraps",
+        str(args.bootstraps),
+        "--report",
+        str(out["report"]),
     ]
     log("RUN " + shlex.join(gate_cmd))
     gate_rc = subprocess.run(gate_cmd, cwd=REPO).returncode
@@ -497,8 +622,55 @@ def main(argv: list[str] | None = None) -> int:
     base_legality = report["baseline"]["legality_rate"]
 
     l1 = cand_overall is not None and cand_overall > PREREG_STRATEGIC_FLOOR
-    l2 = (cand_legality is not None and base_legality is not None
-          and cand_legality >= base_legality)
+    l2 = cand_legality is not None and base_legality is not None and cand_legality >= base_legality
+
+    # ---- L3 combat slice (scored with the dedicated combat gate) ---------
+    l3 = None
+    l3_detail: dict = {"status": "SKIPPED", "reason": "--skip-combat passed"}
+    if not args.skip_combat:
+        combat_gate_cmd = [
+            sys.executable,
+            "-m",
+            "tools.training.gate_combat_decisions",
+            "gate",
+            "--corpus",
+            str(combat_corpus),
+            "--permuted-corpus",
+            str(combat_permuted),
+            "--responses",
+            str(out["combat_cand"]),
+            "--permuted-responses",
+            str(out["combat_cand_perm"]),
+            "--baseline-responses",
+            str(out["combat_base"]),
+            "--backend-label",
+            cand_label,
+            "--baseline-label",
+            base_label,
+            "--report",
+            str(out["combat_report"]),
+        ]
+        log("RUN " + shlex.join(combat_gate_cmd))
+        combat_rc = subprocess.run(combat_gate_cmd, cwd=REPO).returncode
+        if combat_rc not in (0, 2):
+            die(f"gate_combat_decisions crashed (exit {combat_rc})")
+        if not out["combat_report"].exists():
+            die("combat gate report was not written")
+        combat_report = json.loads(out["combat_report"].read_text(encoding="utf-8"))
+        cand_nd = combat_report["candidate"]["non_degenerate"]["accuracy"]
+        base_nd = combat_report["baseline"]["non_degenerate"]["accuracy"]
+        l3 = cand_nd is not None and cand_nd >= PREREG_COMBAT_FLOOR
+        l3_detail = {
+            "status": "PASS" if l3 else "FAIL",
+            "floor": PREREG_COMBAT_FLOOR,
+            "floor_provenance": "gate_combat_report_combat_v1_gemma31b_lora.json "
+            "baseline.non_degenerate.accuracy (n=2,557)",
+            "candidate_non_degenerate": cand_nd,
+            "baseline_12b_non_degenerate": base_nd,
+            "paired_bootstrap_non_degenerate": combat_report.get("paired_bootstrap_non_degenerate"),
+            "full_combat_gate_verdict": combat_report.get("verdict"),
+            "combat_report": str(out["combat_report"]),
+        }
 
     summary = {
         "run_id": args.run_id,
@@ -511,7 +683,7 @@ def main(argv: list[str] | None = None) -> int:
             "L1_strategic_gt_floor": {
                 "floor": PREREG_STRATEGIC_FLOOR,
                 "floor_provenance": "gate_report_strategic_v1.json baseline arm "
-                                    "(openai-compat:gemma-4-31b-it-base, 260/550)",
+                "(openai-compat:gemma-4-31b-it-base, 260/550)",
                 "candidate_overall": cand_overall,
                 "pass": l1,
             },
@@ -520,11 +692,7 @@ def main(argv: list[str] | None = None) -> int:
                 "baseline_legality": base_legality,
                 "pass": l2,
             },
-            "L3_combat_no_regression": {
-                "status": "VACUOUS",
-                "reason": "combat gate corpus stale/empty tonight "
-                          "(rl-training-status section 23.8); leg not evaluable",
-            },
+            "L3_combat_no_regression": l3_detail,
         },
         "same_base_comparison": {
             "baseline_overall_gemma12b": base_overall,
@@ -540,18 +708,36 @@ def main(argv: list[str] | None = None) -> int:
     out["summary"].write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
 
     log("=" * 72)
-    log(f"pre-registered L1 (overall > {PREREG_STRATEGIC_FLOOR}): "
-        f"candidate {cand_overall} -> {'PASS' if l1 else 'FAIL'}")
-    log(f"pre-registered L2 (legality >= base): "
-        f"{cand_legality} vs {base_legality} -> {'PASS' if l2 else 'FAIL'}")
-    log("pre-registered L3 (combat slice): VACUOUS tonight (empty/stale corpus)")
-    log(f"same-base (12B) comparison: base overall {base_overall}, "
-        f"paired delta CI {report.get('paired_bootstrap')}")
+    log(
+        f"pre-registered L1 (overall > {PREREG_STRATEGIC_FLOOR}): "
+        f"candidate {cand_overall} -> {'PASS' if l1 else 'FAIL'}"
+    )
+    log(
+        f"pre-registered L2 (legality >= base): "
+        f"{cand_legality} vs {base_legality} -> {'PASS' if l2 else 'FAIL'}"
+    )
+    if l3 is None:
+        log(
+            "pre-registered L3 (combat slice): SKIPPED (--skip-combat) — "
+            "exit code ignores L3; do not read this run as a 3-leg verdict"
+        )
+    else:
+        log(
+            f"pre-registered L3 (combat non-degenerate >= {PREREG_COMBAT_FLOOR}): "
+            f"candidate {l3_detail['candidate_non_degenerate']} "
+            f"(12B base: {l3_detail['baseline_12b_non_degenerate']}) "
+            f"-> {'PASS' if l3 else 'FAIL'}"
+        )
+    log(
+        f"same-base (12B) comparison: base overall {base_overall}, "
+        f"paired delta CI {report.get('paired_bootstrap')}"
+    )
     log(f"full G1-G7 gate verdict: {report.get('verdict')} (exit {gate_rc})")
     log(f"summary: {out['summary']}")
     log("=" * 72)
 
-    return 0 if (l1 and l2) else 2
+    legs = [l1, l2] + ([] if l3 is None else [l3])
+    return 0 if all(legs) else 2
 
 
 if __name__ == "__main__":

--- a/tools/training/wp3/score_tripwires.py
+++ b/tools/training/wp3/score_tripwires.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Score tripwire-fixture responses from a responses JSONL (WP-3 / B5 gate slice).
+
+The 55 tripwire fixtures (#443, ``tools/training/build_tripwires.py``) ship a
+programmatic evaluator (``run_tripwire_eval``) that takes a live ``model_fn``.
+The gate pipeline, however, produces *response files* via ``tools.eval.run``.
+This script bridges the two WITHOUT re-implementing any scoring logic: it
+builds a lookup ``model_fn`` over a responses JSONL and feeds it to the
+existing ``run_tripwire_eval``.
+
+Fail-closed semantics:
+  * a fixture with no matching response row, or a row with ``error`` set,
+    scores as FAILED and is separately counted under ``missing_responses`` /
+    ``error_responses`` — never silently skipped;
+  * duplicate ``prompt_id`` rows for the same backend are an error (exit 2);
+  * exit 0 does NOT mean the model passed — it means scoring completed.
+    Read ``pass_rate`` and the per-category histogram in the output JSON.
+
+Usage:
+    python tools/training/wp3/score_tripwires.py \
+        --fixtures tools/training/data/tripwire_fixtures_55.jsonl \
+        --responses tools/training/data/gate_b5_tripwires.jsonl \
+        --backend-label openai-compat:b5 \
+        --out tools/training/data/gate_b5_tripwires_candidate_score.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+if str(REPO / "src") not in sys.path:
+    sys.path.insert(0, str(REPO / "src"))
+
+from tools.training.build_tripwires import run_tripwire_eval  # noqa: E402
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows = []
+    with open(path, encoding="utf-8") as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"FAIL-CLOSED: malformed JSONL {path}:{i}: {e}")
+    return rows
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--fixtures", type=Path, required=True)
+    ap.add_argument("--responses", type=Path, required=True)
+    ap.add_argument("--backend-label", required=True)
+    ap.add_argument("--out", type=Path, default=None, help="write summary JSON here")
+    ap.add_argument(
+        "--expect-fixtures",
+        type=int,
+        default=55,
+        help="fail closed unless the fixture file has exactly this many records",
+    )
+    args = ap.parse_args(argv)
+
+    if not args.fixtures.exists():
+        print(f"FAIL-CLOSED: fixtures file missing: {args.fixtures}", file=sys.stderr)
+        return 2
+    if not args.responses.exists():
+        print(f"FAIL-CLOSED: responses file missing: {args.responses}", file=sys.stderr)
+        return 2
+
+    fixtures = _read_jsonl(args.fixtures)
+    if len(fixtures) != args.expect_fixtures:
+        print(
+            f"FAIL-CLOSED: fixture count {len(fixtures)} != expected "
+            f"{args.expect_fixtures} in {args.fixtures} "
+            f"(regenerate with tools/training/build_tripwires.py)",
+            file=sys.stderr,
+        )
+        return 2
+
+    by_id: dict[str, dict] = {}
+    duplicates = 0
+    for row in _read_jsonl(args.responses):
+        if row.get("backend") != args.backend_label:
+            continue
+        pid = str(row.get("prompt_id"))
+        if pid in by_id:
+            duplicates += 1
+            continue
+        by_id[pid] = row
+
+    if duplicates:
+        print(
+            f"FAIL-CLOSED: {duplicates} duplicate prompt_id rows for backend "
+            f"{args.backend_label!r} in {args.responses}",
+            file=sys.stderr,
+        )
+        return 2
+
+    missing: list[str] = []
+    errored: list[str] = []
+
+    # run_tripwire_eval iterates fixtures in order and calls
+    # model_fn(system, user) with no id, so walk the same list in lockstep and
+    # assert each call matches the fixture we expect (fail closed on skew).
+    fixture_iter = iter(fixtures)
+
+    def model_fn(system: str, user: str) -> str:
+        fixture = next(fixture_iter)
+        if fixture["system"] != system or fixture["user"] != user:
+            raise AssertionError(
+                f"fixture/model_fn ordering skew at {fixture['id']} — "
+                "run_tripwire_eval iteration order changed; refusing to score"
+            )
+        row = by_id.get(str(fixture["id"]))
+        if row is None:
+            missing.append(fixture["id"])
+            return ""  # fails schema validation -> counted as failed
+        if row.get("error"):
+            errored.append(fixture["id"])
+            return ""
+        return row.get("response") or ""
+
+    summary = run_tripwire_eval(fixtures, model_fn, verbose=True)
+    summary["backend_label"] = args.backend_label
+    summary["responses_file"] = str(args.responses)
+    summary["fixtures_file"] = str(args.fixtures)
+    summary["missing_responses"] = missing
+    summary["error_responses"] = errored
+
+    if missing or errored:
+        print(
+            f"WARNING: {len(missing)} missing + {len(errored)} errored responses "
+            "were scored as FAILED (fail-closed accounting, not silently dropped)",
+            file=sys.stderr,
+        )
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+        print(f"wrote {args.out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Makes the pre-registered B5 gate (LoRA `wp3_gemma12b_b5_smoke` on `google/gemma-4-12B-it`) runnable with one command once the GPU frees:

    /home/joshu/venv-train/bin/python3 -m tools.training.wp3.run_b5_gate_eval --gpu 0

CPU-only preflight (safe while training runs): same command with `--dry-run`.

New files: `tools/training/wp3/run_b5_gate_eval.py`, `tools/training/wp3/score_tripwires.py`, `tools/training/wp3/PROGRESS-wp3-gate-eval-prep.md`.

## Measured facts (all CPU, no GPU touched)

- The 47.27 floor traces to `gate_report_strategic_v1.json`: baseline arm `openai-compat:gemma-4-31b-it-base`, overall 0.4727 = 260/550 on `gate_strategic_decisions_test.jsonl`. Scorer is `gate_play_decisions.py gate` (G1-G7). Note: floor was measured with the 31B base; tonight's baseline arm is the 12B base — the summary records both the absolute floor check and the same-base paired delta.
- The scorer is model-free; the model-touching step is generation. vLLM (venv-serve, 0.22.1rc1.dev596, import verified) consumes the PEFT adapter dir directly via `--enable-lora --max-lora-rank 8 --lora-modules b5=<dir>` — no merge. The B5 `adapter_config.json` shape (LORA, r=8, regex target_modules) is identical to `play_decisions_v2_gemma31b_lora`, which was served this way for the section-21 gate run.
- Last-complete-checkpoint resolution verified against the LIVE trainer: picked `checkpoint-150` (complete, aged >90s), skipped the incomplete root dir.
- Dry-run preflight PASS: corpora 550/550 records, id sets equal modulo `#perm`; all three CLI import chains exit 0.
- Real `gate` command executed on CPU with the runner's exact labels over `simulate`-generated reflex arms (n=550, 2000 bootstraps): verdict BLOCKED on G6/G7 as expected; every report field the verdict code reads is present.
- Tripwire scorer (reuses `build_tripwires.run_tripwire_eval`, no re-implementation): oracle arm 55/55 (100.0%), broken arm 0/55 with missing=3 / errored=2 separately counted. Category histogram: 15 keep / 15 mull / 10 lethal / 10 counter / 2 develop / 2 attack / 1 pass. Checked-out `tripwire_fixtures.jsonl` had 50 rows (stale); the runner regenerates 55 deterministically to `tripwire_fixtures_55.jsonl`.
- pytest `test_gate_play_decisions.py` + `test_gate_stats.py` + `test_temperature_fallback.py`: 46 passed, 4 skipped.

## Not verified (needs the GPU, the one GPU step)

- vLLM actually loading THIS adapter on this vllm build; `--max-model-len 49152` headroom for the known 32.4k-token prompt; end-to-end latency.

## Gaps / concerns

- Combat leg is VACUOUS tonight (combat gate corpus stale per rl-training-status section 23.8) — the runner prints VACUOUS, never PASS.
- Tripwires are an ADVISORY slice only; wiring them into a hard gate leg remains backlog ('wire tripwires into a gate').
- Corpus system prompt (7907 chars) predates the current AUTOPILOT_SYSTEM_PROMPT (8262 chars); generation uses the system stored in the corpus records, which is what keeps comparability with the 47.27 measurement.