### PR TITLE
WP-3: hand attribution from name-attributed logList lines (last positional assumption)

### DIFF
--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -788,7 +788,8 @@ class TestPassDecisionRecovery:
         """A pool whose argmax is Pass and which no chose-action consumed."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
-            + self.HAND3 + self.HAND4
+            + self.HAND3
+            + self.HAND4
             + self.LIFE
             # MCTS deliberates and prefers Pass — XMage logs no chose action.
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
@@ -809,7 +810,8 @@ class TestPassDecisionRecovery:
         """An un-consumed pool whose argmax is NOT a pass must not be guessed."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
-            + self.HAND3 + self.HAND4
+            + self.HAND3
+            + self.HAND4
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.2 count: 30] [Cast Bounce Off score: 0.5 count: 900] =>[T]\n"
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
@@ -903,15 +905,18 @@ class TestNamedHandAttribution:
         assert m.group(4) == "PlayerA"
         cards = parse_named_hand_cards(m.group(5))
         assert cards == [
-            "Island", "Negate", "Soul Partition", "Bounce Off",
-            "Combat Research", "Skrelv, Defector Mite", "Skrelv, Defector Mite",
+            "Island",
+            "Negate",
+            "Soul Partition",
+            "Bounce Off",
+            "Combat Research",
+            "Skrelv, Defector Mite",
+            "Skrelv, Defector Mite",
         ]
 
     def test_parse_named_hand_cards_comma_names(self):
         """Separator commas have no trailing space; in-name commas do."""
-        cards = parse_named_hand_cards(
-            "Kitsa, Otterball Elite,Malcolm, Alluring Scoundrel,Island,"
-        )
+        cards = parse_named_hand_cards("Kitsa, Otterball Elite,Malcolm, Alluring Scoundrel,Island,")
         assert cards == ["Kitsa, Otterball Elite", "Malcolm, Alluring Scoundrel", "Island"]
 
     def test_parse_named_hand_cards_empty(self):
@@ -944,9 +949,7 @@ class TestNamedHandAttribution:
 
     def test_row_without_named_hand_for_its_turn_is_dropped_and_counted(self):
         """FAIL CLOSED: no named hand line in the game for the row's turn."""
-        decisions = self._parse(
-            "INFO  Player A won the die roll =>[T]\n" + self.DECISION
-        )
+        decisions = self._parse("INFO  Player A won the die roll =>[T]\n" + self.DECISION)
         assert decisions == [], "an unattributable-hand row must be dropped, not guessed"
         assert LAST_PARSE_STATS["hand_dropped_unattributed"] == 1
         assert LAST_PARSE_STATS["hand_named_attributed"] == 0
@@ -958,9 +961,7 @@ class TestNamedHandAttribution:
             "INFO  [1:Beginning:UPKEEP]PlayerB hand: : Mountain,Hired Claw, =>[T] ComputerPlayer.logList \n"
             + self.DECISION
         )
-        assert decisions == [], (
-            "a PlayerB hand line must neither fill the row nor count as attribution"
-        )
+        assert decisions == [], "a PlayerB hand line must neither fill the row nor count as attribution"
         assert LAST_PARSE_STATS["hand_dropped_unattributed"] == 1
 
     def test_named_hands_reset_at_game_boundary(self):
@@ -972,17 +973,14 @@ class TestNamedHandAttribution:
             + "INFO  Player A won the die roll =>[T]\n"  # game 2, no hand line
             + self.DECISION
         )
-        assert len(decisions) == 1, (
-            "game 2's row has no hand line IN ITS OWN GAME and must be dropped"
-        )
+        assert len(decisions) == 1, "game 2's row has no hand line IN ITS OWN GAME and must be dropped"
         assert decisions[0]["hand"] == ["Island", "Negate"]
 
     def test_empty_named_hand_is_valid_attribution(self):
         """An empty logList hand means the hand IS empty — the row is kept."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
-            "INFO  [1:Beginning:UPKEEP]PlayerA hand: :  =>[T] ComputerPlayer.logList \n"
-            + self.DECISION
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: :  =>[T] ComputerPlayer.logList \n" + self.DECISION
         )
         assert len(decisions) == 1
         assert decisions[0]["hand"] == []
@@ -1015,14 +1013,27 @@ class TestNamedHandAttribution:
 # UWTempo.dck (magezero/xmage/decks/UWTempo.dck) — the primary player's deck
 # in every smoke-log game. 17 distinct names; any other name in a `hand`
 # field means hand attribution broke.
-UWTEMPO_DECK = frozenset({
-    "Malcolm, Alluring Scoundrel", "Island", "Sheltered by Ghosts",
-    "Skrelv, Defector Mite", "Combat Research", "No More Lies",
-    "Adarkar Wastes", "Seachrome Coast", "Meticulous Archive",
-    "Shardmage's Rescue", "Floodfarm Verge", "Soul Partition", "Negate",
-    "Kitsa, Otterball Elite", "Bounce Off", "Spell Pierce",
-    "Sleep-Cursed Faerie",
-})
+UWTEMPO_DECK = frozenset(
+    {
+        "Malcolm, Alluring Scoundrel",
+        "Island",
+        "Sheltered by Ghosts",
+        "Skrelv, Defector Mite",
+        "Combat Research",
+        "No More Lies",
+        "Adarkar Wastes",
+        "Seachrome Coast",
+        "Meticulous Archive",
+        "Shardmage's Rescue",
+        "Floodfarm Verge",
+        "Soul Partition",
+        "Negate",
+        "Kitsa, Otterball Elite",
+        "Bounce Off",
+        "Spell Pierce",
+        "Sleep-Cursed Faerie",
+    }
+)
 
 
 class TestHandDeckSignature:
@@ -1075,10 +1086,7 @@ class TestHandDeckSignature:
             for c in d.get("hand", [])
             if c not in UWTEMPO_DECK
         ]
-        assert not violations, (
-            f"{len(violations)} non-deck hand entries, first 10: {violations[:10]}"
-        )
-
+        assert not violations, f"{len(violations)} non-deck hand entries, first 10: {violations[:10]}"
 
 
 class TestSegmentMenu:

--- a/tests/test_parse_magezero_log.py
+++ b/tests/test_parse_magezero_log.py
@@ -6,6 +6,7 @@ hand/perm parsing, outcome calibration, and edge cases.
 
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -16,10 +17,12 @@ sys.path.insert(0, str(_HERE.parent / "tools" / "training"))
 
 import pytest
 from parse_magezero_log import (
+    LAST_PARSE_STATS,
     RE_CHOSE_ACTION,
     RE_DIE_ROLL,
     RE_HAND,
     RE_LOG_LIFE,
+    RE_NAMED_HAND,
     RE_PERMANENTS,
     RE_PLAYABLE,
     RE_PLAYER_LIFE,
@@ -31,6 +34,7 @@ from parse_magezero_log import (
     detect_sessions,
     parse_card_list,
     parse_log,
+    parse_named_hand_cards,
     parse_permanents,
     parse_pool_actions,
 )
@@ -272,6 +276,8 @@ TEST_LOG_MULTI_THREAD = """\
 INFO  2026-07-28 21:33:40,710 Simulating 2 games. Using thread pool of size 2 on 16 available cores.                    =>[main] ParallelDataGenerator.runSimulations
 INFO  2026-07-28 21:33:40,712 Player A won the die roll                                                                  =>[pool-3-thread-1] ParallelDataGenerator.runSingleGame
 INFO  2026-07-28 21:33:40,712 Player B won the die roll                                                                  =>[pool-3-thread-2] ParallelDataGenerator.runSingleGame
+INFO  2026-07-28 21:33:44,900 [1:Beginning:UPKEEP]PlayerA hand: : Island,Adarkar Wastes,Bounce Off,Combat Research,Shardmage's Rescue,Sleep-Cursed Faerie, =>[pool-3-thread-1] ComputerPlayer.logList
+INFO  2026-07-28 21:33:44,950 [1:Beginning:UPKEEP]PlayerA hand: : Mountain,Mountain,Lightning Strike,Nova Hellkite,Mountain,Mountain, =>[pool-3-thread-2] ComputerPlayer.logList
 INFO  2026-07-28 21:33:45,071 PRECOMBAT_MAIN0pool= actions: [Pass score: -0.075 count: 57] [Play Island score: 0.059 count: 304]  =>[pool-3-thread-1] MCTSNode.bestChild
 INFO  2026-07-28 21:33:45,072 playable abilities: [Play Island, Pass]                                                    =>[pool-3-thread-1] ComputerPlayerMCTS.priority
 INFO  2026-07-28 21:33:45,072 [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.0589            =>[pool-3-thread-1] ComputerPlayerMCTS.priority
@@ -506,6 +512,9 @@ INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Pass success ratio: 0.0 =>[p
         log = """\
 INFO  Simulating 1 games. =>[main]
 INFO  Player A won the die roll =>[pool-3-thread-1]
+INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Mountain, =>[t1] ComputerPlayer.logList
+INFO  [2:Beginning:UPKEEP]PlayerA hand: : Island,Mountain, =>[t1] ComputerPlayer.logList
+INFO  [3:Beginning:UPKEEP]PlayerA hand: : Island,Mountain, =>[t1] ComputerPlayer.logList
 INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[t1]
 INFO  playable abilities: [Play Island, Pass] =>[t1]
 INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[t1]
@@ -554,6 +563,7 @@ INFO  Player A win rate: 100.00% (1/1) =>[main]
         log = """\
 INFO  Simulating 1 games. =>[main]
 INFO  Player A won the die roll =>[pool-3-thread-1]
+INFO  [2:Beginning:UPKEEP]PlayerA hand: : Island, =>[t1] ComputerPlayer.logList
 INFO  DECLARE_ATTACKERS0pool= actions: [false score: -0.106 count: 764] [true score: -0.153 count: 235] =>[t1]
 INFO  playable abilities: [false, true] =>[t1]
 INFO  [2:Combat:DECLARE_ATTACKERS]chose action:false success ratio: -0.1 =>[t1]
@@ -574,11 +584,16 @@ INFO  Player A win rate: 100.00% (1/1) =>[main]
             if d["phase"] == "DECLARE_ATTACKERS":
                 assert d["decision_kind"] == "binary"
 
-    def test_hand_backfill(self):
-        """Hand lines after chose action should backfill into the decision."""
+    def test_hand_comes_from_named_line_not_positional_block(self):
+        """`hand` is sourced from the name-attributed logList line.
+
+        The positional `-> Hand:` block line deliberately DIFFERS from the
+        named line here (missing Negate); the named line must win.
+        """
         log = """\
 INFO  Simulating 1 games. =>[main]
-INFO  Player A won the die roll =>[pool-3-thread-1]
+INFO  Player A won the die roll =>[t1]
+INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Adarkar Wastes,Bounce Off,Negate, =>[t1] ComputerPlayer.logList
 INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[t1]
 INFO  playable abilities: [Play Island, Pass] =>[t1]
 INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[t1]
@@ -596,7 +611,7 @@ INFO  Player A win rate: 100.00% (1/1) =>[main]
         Path(log_path).unlink()
 
         assert len(decisions) == 1
-        assert decisions[0]["hand"] == ["Island", "Adarkar Wastes", "Bounce Off"]
+        assert decisions[0]["hand"] == ["Island", "Adarkar Wastes", "Bounce Off", "Negate"]
         assert decisions[0]["battlefield_self"] == [{"name": "Island", "tapped": False}]
 
 
@@ -635,6 +650,7 @@ class TestIssue430BlockAttribution:
         """A PlayerB-headed one-line evaluator block is the OPPONENT's board."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
             "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
             "INFO  [PlayerB], life = 20, score = 670 (Life:10000, Hand:25, Perm:280) =>[T] GameStateEvaluator2.printBattlefield \n"
@@ -655,6 +671,7 @@ class TestIssue430BlockAttribution:
         """PlayerB's hand is the opponent's HIDDEN hand — an L4 leak if kept."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
             "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
             "INFO  [PlayerB], life = 20, score = 670 (Life:10000, Hand:25, Perm:280) =>[T] GameStateEvaluator2.printBattlefield \n"
@@ -682,6 +699,8 @@ class TestIssue430BlockAttribution:
         """
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
+            "INFO  [2:Beginning:UPKEEP]PlayerA hand: : Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
             "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
             # one-line evaluator block (PlayerA's own board)
@@ -712,6 +731,7 @@ class TestIssue430BlockAttribution:
         """A turn-1 decision with genuinely empty boards must keep them."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
             "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
             # turn-1 block: both boards empty
@@ -761,11 +781,14 @@ class TestPassDecisionRecovery:
             Path(path).unlink()
 
     LIFE = "INFO  [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:18] =>[T]\n"
+    HAND3 = "INFO  [3:Beginning:UPKEEP]PlayerA hand: : Island, =>[T] ComputerPlayer.logList \n"
+    HAND4 = "INFO  [4:Beginning:UPKEEP]PlayerA hand: : Island, =>[T] ComputerPlayer.logList \n"
 
     def test_unconsumed_pass_pool_becomes_a_decision(self):
         """A pool whose argmax is Pass and which no chose-action consumed."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3 + self.HAND4
             + self.LIFE
             # MCTS deliberates and prefers Pass — XMage logs no chose action.
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
@@ -786,6 +809,7 @@ class TestPassDecisionRecovery:
         """An un-consumed pool whose argmax is NOT a pass must not be guessed."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3 + self.HAND4
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.2 count: 30] [Cast Bounce Off score: 0.5 count: 900] =>[T]\n"
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
@@ -800,9 +824,11 @@ class TestPassDecisionRecovery:
         """The last window of a game still belongs to that game."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
             + "INFO  Player A won the die roll =>[T]\n"  # next game starts
+            + self.HAND4
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 20] [Play Island score: 0.3 count: 400] =>[T]\n"
             + "INFO  [4:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.3 =>[T]\n"
@@ -816,6 +842,7 @@ class TestPassDecisionRecovery:
     def test_pass_pool_pending_at_eof_is_flushed(self):
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
         )
@@ -826,6 +853,7 @@ class TestPassDecisionRecovery:
         """CHOOSE_USE windows decline with `false`, not `Pass`."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [true score: 0.1 count: 40] [false score: 0.4 count: 500] =>[T]\n"
         )
@@ -837,11 +865,220 @@ class TestPassDecisionRecovery:
         """`_recovered_pass` is a leading-underscore field, stripped on write."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            + self.HAND3
             + self.LIFE
             + "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
         )
         assert decisions[0]["_recovered_pass"] is True
         assert not any(k.startswith("_") for k in ("chosen", "menu", "mcts_counts"))
+
+
+class TestNamedHandAttribution:
+    """Hand sourcing from name-attributed ComputerPlayer.logList lines.
+
+    The last positional assumption in the parser was the hand: `-> Hand:`
+    block lines are attributed by header adjacency (the #452 defect family,
+    which swapped boards for entire games). Hands now come ONLY from lines
+    that carry the player NAME, TURN, and PHASE on the line itself:
+
+        [1:Beginning:UPKEEP]PlayerA hand: : Island,Soul Partition, =>[pool-3-thread-4] ComputerPlayer.logList
+
+    A row whose (thread-game, turn) has no such line is DROPPED and counted —
+    an empty hand in a prompt is an observation ("you hold nothing"), so
+    fabricating one is not an acceptable fallback.
+    """
+
+    REAL_LINE = (
+        "INFO  2026-07-28 21:33:40,987 [1:Beginning:UPKEEP]PlayerA hand: : "
+        "Island,Negate,Soul Partition,Bounce Off,Combat Research,"
+        "Skrelv, Defector Mite,Skrelv, Defector Mite, "
+        "=>[pool-3-thread-1] ComputerPlayer.logList "
+    )
+
+    def test_named_hand_regex_real_shape(self):
+        m = RE_NAMED_HAND.search(self.REAL_LINE)
+        assert m is not None
+        assert m.group(1) == "1"
+        assert m.group(3) == "UPKEEP"
+        assert m.group(4) == "PlayerA"
+        cards = parse_named_hand_cards(m.group(5))
+        assert cards == [
+            "Island", "Negate", "Soul Partition", "Bounce Off",
+            "Combat Research", "Skrelv, Defector Mite", "Skrelv, Defector Mite",
+        ]
+
+    def test_parse_named_hand_cards_comma_names(self):
+        """Separator commas have no trailing space; in-name commas do."""
+        cards = parse_named_hand_cards(
+            "Kitsa, Otterball Elite,Malcolm, Alluring Scoundrel,Island,"
+        )
+        assert cards == ["Kitsa, Otterball Elite", "Malcolm, Alluring Scoundrel", "Island"]
+
+    def test_parse_named_hand_cards_empty(self):
+        """624 of 9,063 real lines carry an empty list — a legit empty hand."""
+        assert parse_named_hand_cards("") == []
+        assert parse_named_hand_cards("   ") == []
+
+    @staticmethod
+    def _parse(log_body: str):
+        import tempfile
+        from pathlib import Path
+
+        log = (
+            "INFO  Simulating 1 games. =>[main]\n"
+            + log_body
+            + "INFO  Player A win rate: 100.00% (1/1) =>[main]\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            f.write(log.replace("=>[T]", "=>[pool-3-thread-1]"))
+            path = f.name
+        try:
+            return parse_log(path)[0]
+        finally:
+            Path(path).unlink()
+
+    DECISION = (
+        "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] [Play Island score: 0.1 count: 200] =>[T]\n"
+        "INFO  [1:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: 0.1 =>[T]\n"
+    )
+
+    def test_row_without_named_hand_for_its_turn_is_dropped_and_counted(self):
+        """FAIL CLOSED: no named hand line in the game for the row's turn."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n" + self.DECISION
+        )
+        assert decisions == [], "an unattributable-hand row must be dropped, not guessed"
+        assert LAST_PARSE_STATS["hand_dropped_unattributed"] == 1
+        assert LAST_PARSE_STATS["hand_named_attributed"] == 0
+
+    def test_playerb_named_hand_is_ignored(self):
+        """A PlayerB logList hand is hidden information AND wrong attribution."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerB hand: : Mountain,Hired Claw, =>[T] ComputerPlayer.logList \n"
+            + self.DECISION
+        )
+        assert decisions == [], (
+            "a PlayerB hand line must neither fill the row nor count as attribution"
+        )
+        assert LAST_PARSE_STATS["hand_dropped_unattributed"] == 1
+
+    def test_named_hands_reset_at_game_boundary(self):
+        """Game 2's turn 1 must not inherit game 1's turn-1 hand."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Negate, =>[T] ComputerPlayer.logList \n"
+            + self.DECISION
+            + "INFO  Player A won the die roll =>[T]\n"  # game 2, no hand line
+            + self.DECISION
+        )
+        assert len(decisions) == 1, (
+            "game 2's row has no hand line IN ITS OWN GAME and must be dropped"
+        )
+        assert decisions[0]["hand"] == ["Island", "Negate"]
+
+    def test_empty_named_hand_is_valid_attribution(self):
+        """An empty logList hand means the hand IS empty — the row is kept."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: :  =>[T] ComputerPlayer.logList \n"
+            + self.DECISION
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["hand"] == []
+        assert LAST_PARSE_STATS["hand_named_attributed"] == 1
+
+    def test_recovered_pass_row_uses_named_hand_for_its_turn(self):
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [3:Beginning:UPKEEP]PlayerA hand: : Negate,Bounce Off, =>[T] ComputerPlayer.logList \n"
+            "INFO  [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:18] =>[T]\n"
+            "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 700] [Cast Bounce Off score: 0.1 count: 90] =>[T]\n"
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["chosen"] == "Pass"
+        assert decisions[0]["hand"] == ["Negate", "Bounce Off"]
+
+    def test_hand_positional_shadow_is_internal_only(self):
+        """`_hand_positional` must be stripped by the writer's underscore rule."""
+        decisions = self._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island, =>[T] ComputerPlayer.logList \n"
+            + self.DECISION
+        )
+        assert len(decisions) == 1
+        assert "_hand_positional" in decisions[0]  # available for --report
+        clean = {k for k in decisions[0] if not k.startswith("_")}
+        assert "hand" in clean
+
+
+# UWTempo.dck (magezero/xmage/decks/UWTempo.dck) — the primary player's deck
+# in every smoke-log game. 17 distinct names; any other name in a `hand`
+# field means hand attribution broke.
+UWTEMPO_DECK = frozenset({
+    "Malcolm, Alluring Scoundrel", "Island", "Sheltered by Ghosts",
+    "Skrelv, Defector Mite", "Combat Research", "No More Lies",
+    "Adarkar Wastes", "Seachrome Coast", "Meticulous Archive",
+    "Shardmage's Rescue", "Floodfarm Verge", "Soul Partition", "Negate",
+    "Kitsa, Otterball Elite", "Bounce Off", "Spell Pierce",
+    "Sleep-Cursed Faerie",
+})
+
+
+class TestHandDeckSignature:
+    """#452-family guardrail for hands: the UWTempo player must not 'hold'
+    cards that are not in the UWTempo deck.
+
+    Before the switch, evaluator-block `-> Hand:` lines backfilled `hand`
+    positionally: on mz_train_smoke.log 5,422 of 18,644 non-empty-hand rows
+    carried `:N` score-suffixed names ("Negate:5") — format pollution that
+    would have shipped straight into training prompts.
+    """
+
+    def test_positional_evaluator_hand_cannot_pollute_hand(self):
+        """A score-suffixed evaluator hand block must never reach `hand`."""
+        decisions = TestNamedHandAttribution._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Negate, =>[T] ComputerPlayer.logList \n"
+            + TestNamedHandAttribution.DECISION
+            + "INFO  [PlayerA], life = 20, score = 295 (Life:10000, Hand:30, Perm:300) =>[T] GameStateEvaluator2.printBattlefield \n"
+            + "INFO  -> Hand: [Island:5; Negate:5] =>[T] GameStateEvaluator2.printBattlefield \n"
+            + "INFO  -> Permanents: [Island:300] =>[T] GameStateEvaluator2.printBattlefield \n"
+        )
+        assert len(decisions) == 1
+        for card in decisions[0]["hand"]:
+            assert card in UWTEMPO_DECK, f"non-deck name in hand: {card!r}"
+
+    def test_off_deck_positional_hand_cannot_pollute_hand(self):
+        """Opponent-deck cards in a positional window must never reach `hand`."""
+        decisions = TestNamedHandAttribution._parse(
+            "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Combat Research, =>[T] ComputerPlayer.logList \n"
+            + TestNamedHandAttribution.DECISION
+            # A headerless -> Hand: line (unattributable window) with opponent cards
+            + "INFO  -> Hand: [Mountain; Lightning Strike] =>[T] ComputerPlayerMCTS.printBattlefieldScore \n"
+        )
+        assert len(decisions) == 1
+        assert decisions[0]["hand"] == ["Combat Research"]
+
+    @pytest.mark.skipif(
+        not os.environ.get("MZ_SMOKE_LOG"),
+        reason="set MZ_SMOKE_LOG=/path/to/mz_train_smoke.log to run (parses 210MB)",
+    )
+    def test_smoke_log_hands_match_deck_signature(self):
+        """Every hand card in every emitted row is a UWTempo deck card."""
+        decisions, _ = parse_log(os.environ["MZ_SMOKE_LOG"])
+        assert decisions, "smoke log parsed to zero rows"
+        violations = [
+            (d["game_id"], d["turn"], c)
+            for d in decisions
+            for c in d.get("hand", [])
+            if c not in UWTEMPO_DECK
+        ]
+        assert not violations, (
+            f"{len(violations)} non-deck hand entries, first 10: {violations[:10]}"
+        )
+
 
 
 class TestSegmentMenu:
@@ -945,6 +1182,9 @@ class TestCommaMenuEndToEnd:
     def test_comma_named_cast_matches_menu(self):
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
+            "INFO  [2:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
+            "INFO  [3:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  [2:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:20] =>[T]\n"
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] "
             "[Cast Skrelv, Defector Mite score: 0.2 count: 500] =>[T]\n"
@@ -963,6 +1203,9 @@ class TestCommaMenuEndToEnd:
         """An unconsumed pass pool whose playable-abilities line landed."""
         decisions = self._parse(
             "INFO  Player A won the die roll =>[T]\n"
+            "INFO  [1:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
+            "INFO  [2:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
+            "INFO  [3:Beginning:UPKEEP]PlayerA hand: : Island,Combat Research, =>[T] ComputerPlayer.logList \n"
             "INFO  [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:18] =>[T]\n"
             # Window 1: menu + comma-named cast.
             "INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] "

--- a/tools/eval/forge_fidelity.py
+++ b/tools/eval/forge_fidelity.py
@@ -373,9 +373,7 @@ def _board_card(
         # permanents; a live creature cannot be 0/0 without counters. Net
         # toughness > 0 (or a 0/0 carrying counters) ⇒ creature. Recorded as
         # derived, not shim-native.
-        is_creature = toughness > 0 or (
-            power == 0 and toughness == 0 and bool(counters) and not type_line
-        )
+        is_creature = toughness > 0 or (power == 0 and toughness == 0 and bool(counters) and not type_line)
         if is_creature and not type_line:
             type_line = "Creature"
             derived.add("creature_from_net_pt")
@@ -456,9 +454,7 @@ def build_game_state_from_shim(
 
     battlefield: list[dict] = []
     for i, obj in enumerate(local_in.get("board") or []):
-        battlefield.append(
-            _board_card(obj, local_seat, turn_num, 100000 + i, derived, gaps, fabrications)
-        )
+        battlefield.append(_board_card(obj, local_seat, turn_num, 100000 + i, derived, gaps, fabrications))
     for i, obj in enumerate(opp_in.get("board") or []):
         battlefield.append(_board_card(obj, opp_seat, turn_num, 900000 + i, derived, gaps, fabrications))
 
@@ -615,7 +611,15 @@ def build_game_state_from_shim(
             }
             for i, (t, mp) in enumerate(zip(menu_rows, mappings, strict=False))
         ]
-        + [{"index": len(menu_rows), "text": "Pass", "kind": "pass", "host": None, "mapping": "implicit_pass"}],
+        + [
+            {
+                "index": len(menu_rows),
+                "text": "Pass",
+                "kind": "pass",
+                "host": None,
+                "mapping": "implicit_pass",
+            }
+        ],
         "menu_size": len(menu_rows),
         "shim_mana_available": req.get("mana_available"),
         "derived": sorted(derived),
@@ -700,8 +704,7 @@ SECTION_ANCHORS: dict[str, tuple[str, str | None]] = {
 #   empty           — legitimately empty for these decisions (matches reference)
 #   unconstructible — the real corpus populates it, the shim JSON cannot
 SECTION_VERDICT_NOTES = {
-    "trigger": "mapped from phase + own-turn (v2: engine-native is_own_turn); new_turn only on "
-    "own Main-1",
+    "trigger": "mapped from phase + own-turn (v2: engine-native is_own_turn); new_turn only on own Main-1",
     "header": "constant",
     "legal_menu": "options[] + implicit Pass, worded by the gate's menu_line; v2 rows carry "
     "native kind/host/affordable (incl. unaffordable Cast rows, like real MTGA menus)",
@@ -936,9 +939,7 @@ def ranked_gaps(real: list[dict], rendered: list[dict], real_counts: dict, n_rea
             "effects and games with no land drop. Closed by protocol v2: "
             "PhaseHandler.isPlayerTurn ships as is_own_turn",
             "affected_decisions": sum(
-                1
-                for r in rendered
-                if r["meta"]["own_turn_source"] not in ("shim_native", "land_drop_direct")
+                1 for r in rendered if r["meta"]["own_turn_source"] not in ("shim_native", "land_drop_direct")
             ),
         },
         {
@@ -1157,8 +1158,7 @@ def write_md(report: dict, path: Path) -> None:
         "# Forge → mtgacoach prompt fidelity report (WP-2.1 Days 3-4)",
         "",
         f"Generated: {report['generated_at']}",
-        f"Shim decisions: {report['inputs']['decisions_used']} "
-        f"(from {report['inputs']['decisions_path']})",
+        f"Shim decisions: {report['inputs']['decisions_used']} (from {report['inputs']['decisions_path']})",
         f"Reference corpus: {report['inputs']['real_corpus_n']} real MTGA gate prompts "
         f"({report['inputs']['real_corpus_path']})",
         "",
@@ -1214,8 +1214,7 @@ def write_md(report: dict, path: Path) -> None:
         f"({m['real']['cast_with_ok']}/{m['real']['cast_entries']} Cast rows tagged [OK])",
         f"- Forge entry heads: `{m['forge']['entry_heads']}` "
         f"({m['forge']['cast_with_ok']}/{m['forge']['cast_entries']} Cast rows tagged [OK])",
-        f"- Unmapped option rows rendered verbatim: {m['unmapped_rows']} "
-        f"({m['unmapped_share']} of all rows)",
+        f"- Unmapped option rows rendered verbatim: {m['unmapped_rows']} ({m['unmapped_share']} of all rows)",
         f"- Mapping breakdown: `{m['forge']['mapping_breakdown']}`",
     ]
     lines += [f"- {n}" for n in m["diff_notes"]]

--- a/tools/eval/replay/menu_groundtruth.py
+++ b/tools/eval/replay/menu_groundtruth.py
@@ -931,8 +931,12 @@ def _norm_optional(req: dict, snap, response: Optional[ReplayMessage]) -> tuple[
     return (
         active,
         [],
-        dict(extra, _pick=_pick_from_indices([idx] if idx is not None else [], active, status,
-                                             optional_response=resp)),
+        dict(
+            extra,
+            _pick=_pick_from_indices(
+                [idx] if idx is not None else [], active, status, optional_response=resp
+            ),
+        ),
     )
 
 

--- a/tools/eval/replay/strategic_groundtruth.py
+++ b/tools/eval/replay/strategic_groundtruth.py
@@ -446,7 +446,7 @@ def _pick_record(
 def build_attack_decision(
     request: ReplayMessage, response: Optional[ReplayMessage], snap: GameStateSnapshot
 ) -> Optional[dict]:
-    """"Which creature attacks?" — only when the answer is a single creature.
+    """ "Which creature attacks?" — only when the answer is a single creature.
 
     ``autoDeclare`` (attack with everything) and multi-creature declarations
     have several equally-correct picks, so they are reported as ambiguous
@@ -561,7 +561,7 @@ def build_block_decision(
     pair_keys: dict[tuple[int, int], str],
     episode: list[tuple[ReplayMessage, Optional[ReplayMessage]]],
 ) -> dict:
-    """"Which blocker goes in front of which attacker?" for one combat.
+    """ "Which blocker goes in front of which attacker?" for one combat.
 
     ``episode`` is every ``DeclareBlockersReq`` of one combat, in order, each
     with its paired response — MTGA re-issues the request after each
@@ -604,7 +604,7 @@ def build_block_decision(
 def build_target_decision(
     request: ReplayMessage, response: Optional[ReplayMessage], snap: GameStateSnapshot
 ) -> Optional[dict]:
-    """"What does this spell or ability point at?" — single slot, one target."""
+    """ "What does this spell or ability point at?" — single slot, one target."""
     st = request.payload.get("selectTargetsReq") or {}
     slots = st.get("targets") or []
     if len(slots) != 1:
@@ -664,7 +664,7 @@ def build_target_decision(
 def build_select_n_decision(
     request: ReplayMessage, response: Optional[ReplayMessage], snap: GameStateSnapshot
 ) -> Optional[dict]:
-    """"Choose one of these." — the GRE's general single-selection request."""
+    """ "Choose one of these." — the GRE's general single-selection request."""
     sn = request.payload.get("selectNReq") or {}
     ids = sn.get("ids") or []
     if not ids:
@@ -719,7 +719,7 @@ def build_select_n_decision(
 def build_search_decision(
     request: ReplayMessage, response: Optional[ReplayMessage], snap: GameStateSnapshot
 ) -> Optional[dict]:
-    """"What do you fetch?" — a tutor's target, the purest strategic choice."""
+    """ "What do you fetch?" — a tutor's target, the purest strategic choice."""
     sr = request.payload.get("searchReq") or {}
     sought = sr.get("itemsSought") or []
     if not sought:
@@ -770,7 +770,8 @@ def build_search_decision(
             "source_name": source_name,
             "zones_to_search": sr.get("zonesToSearch"),
             "n_candidates": len(sought),
-            "n_distinct_candidates": len(menu) - (1 if allow_fail and allow_fail != "AllowFailToFind_No" else 0),
+            "n_distinct_candidates": len(menu)
+            - (1 if allow_fail and allow_fail != "AllowFailToFind_No" else 0),
             "menu_rows_collapsed": collapsed,
             "library_size_searched": len(sr.get("itemsToSearch") or []),
             "allow_fail_to_find": allow_fail,
@@ -781,7 +782,7 @@ def build_search_decision(
 def build_pay_costs_decision(
     request: ReplayMessage, response: Optional[ReplayMessage], snap: GameStateSnapshot
 ) -> Optional[dict]:
-    """"Which permanents pay for this?" — extracted so the funnel can say it.
+    """ "Which permanents pay for this?" — extracted so the funnel can say it.
 
     Every row is ``ActionType_Activate_Mana``, so ``strategic_verdict`` drops
     the whole request as ``single_option_menu``/``land_or_pass_only``. That is
@@ -1188,7 +1189,7 @@ def extract_replay(path: Path, *, seat_override: Optional[int] = None) -> tuple[
     # from it (``pd-<stem>-<index>``) and a collision silently merges two
     # decisions. The AA path reuses menu_groundtruth's numbering, so everything
     # else is renumbered above it, in message order.
-    records.sort(key=lambda r: (r["msg_id"] if r["msg_id"] is not None else 0))
+    records.sort(key=lambda r: r["msg_id"] if r["msg_id"] is not None else 0)
     next_index = aa_index + 1
     for rec in records:
         if rec["request_type"] != "ActionsAvailable":
@@ -1235,9 +1236,7 @@ def summarize(all_stats: list[WalkStats], records: list[dict]) -> dict:
         out["dropped"] = {r: n for (t, r), n in sorted(drops.items()) if t == rtype}
         return out
 
-    land_picks = sum(
-        1 for r in records if r["real_pick"].get("action_type") in PLAY_ACTION_TYPES
-    )
+    land_picks = sum(1 for r in records if r["real_pick"].get("action_type") in PLAY_ACTION_TYPES)
     pass_picks = sum(1 for r in records if r["real_pick"].get("action_type") in PASS_LEVEL_ACTION_TYPES)
     n = len(records)
     menu_sizes = sorted(r["real_menu_size"] for r in records)

--- a/tools/training/build_combat_decisions.py
+++ b/tools/training/build_combat_decisions.py
@@ -686,9 +686,7 @@ def _own_board_block(facts: CombatFacts, dec: Any, oracle_chars: int) -> list[st
     lines.extend(_board_lines(facts.resolver, facts.detail, dec.own_board, oracle_chars))
     extra_groups = Counter(dec.own_board_extra)
     for gid, note in dict.fromkeys(dec.own_board_extra):
-        for ln in _board_lines(
-            facts.resolver, facts.detail, [gid] * extra_groups[(gid, note)], oracle_chars
-        ):
+        for ln in _board_lines(facts.resolver, facts.detail, [gid] * extra_groups[(gid, note)], oracle_chars):
             lines.append(f"{ln} {note}")
     return lines
 
@@ -839,11 +837,14 @@ def _canonical_block_explanation(dec: BlockDecision, solved: dict) -> str:
         # Mirrors Emitter._state_key — the identity agreement was judged on.
         return (gids.get(int(iid)), dec.live.get(int(iid)))
 
-    desc = ", ".join(
-        f"{b_name[b]} blocks {a_name[dec.assignments[b]]}"
-        for (_n, _g, b) in dec.blockers
-        if b in dec.assignments
-    ) or "no blocks"
+    desc = (
+        ", ".join(
+            f"{b_name[b]} blocks {a_name[dec.assignments[b]]}"
+            for (_n, _g, b) in dec.blockers
+            if b in dec.assignments
+        )
+        or "no blocks"
+    )
 
     # Gang structure must match before the tail's kill/loss claims can be
     # renamed: per attacker copy, the multiset of blocker states ganged onto
@@ -994,9 +995,7 @@ class Emitter:
         # the human's names before the line can render.
         explanation: Optional[str] = None
         if solved is not None:
-            explanation = (
-                _canonical_attack_explanation(solved, names) if agrees else solved["explanation"]
-            )
+            explanation = _canonical_attack_explanation(solved, names) if agrees else solved["explanation"]
         line = self._solver_line("attack", agrees, explanation)
 
         user, menu = render_attack_user(self.facts, dec, self.args.oracle_chars, line)
@@ -1066,9 +1065,7 @@ class Emitter:
         # not render solver copy names the response contradicts.
         explanation: Optional[str] = None
         if solved is not None:
-            explanation = (
-                _canonical_block_explanation(dec, solved) if agrees else solved["explanation"]
-            )
+            explanation = _canonical_block_explanation(dec, solved) if agrees else solved["explanation"]
         line = self._solver_line("block", agrees, explanation)
 
         user, menu = render_block_user(self.facts, dec, self.args.oracle_chars, line)
@@ -1351,8 +1348,7 @@ def iter_17lands_attacks(
                 life=_num(rv.get(row, pre + "eot_user_life")) if pre else None,
                 opp_life=_num(rv.get(row, pre + "eot_oppo_life")) if pre else None,
                 opp_hand=_num(rv.get(row, pre + "eot_oppo_cards_in_hand")) if pre else None,
-                own_board=pool_gids
-                + (rv.ids(row, pre + "eot_user_non_creatures_in_play") if pre else []),
+                own_board=pool_gids + (rv.ids(row, pre + "eot_user_non_creatures_in_play") if pre else []),
                 # The land played THIS turn is on the battlefield at declare
                 # attackers; the prior-eot list understated mana by one on
                 # nearly every attack record.
@@ -1872,9 +1868,7 @@ def _gre_attack(
     rem_names = disambiguate([_obj_name(snap, i)[1] for (_g, i) in rem_raw])
     remaining = [(n, g, i) for n, (g, i) in zip(rem_names, rem_raw, strict=True)]
     opp_names = disambiguate([_obj_name(snap, i)[1] for (i, _g, _p, _t, _tp) in opp_objs])
-    opp_creature_entries = [
-        (n, g, i) for n, (i, g, _p, _t, _tp) in zip(opp_names, opp_objs, strict=True)
-    ]
+    opp_creature_entries = [(n, g, i) for n, (i, g, _p, _t, _tp) in zip(opp_names, opp_objs, strict=True)]
     opp_blockers = [
         e for e, (_i, _g, _p, _t, tapped) in zip(opp_creature_entries, opp_objs, strict=True) if not tapped
     ]
@@ -2070,9 +2064,7 @@ def iter_gre_logs(facts: CombatFacts, root: Path, args, stats: Counter) -> Itera
                 stats["gre_seat_undetermined"] += 1
                 continue
             key = f"{fp.name}|m{mi}|{lm.match_id}"
-            yield from iter_gre_combat(
-                facts, lm.messages, seat, SOURCE_GRE_LOG, key, args, stats
-            )
+            yield from iter_gre_combat(facts, lm.messages, seat, SOURCE_GRE_LOG, key, args, stats)
 
 
 def iter_rply(facts: CombatFacts, root: Path, args, stats: Counter) -> Iterable[Any]:

--- a/tools/training/build_curriculum.py
+++ b/tools/training/build_curriculum.py
@@ -135,9 +135,9 @@ SCRYFALL_BULK = Path.home() / ".arenamcp" / "cache" / "scryfall" / "default_card
 WEIGHTS = {"branch": 0.45, "board": 0.30, "cre_amb": 0.20, "rules": 0.05}
 
 STAGE_NAMES = {
-    1: "curve",     # near-forced, creature-centric, small board
-    2: "contest",   # real branching, mixed types, developed board
-    3: "tangle",    # wide branching, dense board, spell-vs-creature judgment
+    1: "curve",  # near-forced, creature-centric, small board
+    2: "contest",  # real branching, mixed types, developed board
+    3: "tangle",  # wide branching, dense board, spell-vs-creature judgment
 }
 
 PRIMARY_TYPES = (
@@ -385,9 +385,16 @@ def option_features(name: str, card: Optional[dict], mana: int, sources: list[se
         # Unresolved name: neutral, non-affordable, flagged. Measured rate on
         # the full corpus is reported as unresolved_option_names.
         return {
-            "name": name, "types": [], "cmc": None, "affordable": False,
-            "instant": False, "targets": False, "modal": False,
-            "triggers": 0, "text_len": 0, "resolved": False,
+            "name": name,
+            "types": [],
+            "cmc": None,
+            "affordable": False,
+            "instant": False,
+            "targets": False,
+            "modal": False,
+            "triggers": 0,
+            "text_len": 0,
+            "resolved": False,
         }
     type_line = (card.get("tl") or "").lower()
     text = card.get("t") or ""
@@ -410,8 +417,7 @@ def decision_features(record: dict, cards: dict[str, dict]) -> dict:
     parsed = parse_prompt(record["user"])
     sources = parse_sources(parsed["sources"])
     options = [
-        option_features(name, cards.get(name.lower()), parsed["mana"], sources)
-        for name in parsed["menu"]
+        option_features(name, cards.get(name.lower()), parsed["mana"], sources) for name in parsed["menu"]
     ]
     own_nonland, own_lands = permanent_counts(parsed["board_you"])
     opp_nonland, opp_lands = permanent_counts(parsed["board_opp"])
@@ -481,7 +487,7 @@ def complexity_score(components: dict[str, float]) -> float:
 
 
 def reflex_pick(f: dict) -> int:
-    """"Cast the biggest affordable creature, else the biggest affordable spell."
+    """ "Cast the biggest affordable creature, else the biggest affordable spell."
 
     The strongest trivial policy measured on this corpus (61.1%). Ties break
     toward the earlier menu entry. Returns a 1-based menu index.
@@ -580,7 +586,7 @@ def auc(scores: list[float], labels: list[int]) -> float:
         while j + 1 < len(pairs) and pairs[j + 1][0] == pairs[i][0]:
             j += 1
         avg_rank = (i + j) / 2.0 + 1.0
-        rank_sum += avg_rank * sum(lbl for _, lbl in pairs[i:j + 1])
+        rank_sum += avg_rank * sum(lbl for _, lbl in pairs[i : j + 1])
         i = j + 1
     return (rank_sum - n_pos * (n_pos + 1) / 2.0) / (n_pos * n_neg)
 
@@ -642,9 +648,7 @@ def validation_block(rows: list[dict]) -> dict:
         "proxy_error_rate_pct": round(100.0 * sum(wrong) / len(rows), 1),
         "auc_full_score": round(auc([r["score"] for r in rows], wrong), 4),
         "auc_menu_size_only": round(auc([float(r["menu_size"]) for r in rows], wrong), 4),
-        "auc_by_component": {
-            k: round(auc([c[k] for c in comps], wrong), 4) for k in WEIGHTS
-        },
+        "auc_by_component": {k: round(auc([c[k] for c in comps], wrong), 4) for k in WEIGHTS},
         "weights": WEIGHTS,
     }
     return out
@@ -688,8 +692,7 @@ def check_staleness() -> dict:
             "current_chars": len(SYSTEM_PROMPT),
             "identical": stored == SYSTEM_PROMPT,
             "missing_from_corpus": [
-                line for line in SYSTEM_PROMPT.split("\n")
-                if line.startswith("- ") and line not in stored
+                line for line in SYSTEM_PROMPT.split("\n") if line.startswith("- ") and line not in stored
             ],
         }
     except Exception as exc:  # noqa: BLE001
@@ -703,21 +706,27 @@ def check_staleness() -> dict:
 def write_index(rows: list[dict], path: Path) -> None:
     with path.open("w", encoding="utf-8") as fh:
         for r in rows:
-            fh.write(json.dumps({
-                "id": r["id"],
-                "record_key": r["record_key"],
-                "stage": r["stage"],
-                "stage_name": STAGE_NAMES[r["stage"]],
-                "score": round(r["score"], 4),
-                "components": {k: round(v, 4) for k, v in r["components"].items()},
-                "n_affordable": r["n_affordable"],
-                "menu_size": r["menu_size"],
-                "n_creature_options": r["n_creature_options"],
-                "board_nonland": r["board_nonland"],
-                "max_triggers": r["max_triggers"],
-                "turn": r["turn"],
-                "pick_affordable": r["pick_affordable"],
-            }, ensure_ascii=False) + "\n")
+            fh.write(
+                json.dumps(
+                    {
+                        "id": r["id"],
+                        "record_key": r["record_key"],
+                        "stage": r["stage"],
+                        "stage_name": STAGE_NAMES[r["stage"]],
+                        "score": round(r["score"], 4),
+                        "components": {k: round(v, 4) for k, v in r["components"].items()},
+                        "n_affordable": r["n_affordable"],
+                        "menu_size": r["menu_size"],
+                        "n_creature_options": r["n_creature_options"],
+                        "board_nonland": r["board_nonland"],
+                        "max_triggers": r["max_triggers"],
+                        "turn": r["turn"],
+                        "pick_affordable": r["pick_affordable"],
+                    },
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
 
 
 def materialize(corpus: Path, rows: list[dict], out_dir: Path, prefix: str) -> dict[int, int]:
@@ -749,7 +758,9 @@ def materialize(corpus: Path, rows: list[dict], out_dir: Path, prefix: str) -> d
     return dict(counts)
 
 
-def dump_examples(corpus: Path, rows: list[dict], n: int, stages: tuple[int, ...], out: Path, seed: int) -> None:
+def dump_examples(
+    corpus: Path, rows: list[dict], n: int, stages: tuple[int, ...], out: Path, seed: int
+) -> None:
     """Sample ``n`` decisions per stage and write their full prompts out for
     human inspection. This is the sanity check the metric does not get to
     self-certify."""
@@ -776,7 +787,7 @@ def dump_examples(corpus: Path, rows: list[dict], n: int, stages: tuple[int, ...
                 fh.write("=" * 100 + "\n")
                 fh.write(
                     f"STAGE {st} ({STAGE_NAMES[st]})  score={row['score']:.3f}  "
-                    f"components={ {k: round(v,2) for k,v in row['components'].items()} }\n"
+                    f"components={ {k: round(v, 2) for k, v in row['components'].items()} }\n"
                     f"n_affordable={row['n_affordable']}/{row['menu_size']}  "
                     f"creature_options={row['n_creature_options']}  "
                     f"board_nonland={row['board_nonland']}  turn={row['turn']}\n"
@@ -796,17 +807,25 @@ def build_arg_parser() -> argparse.ArgumentParser:
     ap.add_argument("--prefix", default="strategic_casts_stage")
     ap.add_argument("--stride", type=int, default=1, help="read every Nth record")
     ap.add_argument("--limit", type=int, default=None)
-    ap.add_argument("--cuts", default="0.3333,0.6667",
-                    help="score quantiles separating stage 1|2 and 2|3")
-    ap.add_argument("--materialize", action="store_true",
-                    help="write full per-stage corpora (~2.4 GB) as well as the index")
+    ap.add_argument("--cuts", default="0.3333,0.6667", help="score quantiles separating stage 1|2 and 2|3")
+    ap.add_argument(
+        "--materialize",
+        action="store_true",
+        help="write full per-stage corpora (~2.4 GB) as well as the index",
+    )
     ap.add_argument("--no-index", action="store_true")
-    ap.add_argument("--validate", action="store_true",
-                    help="recompute the AUC table and the stratified honesty check")
-    ap.add_argument("--no-staleness-check", dest="check_staleness", action="store_false",
-                    help="skip the system-prompt staleness comparison (it imports the builder)")
-    ap.add_argument("--dump-examples", type=int, default=0,
-                    help="sample N decisions per stage into a human-readable file")
+    ap.add_argument(
+        "--validate", action="store_true", help="recompute the AUC table and the stratified honesty check"
+    )
+    ap.add_argument(
+        "--no-staleness-check",
+        dest="check_staleness",
+        action="store_false",
+        help="skip the system-prompt staleness comparison (it imports the builder)",
+    )
+    ap.add_argument(
+        "--dump-examples", type=int, default=0, help="sample N decisions per stage into a human-readable file"
+    )
     ap.add_argument("--example-stages", default="1,3")
     ap.add_argument("--rebuild-card-index", action="store_true")
     ap.add_argument("--seed", type=int, default=20260726)
@@ -855,9 +874,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             "max": round(max(scores), 4),
             "histogram": dict(sorted(Counter(round(s, 1) for s in scores).items())),
         },
-        "component_means": {
-            k: round(statistics.mean(r["components"][k] for r in rows), 4) for k in WEIGHTS
-        },
+        "component_means": {k: round(statistics.mean(r["components"][k] for r in rows), 4) for k in WEIGHTS},
         "data_quality": dict(problems),
         "stages": {
             f"{st}_{STAGE_NAMES[st]}": stage_summary([r for r in rows if r["stage"] == st])
@@ -895,10 +912,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         logger.info(
             "stage %d (%-7s) n=%-7d score<=%.3f  n_aff=%.2f board=%.1f creat=%.2f  "
             "reflex=%.1f%% (random %.1f%%)",
-            st, STAGE_NAMES[st], s["n"],
-            s["score_max"], s["n_affordable_mean"], s["board_nonland_mean"],
+            st,
+            STAGE_NAMES[st],
+            s["n"],
+            s["score_max"],
+            s["n_affordable_mean"],
+            s["board_nonland_mean"],
             statistics.mean(r["n_creature_options"] for r in rows if r["stage"] == st),
-            s["reflex_accuracy_pct"], s["random_baseline_pct"],
+            s["reflex_accuracy_pct"],
+            s["random_baseline_pct"],
         )
     return 0
 

--- a/tools/training/build_magezero_bridge.py
+++ b/tools/training/build_magezero_bridge.py
@@ -61,6 +61,7 @@ if str(REPO) not in sys.path:
 # so that downstream lazy imports (e.g. _new_planner in gate_play_decisions)
 # find it.
 
+
 def _load_autopilot_system_prompt() -> str:
     """Load AUTOPILOT_SYSTEM_PROMPT via importlib, bypassing __init__.py."""
     import types
@@ -76,9 +77,7 @@ def _load_autopilot_system_prompt() -> str:
     # Load backend_health (stdlib-only)
     bh_path = SRC / "arenamcp" / "backend_health.py"
     if "arenamcp.backend_health" not in sys.modules:
-        spec_h = importlib.util.spec_from_file_location(
-            "arenamcp.backend_health", str(bh_path)
-        )
+        spec_h = importlib.util.spec_from_file_location("arenamcp.backend_health", str(bh_path))
         assert spec_h is not None, f"cannot find backend_health.py at {bh_path}"
         mod_h = importlib.util.module_from_spec(spec_h)
         mod_h.__package__ = "arenamcp"
@@ -88,9 +87,7 @@ def _load_autopilot_system_prompt() -> str:
     # Load action_planner
     ap_path = SRC / "arenamcp" / "action_planner.py"
     if "arenamcp.action_planner" not in sys.modules:
-        spec_a = importlib.util.spec_from_file_location(
-            "arenamcp.action_planner", str(ap_path)
-        )
+        spec_a = importlib.util.spec_from_file_location("arenamcp.action_planner", str(ap_path))
         assert spec_a is not None, f"cannot find action_planner.py at {ap_path}"
         mod_a = importlib.util.module_from_spec(spec_a)
         mod_a.__package__ = "arenamcp"
@@ -130,18 +127,56 @@ _BASIC_LAND_TYPES: dict[str, str] = {
 
 # Suffix-based land detection: any card whose name ends with one of these
 # tokens is treated as a Land for mana-source counting.
-_LAND_SUFFIXES = ("Land", "lands", "Verge", "Heath", "Foothills", "Delta",
-                  "Strand", "Mire", "Catacombs", "Meadow", "Pool", "Grove",
-                  "Garden", "Tomb", "Node", "Spire", "Cavern", "Passage",
-                  "Factory", "Opal", "Citadel", "Sanctum", "Archive",
-                  "Crossroads", "Hideout", "Shrine", "Village", "Mine",
-                  "Foundry", "Den", "Expanse", "Reach", "Canopy", "Vista",
-                  "Basin", "Fortress", "Cave", "Crater", "Bridge", "Vale",
-                  "Confluence", "Borough", "Hub", "Borderpost", "Column")
+_LAND_SUFFIXES = (
+    "Land",
+    "lands",
+    "Verge",
+    "Heath",
+    "Foothills",
+    "Delta",
+    "Strand",
+    "Mire",
+    "Catacombs",
+    "Meadow",
+    "Pool",
+    "Grove",
+    "Garden",
+    "Tomb",
+    "Node",
+    "Spire",
+    "Cavern",
+    "Passage",
+    "Factory",
+    "Opal",
+    "Citadel",
+    "Sanctum",
+    "Archive",
+    "Crossroads",
+    "Hideout",
+    "Shrine",
+    "Village",
+    "Mine",
+    "Foundry",
+    "Den",
+    "Expanse",
+    "Reach",
+    "Canopy",
+    "Vista",
+    "Basin",
+    "Fortress",
+    "Cave",
+    "Crater",
+    "Bridge",
+    "Vale",
+    "Confluence",
+    "Borough",
+    "Hub",
+    "Borderpost",
+    "Column",
+)
 
 # Lands whose names have no suffix-based signal but contain a basic-land word
-_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's",
-                       "Corrupted", "Darksteel")
+_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's", "Corrupted", "Darksteel")
 
 
 def _resolve_type_line(name: str) -> str:
@@ -156,9 +191,13 @@ def _resolve_type_line(name: str) -> str:
         return hit
     name_lower = name.lower()
     # Check for basic-land-name-in-name (e.g. "Temple of Silence")
-    for basic, tl in (("plains", "Land — Plains"), ("island", "Land — Island"),
-                      ("swamp", "Land — Swamp"), ("mountain", "Land — Mountain"),
-                      ("forest", "Land — Forest")):
+    for basic, tl in (
+        ("plains", "Land — Plains"),
+        ("island", "Land — Island"),
+        ("swamp", "Land — Swamp"),
+        ("mountain", "Land — Mountain"),
+        ("forest", "Land — Forest"),
+    ):
         if basic in name_lower:
             return tl
     # Suffix detection
@@ -216,27 +255,25 @@ def build_game_state(row: dict) -> dict:
     battlefield: list[dict] = []
     next_id = 1
     for card in row.get("battlefield_self", []):
-        battlefield.append(_build_card(card["name"], LOCAL_SEAT,
-                                        card.get("tapped", False), next_id))
+        battlefield.append(_build_card(card["name"], LOCAL_SEAT, card.get("tapped", False), next_id))
         next_id += 1
     for card in row.get("battlefield_opp", []):
-        battlefield.append(_build_card(card["name"], OPP_SEAT,
-                                        card.get("tapped", False),
-                                        1000 + next_id))
+        battlefield.append(_build_card(card["name"], OPP_SEAT, card.get("tapped", False), 1000 + next_id))
         next_id += 1
 
     hand = [_build_hand_card(n) for n in row.get("hand", [])]
 
     # Determine phase string. MageZero uses MTGA-style phase names.
     phase_raw = row.get("phase", "PRECOMBAT_MAIN")
-    phase = {"PRECOMBAT_MAIN": "Phase_Main1",
-             "MAIN1": "Phase_Main1",
-             "MAIN2": "Phase_Main2",
-             "COMBAT_BEFORE_BLOCKERS": "Phase_Combat",
-             "COMBAT_DECLARE_BLOCKERS": "Phase_Combat",
-             "COMBAT_DECLARE_ATTACKERS": "Phase_Combat",
-             "END_COMBAT": "Phase_Combat",
-             }.get(phase_raw, f"Phase_{phase_raw}")
+    phase = {
+        "PRECOMBAT_MAIN": "Phase_Main1",
+        "MAIN1": "Phase_Main1",
+        "MAIN2": "Phase_Main2",
+        "COMBAT_BEFORE_BLOCKERS": "Phase_Combat",
+        "COMBAT_DECLARE_BLOCKERS": "Phase_Combat",
+        "COMBAT_DECLARE_ATTACKERS": "Phase_Combat",
+        "END_COMBAT": "Phase_Combat",
+    }.get(phase_raw, f"Phase_{phase_raw}")
 
     return {
         "players": [
@@ -274,6 +311,7 @@ def build_game_state(row: dict) -> dict:
 # Answer index resolution
 # ---------------------------------------------------------------------------
 
+
 def _resolve_answer(menu: list[str], chosen: str) -> int | None:
     """Return 1-based index of ``chosen`` in ``menu``, or None if not found."""
     try:
@@ -285,6 +323,7 @@ def _resolve_answer(menu: list[str], chosen: str) -> int | None:
 # ---------------------------------------------------------------------------
 # Record construction
 # ---------------------------------------------------------------------------
+
 
 def build_record(row: dict) -> tuple[dict | None, str]:
     """Single MageZero row → training record, or (None, drop_reason)."""
@@ -355,6 +394,7 @@ def build_record(row: dict) -> tuple[dict | None, str]:
 # ---------------------------------------------------------------------------
 # IO
 # ---------------------------------------------------------------------------
+
 
 def _read_jsonl(path: Path) -> list[dict]:
     out: list[dict] = []
@@ -429,6 +469,7 @@ def _report_stats(
 
 def _sha256_text(text: str) -> str:
     import hashlib
+
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
@@ -436,17 +477,19 @@ def _sha256_text(text: str) -> str:
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Build production-shaped training records from MageZero decisions JSONL.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--in", dest="input", type=Path, required=True,
-                        help="Path to decisions JSONL (MageZero schema)")
-    parser.add_argument("--out", dest="output", type=Path, required=True,
-                        help="Path to write training records JSONL")
-    parser.add_argument("--report", action="store_true",
-                        help="Print build report to stderr on completion")
+    parser.add_argument(
+        "--in", dest="input", type=Path, required=True, help="Path to decisions JSONL (MageZero schema)"
+    )
+    parser.add_argument(
+        "--out", dest="output", type=Path, required=True, help="Path to write training records JSONL"
+    )
+    parser.add_argument("--report", action="store_true", help="Print build report to stderr on completion")
     args = parser.parse_args(argv)
 
     t0 = time.time()
@@ -489,12 +532,12 @@ def main(argv: list[str] | None = None) -> int:
     written = _write_jsonl(args.output, records)
     logger.info(f"wrote {written} records -> {args.output}")
 
-    stats = _report_stats(records, drops, read_count, args.input,
-                          args.output, elapsed)
+    stats = _report_stats(records, drops, read_count, args.input, args.output, elapsed)
 
     # Write report to stderr if --report
     if args.report:
         import pprint
+
         print("\n=== BUILD REPORT ===", file=sys.stderr)
         pprint.pprint(stats, stream=sys.stderr, width=100, sort_dicts=False)
         print("", file=sys.stderr)

--- a/tools/training/build_magezero_combat.py
+++ b/tools/training/build_magezero_combat.py
@@ -65,9 +65,11 @@ for _p in (str(SRC), str(REPO)):
 
 # ── Import AUTOPILOT_SYSTEM_PROMPT via importlib (avoids PySide6 cascade) ──
 
+
 def _load_autopilot_system_prompt() -> str:
     import importlib.util
     import types
+
     if "arenamcp" not in sys.modules:
         pkg = types.ModuleType("arenamcp")
         pkg.__path__ = [str(SRC / "arenamcp")]
@@ -76,9 +78,7 @@ def _load_autopilot_system_prompt() -> str:
         sys.modules["arenamcp"] = pkg
     bh_path = SRC / "arenamcp" / "backend_health.py"
     if "arenamcp.backend_health" not in sys.modules:
-        spec_h = importlib.util.spec_from_file_location(
-            "arenamcp.backend_health", str(bh_path)
-        )
+        spec_h = importlib.util.spec_from_file_location("arenamcp.backend_health", str(bh_path))
         assert spec_h is not None, f"cannot find backend_health.py at {bh_path}"
         mod_h = importlib.util.module_from_spec(spec_h)
         mod_h.__package__ = "arenamcp"
@@ -86,15 +86,14 @@ def _load_autopilot_system_prompt() -> str:
         spec_h.loader.exec_module(mod_h)
     ap_path = SRC / "arenamcp" / "action_planner.py"
     if "arenamcp.action_planner" not in sys.modules:
-        spec_a = importlib.util.spec_from_file_location(
-            "arenamcp.action_planner", str(ap_path)
-        )
+        spec_a = importlib.util.spec_from_file_location("arenamcp.action_planner", str(ap_path))
         assert spec_a is not None, f"cannot find action_planner.py at {ap_path}"
         mod_a = importlib.util.module_from_spec(spec_a)
         mod_a.__package__ = "arenamcp"
         sys.modules["arenamcp.action_planner"] = mod_a
         spec_a.loader.exec_module(mod_a)
     return sys.modules["arenamcp.action_planner"].AUTOPILOT_SYSTEM_PROMPT
+
 
 AUTOPILOT_SYSTEM_PROMPT = _load_autopilot_system_prompt()
 
@@ -115,21 +114,69 @@ from tools.training.build_combat_decisions import (  # noqa: E402
 
 # Best-effort land detection — only needed to exclude lands from the
 # attack/block pool (MZ data has no grp_ids or type lines).
-_BASIC_LANDS = frozenset({
-    "Plains", "Island", "Swamp", "Mountain", "Forest",
-    "Snow-Covered Plains", "Snow-Covered Island", "Snow-Covered Swamp",
-    "Snow-Covered Mountain", "Snow-Covered Forest", "Wastes",
-})
-_LAND_SUFFIXES = ("Land", "lands", "Verge", "Heath", "Foothills", "Delta",
-                  "Strand", "Mire", "Catacombs", "Meadow", "Pool", "Grove",
-                  "Garden", "Tomb", "Node", "Spire", "Cavern", "Passage",
-                  "Factory", "Opal", "Citadel", "Sanctum", "Archive",
-                  "Crossroads", "Hideout", "Shrine", "Village", "Mine",
-                  "Foundry", "Den", "Expanse", "Reach", "Canopy", "Vista",
-                  "Basin", "Fortress", "Cave", "Crater", "Bridge", "Vale",
-                  "Confluence", "Borough", "Hub", "Borderpost", "Column")
-_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's",
-                       "Corrupted", "Darksteel")
+_BASIC_LANDS = frozenset(
+    {
+        "Plains",
+        "Island",
+        "Swamp",
+        "Mountain",
+        "Forest",
+        "Snow-Covered Plains",
+        "Snow-Covered Island",
+        "Snow-Covered Swamp",
+        "Snow-Covered Mountain",
+        "Snow-Covered Forest",
+        "Wastes",
+    }
+)
+_LAND_SUFFIXES = (
+    "Land",
+    "lands",
+    "Verge",
+    "Heath",
+    "Foothills",
+    "Delta",
+    "Strand",
+    "Mire",
+    "Catacombs",
+    "Meadow",
+    "Pool",
+    "Grove",
+    "Garden",
+    "Tomb",
+    "Node",
+    "Spire",
+    "Cavern",
+    "Passage",
+    "Factory",
+    "Opal",
+    "Citadel",
+    "Sanctum",
+    "Archive",
+    "Crossroads",
+    "Hideout",
+    "Shrine",
+    "Village",
+    "Mine",
+    "Foundry",
+    "Den",
+    "Expanse",
+    "Reach",
+    "Canopy",
+    "Vista",
+    "Basin",
+    "Fortress",
+    "Cave",
+    "Crater",
+    "Bridge",
+    "Vale",
+    "Confluence",
+    "Borough",
+    "Hub",
+    "Borderpost",
+    "Column",
+)
+_LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's", "Corrupted", "Darksteel")
 
 
 def _is_land(name: str) -> bool:
@@ -169,6 +216,7 @@ def _known_combat_state(name: str) -> bool:
 
 # ── Name disambiguation (matches build_combat_decisions.disambiguate) ──────
 
+
 def _disambiguate(names: list[str]) -> list[str]:
     """Byte-identical to build_combat_decisions.disambiguate."""
     counts = Counter(names)
@@ -184,6 +232,7 @@ def _disambiguate(names: list[str]) -> list[str]:
 
 
 # ── Response formatters (thin wrappers matching build_combat_decisions) ────
+
 
 def _attack_response(names: list[str]) -> str:
     return json.dumps(
@@ -201,6 +250,7 @@ def _block_response(assignments: dict[str, str]) -> str:
 
 # ── System prompt builder (matches build_combat_decisions.build_system) ────
 
+
 def _build_system(kind: str) -> str:
     addendum = ATTACK_ADDENDUM if kind == "attack" else BLOCK_ADDENDUM
     addendum += NO_SOLVER_ADDENDUM
@@ -209,6 +259,7 @@ def _build_system(kind: str) -> str:
 
 
 # ── User prompt builders ───────────────────────────────────────────────────
+
 
 def _user_prompt_attack(
     row: dict,
@@ -301,6 +352,7 @@ def _board_lines(row: dict, side: str) -> list[str]:
 
 # ── Record construction ────────────────────────────────────────────────────
 
+
 def _rid(key: str) -> str:
     return f"mzc-{hashlib.sha1(key.encode()).hexdigest()[:16]}"
 
@@ -385,9 +437,7 @@ def build_attack_record(row: dict) -> tuple[dict | None, str]:
         # a priority action during combat, not a combat decision.
         return None, "attack_no_declared"
 
-    declared = _match_declared_to_pool(
-        [n for n, _ in self_raw], pool, declared_raw
-    )
+    declared = _match_declared_to_pool([n for n, _ in self_raw], pool, declared_raw)
 
     user = _user_prompt_attack(row, pool, declared)
     rec = {
@@ -421,8 +471,9 @@ def build_attack_record(row: dict) -> tuple[dict | None, str]:
     }
     # Prove no solver line and no mcts_counts in the prompt
     assert "Computed optimal" not in rec["user"], "solver line leaked into prompt"
-    assert "count" not in rec["user"].lower() or "discard" not in rec["user"].lower(), \
+    assert "count" not in rec["user"].lower() or "discard" not in rec["user"].lower(), (
         "mcts_counts may have leaked"
+    )
     return rec, ""
 
 
@@ -477,12 +528,8 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
     # attackers for THIS blockers decision are the opp creatures with
     # ,attacking — but in this pattern, no opp creature has ,attacking.
     # We cannot determine the blocking assignment from ambiguous markers.
-    self_attacking = any(
-        _is_attacking(p["name"]) for p in row.get("battlefield_self", [])
-    )
-    opp_blocking = any(
-        _is_blocking(p["name"]) for p in row.get("battlefield_opp", [])
-    )
+    self_attacking = any(_is_attacking(p["name"]) for p in row.get("battlefield_self", []))
+    opp_blocking = any(_is_blocking(p["name"]) for p in row.get("battlefield_opp", []))
     if self_attacking and opp_blocking:
         return None, "block_reversed_markers_ambiguous"
 
@@ -490,8 +537,7 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
         # No blockers declared — opponent's attackers are known
         if not opp_attackers:
             return None, "block_no_attackers_either"
-        user = _user_prompt_block(row, blocker_pool,
-                                   opp_attackers, {})
+        user = _user_prompt_block(row, blocker_pool, opp_attackers, {})
         rec = {
             "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
             "system": _build_system("block"),
@@ -528,14 +574,11 @@ def build_block_record(row: dict) -> tuple[dict | None, str]:
         return None, f"block_{len(opp_attackers)}_attackers_cannot_pair"
 
     # Match declared blockers against the pool for correct disambiguation
-    declared_blockers = _match_declared_to_pool(
-        blocker_pool_raw, blocker_pool, self_blockers_raw
-    )
+    declared_blockers = _match_declared_to_pool(blocker_pool_raw, blocker_pool, self_blockers_raw)
     target_name = opp_attackers[0]
     assignments = {b: target_name for b in declared_blockers}
 
-    user = _user_prompt_block(row, blocker_pool,
-                               opp_attackers, assignments)
+    user = _user_prompt_block(row, blocker_pool, opp_attackers, assignments)
     rec = {
         "id": _rid(row.get("game_id", "") + ":blk:" + str(row.get("turn", 0))),
         "system": _build_system("block"),
@@ -593,9 +636,7 @@ def _class_histogram(
     return items
 
 
-def _check_class_share(
-    hist: list[tuple[str, int, float]], max_share: float, label: str
-) -> None:
+def _check_class_share(hist: list[tuple[str, int, float]], max_share: float, label: str) -> None:
     """Raise SystemExit if any class in *hist* exceeds *max_share*."""
     if not hist:
         return
@@ -610,10 +651,7 @@ def _check_class_share(
         ]
         for c, nn, s in hist:
             lines.append(f"    {c}: {nn} ({s:.1%})")
-        lines.append(
-            "  Pass --allow-skewed to build anyway, or use "
-            "--balance downsample."
-        )
+        lines.append("  Pass --allow-skewed to build anyway, or use --balance downsample.")
         raise SystemExit("\n".join(lines))
 
 
@@ -649,8 +687,7 @@ def _downsample(
         if max_share <= threshold:
             kept.extend(subset)
             print(
-                f"  [{kind_val}] no class exceeds {threshold:.0%}, "
-                f"keeping all {len(subset)}",
+                f"  [{kind_val}] no class exceeds {threshold:.0%}, keeping all {len(subset)}",
                 file=sys.stderr,
             )
             continue
@@ -667,14 +704,8 @@ def _downsample(
             kept.extend(subset)
             continue
 
-        majority_recs = [
-            r for r in subset
-            if r["meta"].get(meta_class_field, "") == max_class
-        ]
-        non_majority = [
-            r for r in subset
-            if r["meta"].get(meta_class_field, "") != max_class
-        ]
+        majority_recs = [r for r in subset if r["meta"].get(meta_class_field, "") == max_class]
+        non_majority = [r for r in subset if r["meta"].get(meta_class_field, "") != max_class]
 
         rng.shuffle(majority_recs)
         keep_count = len(majority_recs) - to_drop
@@ -690,6 +721,7 @@ def _downsample(
         kept.extend(keep_majority)
 
     return kept
+
 
 def _read_jsonl(path: Path) -> list[dict]:
     out: list[dict] = []
@@ -714,20 +746,26 @@ def main(argv: list[str] | None = None) -> int:
         description="Build combat-gate-shaped records from MageZero decisions JSONL.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--in", dest="input", type=Path, required=True,
-                        help="Path to decisions JSONL (MageZero schema)")
-    parser.add_argument("--out", dest="output", type=Path, required=True,
-                        help="Path to write training records JSONL")
-    parser.add_argument("--report", action="store_true",
-                        help="Print build report to stderr on completion")
-    parser.add_argument("--max-class-share", type=float, default=0.50,
-                        help="Maximum allowed share of any single class "
-                             "(default: 0.50).  Build aborts if exceeded.")
-    parser.add_argument("--allow-skewed", action="store_true",
-                        help="Skip the fail-closed class-share guard")
-    parser.add_argument("--balance", choices=("downsample",), default=None,
-                        help="Downsample the majority class toward the "
-                             "threshold (deterministic, seed=7)")
+    parser.add_argument(
+        "--in", dest="input", type=Path, required=True, help="Path to decisions JSONL (MageZero schema)"
+    )
+    parser.add_argument(
+        "--out", dest="output", type=Path, required=True, help="Path to write training records JSONL"
+    )
+    parser.add_argument("--report", action="store_true", help="Print build report to stderr on completion")
+    parser.add_argument(
+        "--max-class-share",
+        type=float,
+        default=0.50,
+        help="Maximum allowed share of any single class (default: 0.50).  Build aborts if exceeded.",
+    )
+    parser.add_argument("--allow-skewed", action="store_true", help="Skip the fail-closed class-share guard")
+    parser.add_argument(
+        "--balance",
+        choices=("downsample",),
+        default=None,
+        help="Downsample the majority class toward the threshold (deterministic, seed=7)",
+    )
     args = parser.parse_args(argv)
 
     t0 = time.time()
@@ -784,11 +822,13 @@ def main(argv: list[str] | None = None) -> int:
     # ── Class-histogram guard -------------------------------------------------
 
     attack_hist = _class_histogram(
-        records, "attack_class",
+        records,
+        "attack_class",
         lambda r: r.get("kind") == "combat_attack",
     )
     block_hist = _class_histogram(
-        records, "block_class",
+        records,
+        "block_class",
         lambda r: r.get("kind") == "combat_block",
     )
 
@@ -799,15 +839,16 @@ def main(argv: list[str] | None = None) -> int:
     # ── Rebalance -------------------------------------------------------------
 
     if args.balance == "downsample":
-        records = _downsample(records, attack_hist, block_hist,
-                              args.max_class_share)
+        records = _downsample(records, attack_hist, block_hist, args.max_class_share)
         # Recompute histograms after downsample for accurate report
         attack_hist = _class_histogram(
-            records, "attack_class",
+            records,
+            "attack_class",
             lambda r: r.get("kind") == "combat_attack",
         )
         block_hist = _class_histogram(
-            records, "block_class",
+            records,
+            "block_class",
             lambda r: r.get("kind") == "combat_block",
         )
 
@@ -816,9 +857,17 @@ def main(argv: list[str] | None = None) -> int:
     logger.info(f"wrote {written} records -> {args.output}")
 
     if args.report:
-        _print_report(records, drops, skip_counts, read_count,
-                      args.input, args.output, elapsed,
-                      attack_hist=attack_hist, block_hist=block_hist)
+        _print_report(
+            records,
+            drops,
+            skip_counts,
+            read_count,
+            args.input,
+            args.output,
+            elapsed,
+            attack_hist=attack_hist,
+            block_hist=block_hist,
+        )
 
     return 0
 
@@ -836,10 +885,7 @@ def _print_report(
 ) -> None:
     attack_recs = [r for r in records if r.get("kind") == "combat_attack"]
     block_recs = [r for r in records if r.get("kind") == "combat_block"]
-    any_mcts = sum(
-        1 for r in records
-        if isinstance(r.get("meta"), dict) and r["meta"].get("mcts_chosen")
-    )
+    any_mcts = sum(1 for r in records if isinstance(r.get("meta"), dict) and r["meta"].get("mcts_chosen"))
 
     print("\n=== BUILD REPORT ===", file=sys.stderr)
     print(f"  Input:      {input_path} ({read_count} rows)", file=sys.stderr)
@@ -872,15 +918,21 @@ def _print_report(
         sample = attack_recs[0]
         print(f"    id: {sample['id']}", file=sys.stderr)
         print(f"    response: {sample['response']}", file=sys.stderr)
-        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('pool_size','chosen_size','chosen_names','attack_class')})}", file=sys.stderr)
+        print(
+            f"    meta: {json.dumps({k: sample['meta'][k] for k in ('pool_size', 'chosen_size', 'chosen_names', 'attack_class')})}",
+            file=sys.stderr,
+        )
     if block_recs:
         print("\n  Sample block response:", file=sys.stderr)
         sample = block_recs[0]
         print(f"    id: {sample['id']}", file=sys.stderr)
         print(f"    response: {sample['response']}", file=sys.stderr)
-        print(f"    meta: {json.dumps({k: sample['meta'][k] for k in ('blocker_pool_size','n_attackers','n_blocks','block_class')})}", file=sys.stderr)
+        print(
+            f"    meta: {json.dumps({k: sample['meta'][k] for k in ('blocker_pool_size', 'n_attackers', 'n_blocks', 'block_class')})}",
+            file=sys.stderr,
+        )
 
-    print(f"  {'='*40}", file=sys.stderr)
+    print(f"  {'=' * 40}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tools/training/build_strategic_casts.py
+++ b/tools/training/build_strategic_casts.py
@@ -462,9 +462,7 @@ def render_user_message(
     else:
         lines.append("Land: no land played this turn — land actions are excluded from this decision")
     if step.already_cast:
-        cast_names = ", ".join(
-            resolver.get(g).name or f"grpId {g}" for g in step.already_cast
-        )
+        cast_names = ", ".join(resolver.get(g).name or f"grpId {g}" for g in step.already_cast)
         lines.append(f"Already cast this turn: {cast_names}")
     lines.append(f"On the {'play' if pos.on_play else 'draw'}.")
     if pos.opp_hand_count is not None:
@@ -787,9 +785,7 @@ def _pct(n: int, d: int) -> float:
     return round(100.0 * n / d, 3) if d else 0.0
 
 
-def summarize(
-    st: BuildStats, audit: dict[str, Counter], args: argparse.Namespace, elapsed: float
-) -> dict:
+def summarize(st: BuildStats, audit: dict[str, Counter], args: argparse.Namespace, elapsed: float) -> dict:
     per_turn = []
     for t in sorted(set(st.turns_with_cast_by_turn) | set(st.emitted_by_turn)):
         casts = st.casts_by_turn.get(t, 0)
@@ -872,16 +868,12 @@ def summarize(
         "menu": {
             "mean_menu_size": round(statistics.mean(st.menu_sizes), 2) if st.menu_sizes else 0,
             "median_menu_size": statistics.median(st.menu_sizes) if st.menu_sizes else 0,
-            "mean_cast_entries": round(
-                statistics.mean(st.menu_sizes) - (1 if args.include_pass else 0), 2
-            )
+            "mean_cast_entries": round(statistics.mean(st.menu_sizes) - (1 if args.include_pass else 0), 2)
             if st.menu_sizes
             else 0,
             "pick_index_distribution": dict(sorted(st.pick_indices.items())),
             "pick_index_1_observed_pct": _pct(st.pick_indices.get(1, 0), st.emitted),
-            "pick_index_1_expected_pct_if_uniform": round(
-                100.0 * st.expected_index1 / st.emitted, 3
-            )
+            "pick_index_1_expected_pct_if_uniform": round(100.0 * st.expected_index1 / st.emitted, 3)
             if st.emitted
             else 0.0,
             "mean_prompt_chars": round(statistics.mean(st.prompt_chars), 1) if st.prompt_chars else 0,
@@ -896,8 +888,11 @@ def summarize(
             p: {
                 "records": c.get("emitted", 0),
                 "turns_emitting": c.get("turns_emitting", 0),
-                "dropped": {k: v for k, v in c.items() if not k.startswith("turn_") and k not in
-                            ("emitted", "turns_emitting")},
+                "dropped": {
+                    k: v
+                    for k, v in c.items()
+                    if not k.startswith("turn_") and k not in ("emitted", "turns_emitting")
+                },
             }
             for p, c in audit.items()
         }
@@ -910,9 +905,7 @@ def summarize(
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    ap = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--replay-csv", type=Path, action="append", required=True)
     ap.add_argument("--min-rank", default="diamond", choices=[*RANK_ORDER, ""])
     ap.add_argument("--max-rows-per-file", type=int, default=20000)

--- a/tools/training/build_tripwires.py
+++ b/tools/training/build_tripwires.py
@@ -244,16 +244,16 @@ def run_tripwire_eval(
     }
 
     if verbose:
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("TRIPWIRE EVALUATION")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         print(f"Total: {total} | Passed: {passed_total} | Failed: {total - passed_total}")
         print(f"Overall pass rate: {summary['pass_rate']}%")
         print("\nCategory breakdown:")
         for cat, s in sorted(cats.items()):
             pct = round(s["passed"] / s["total"] * 100, 1) if s["total"] else 0.0
             print(f"  {cat:25s} {s['passed']:3d}/{s['total']:<3d} ({pct:5.1f}%)")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
     return summary
 
@@ -263,7 +263,12 @@ def main():
 
     parser = argparse.ArgumentParser(description="Build tripwire puzzle fixtures")
     parser.add_argument("--check", action="store_true", help="Check fixture count and uniqueness")
-    parser.add_argument("--output", type=str, default=None, help="Output path (default: tools/training/data/tripwire_fixtures.jsonl)")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output path (default: tools/training/data/tripwire_fixtures.jsonl)",
+    )
     args = parser.parse_args()
 
     out_path = Path(args.output) if args.output else REPO / "tools/training/data/tripwire_fixtures.jsonl"

--- a/tools/training/gate_combat_decisions.py
+++ b/tools/training/gate_combat_decisions.py
@@ -434,9 +434,7 @@ def parse_menu(user: str) -> tuple[list[tuple[str, int | None, int | None]], str
     _prefix, rows, _done, _suffix = menu_rows(user)
     if not rows:
         raise ValueError("menu has no creature rows")
-    kinds = {
-        ATTACK_ROW_PREFIX if r.startswith(ATTACK_ROW_PREFIX) else BLOCK_ROW_PREFIX for r in rows
-    }
+    kinds = {ATTACK_ROW_PREFIX if r.startswith(ATTACK_ROW_PREFIX) else BLOCK_ROW_PREFIX for r in rows}
     if len(kinds) != 1:
         raise ValueError(f"menu mixes attack and block rows: {rows[:3]}")
     kind = "attack" if kinds == {ATTACK_ROW_PREFIX} else "block"
@@ -950,9 +948,7 @@ def random_expectation(rec: ScoreRecord) -> float:
         if counts[-1] < 0:
             return 0.0
         equiv *= _multinomial(m, counts)
-    for tcls, n_used in Counter(
-        attacker_class[t] for t in rec.gold_map.values() if t is not None
-    ).items():
+    for tcls, n_used in Counter(attacker_class[t] for t in rec.gold_map.values() if t is not None).items():
         equiv *= attacker_sizes[tcls] ** n_used
 
     total = (len(rec.dec.attackers) + 1) ** len(rec.dec.blockers)
@@ -1015,9 +1011,7 @@ def reference_policies(corpus: list[ScoreRecord], *, seed: int = DEFAULT_SEED) -
 
     best_a_name, best_a = _argmax(attack_slice)
     best_b_name, best_b = _argmax(block_slice)
-    best_combined = (
-        round(((best_a or 0.0) * n_a + (best_b or 0.0) * n_b) / n, 4) if n else None
-    )
+    best_combined = round(((best_a or 0.0) * n_a + (best_b or 0.0) * n_b) / n, 4) if n else None
     return {
         "n": n,
         "n_attack": n_a,
@@ -1052,9 +1046,7 @@ def _argmax(scores: dict[str, float | None]) -> tuple[str | None, float | None]:
     return best_name, best_val
 
 
-def slice_reference_policies(
-    corpus: list[ScoreRecord], predicate, *, seed: int = DEFAULT_SEED
-) -> dict:
+def slice_reference_policies(corpus: list[ScoreRecord], predicate, *, seed: int = DEFAULT_SEED) -> dict:
     """Best reflex measured ON A SLICE (G9/G10/G11 floors).
 
     A reflex that is useless overall can still be strong inside one class —
@@ -1128,9 +1120,7 @@ def corpus_composition(corpus: list[ScoreRecord]) -> dict:
             "mean": round(sum(pool_sizes) / n, 2),
         },
         "blocks_with_duplicate_named_blockers": dup_blockers,
-        "blocks_with_duplicate_named_blockers_share": round(dup_blockers / block_n, 4)
-        if block_n
-        else 0.0,
+        "blocks_with_duplicate_named_blockers_share": round(dup_blockers / block_n, 4) if block_n else 0.0,
         "non_gated_answer_classes": sorted(NON_GATED_ANSWER_CLASSES),
     }
 
@@ -1309,9 +1299,7 @@ def permutation_metrics(identity: dict, permuted: dict, permuted_corpus: list[Sc
     # unparseable or illegal answers are not evidence that the model read the
     # board the same way twice.
     agree = sum(
-        1
-        for b, p in pairs
-        if b.get("answer_key") is not None and b.get("answer_key") == p.get("answer_key")
+        1 for b, p in pairs if b.get("answer_key") is not None and b.get("answer_key") == p.get("answer_key")
     )
     both_right = sum(1 for b, p in pairs if b["exact"] and p["exact"])
     return {
@@ -1375,9 +1363,7 @@ def _slice_floors(corpus: list[ScoreRecord], *, seed: int) -> dict:
     for cls in sorted({r.answer_class for r in corpus}):
         if cls in floors:
             continue
-        floors[cls] = slice_reference_policies(
-            corpus, lambda r, _c=cls: r.answer_class == _c, seed=seed
-        )
+        floors[cls] = slice_reference_policies(corpus, lambda r, _c=cls: r.answer_class == _c, seed=seed)
     return floors
 
 
@@ -1426,11 +1412,7 @@ def simulate_response(
             )
         target = rec.attacker_names[0] if rec.attacker_names else ILLEGAL_NAME
         return json.dumps(
-            {
-                "actions": [
-                    {"action_type": "declare_blockers", "blocker_assignments": {ILLEGAL_NAME: target}}
-                ]
-            }
+            {"actions": [{"action_type": "declare_blockers", "blocker_assignments": {ILLEGAL_NAME: target}}]}
         )
     if policy == "memorise":
         # The identity record's gold POSITIONS, replayed against whatever now
@@ -1444,26 +1426,18 @@ def simulate_response(
             names = [
                 rec.pool_names[i] for i in positions if isinstance(i, int) and 0 <= i < len(rec.pool_names)
             ]
-            return json.dumps(
-                {"actions": [{"action_type": "declare_attackers", "attacker_names": names}]}
-            )
+            return json.dumps({"actions": [{"action_type": "declare_attackers", "attacker_names": names}]})
         mapping = {}
         for pair in positions:
             b_i, a_i = pair
             if 0 <= b_i < len(rec.pool_names) and 0 <= a_i < len(rec.attacker_names):
                 mapping[rec.pool_names[b_i]] = rec.attacker_names[a_i]
-        return json.dumps(
-            {"actions": [{"action_type": "declare_blockers", "blocker_assignments": mapping}]}
-        )
+        return json.dumps({"actions": [{"action_type": "declare_blockers", "blocker_assignments": mapping}]})
 
     kind, answer = policy_declaration(policy, rec, rng)
     if kind == "attack":
-        return json.dumps(
-            {"actions": [{"action_type": "declare_attackers", "attacker_names": list(answer)}]}
-        )
-    return json.dumps(
-        {"actions": [{"action_type": "declare_blockers", "blocker_assignments": dict(answer)}]}
-    )
+        return json.dumps({"actions": [{"action_type": "declare_attackers", "attacker_names": list(answer)}]})
+    return json.dumps({"actions": [{"action_type": "declare_blockers", "blocker_assignments": dict(answer)}]})
 
 
 def _gold_positions(rec: ScoreRecord) -> list:
@@ -1530,9 +1504,7 @@ def cmd_simulate(args: argparse.Namespace) -> int:
         identity_gold=identity_gold,
     )
     n = _write_jsonl(args.out, rows)
-    logger.info(
-        f"simulated attack={args.attack_policy} block={args.block_policy} n={n} -> {args.out}"
-    )
+    logger.info(f"simulated attack={args.attack_policy} block={args.block_policy} n={n} -> {args.out}")
     return 0
 
 
@@ -1675,8 +1647,7 @@ def cmd_gate(args: argparse.Namespace) -> int:  # noqa: C901 — one linear crit
                     )
                 if metrics["duplicate_response_rows"]:
                     failures.append(
-                        f"{label} responses contain {metrics['duplicate_response_rows']} "
-                        "duplicate prompt_ids"
+                        f"{label} responses contain {metrics['duplicate_response_rows']} duplicate prompt_ids"
                     )
 
             # ---- G4 slice coverage -----------------------------------------
@@ -1690,9 +1661,7 @@ def cmd_gate(args: argparse.Namespace) -> int:  # noqa: C901 — one linear crit
                 failures.append(f"G4 insufficient attack samples: {atk_n} < {args.min_attack_samples}")
             if blk_n < args.min_block_samples:
                 failures.append(f"G4 insufficient block samples: {blk_n} < {args.min_block_samples}")
-            gated_classes = sorted(
-                set(composition.get("by_answer_class", {})) - NON_GATED_ANSWER_CLASSES
-            )
+            gated_classes = sorted(set(composition.get("by_answer_class", {})) - NON_GATED_ANSWER_CLASSES)
             for cls in gated_classes:
                 got = candidate["by_answer_class"].get(cls, {}).get("n", 0)
                 if got < args.min_slice_samples:
@@ -1703,9 +1672,7 @@ def cmd_gate(args: argparse.Namespace) -> int:  # noqa: C901 — one linear crit
             for rank in ("diamond", "mythic"):
                 got = candidate["by_rank"].get(rank, {}).get("n", 0)
                 if got < args.min_rank_slice_samples:
-                    failures.append(
-                        f"G4 rank slice {rank} has {got} < {args.min_rank_slice_samples} samples"
-                    )
+                    failures.append(f"G4 rank slice {rank} has {got} < {args.min_rank_slice_samples} samples")
             for cls in sorted(NON_GATED_ANSWER_CLASSES & set(candidate["by_answer_class"])):
                 stats = candidate["by_answer_class"][cls]
                 advisories.append(
@@ -2063,9 +2030,7 @@ def cmd_dryrun(args: argparse.Namespace) -> int:
         )
         _write_jsonl(
             perm_path,
-            simulate_rows(
-                permuted, atk, blk, label="candidate", seed=args.seed, identity_gold=identity_gold
-            ),
+            simulate_rows(permuted, atk, blk, label="candidate", seed=args.seed, identity_gold=identity_gold),
         )
         scratch.extend([cand_path, perm_path])
         report_path = out_dir / f"{DRYRUN_STEM}_{policy}.json"
@@ -2116,9 +2081,7 @@ def cmd_dryrun(args: argparse.Namespace) -> int:
         "corpus": str(args.corpus),
         "baseline_policy": args.baseline_policy,
         "reference_policies": references,
-        "slice_reflex_floors": {
-            k: v.get("best") for k, v in sorted(floors.items()) if v.get("n")
-        },
+        "slice_reflex_floors": {k: v.get("best") for k, v in sorted(floors.items()) if v.get("n")},
         "verdicts": verdicts,
     }
     summary_path = out_dir / f"{DRYRUN_STEM}_summary.json"
@@ -2204,15 +2167,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--min-nondegenerate-delta-ci-lower",
         type=float,
         default=MIN_NONDEGENERATE_DELTA_CI_LOWER,
-        help="G12: floor for the non-degenerate paired-bootstrap delta CI lower bound "
-        "(may only be raised)",
+        help="G12: floor for the non-degenerate paired-bootstrap delta CI lower bound (may only be raised)",
     )
     g.add_argument(
         "--min-accuracy",
         type=float,
         default=None,
-        help="optional EXTRA floor on exact-set accuracy (tightens the gate; there is no "
-        "loosening flag)",
+        help="optional EXTRA floor on exact-set accuracy (tightens the gate; there is no loosening flag)",
     )
     g.add_argument("--bootstraps", type=int, default=DEFAULT_BOOTSTRAPS)
     g.add_argument("--seed", type=int, default=DEFAULT_SEED)

--- a/tools/training/gate_play_decisions.py
+++ b/tools/training/gate_play_decisions.py
@@ -692,9 +692,7 @@ def build_decision(rec: dict, facts: _CardFacts) -> dict | None:
     # (one per attacker it could block), and (action_type, grpId, instanceId)
     # cannot tell them apart — identity matching silently labelled the wrong
     # attacker on 3 of 996 held-out block decisions.
-    kept = [
-        (i, e) for i, e in enumerate(full_menu) if e.get("action_type") not in MANA_LEVEL_ACTION_TYPES
-    ]
+    kept = [(i, e) for i, e in enumerate(full_menu) if e.get("action_type") not in MANA_LEVEL_ACTION_TYPES]
     menu = [e for _, e in kept]
     if gold_entry.get("action_type") in MANA_LEVEL_ACTION_TYPES:
         return {"drop_reason": "gold_pick_is_mana_action"}
@@ -2008,9 +2006,7 @@ def cmd_gate(args: argparse.Namespace) -> int:
             composition = corpus_composition(corpus) if corpus else {}
             references = reference_policies(corpus) if corpus else {}
             references_strategic = (
-                reference_policies([r for r in corpus if not r["meta"]["is_land_drop"]])
-                if corpus
-                else {}
+                reference_policies([r for r in corpus if not r["meta"]["is_land_drop"]]) if corpus else {}
             )
 
         if not failures:
@@ -2443,8 +2439,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--min-strategic-delta-ci-lower",
         type=float,
         default=MIN_STRATEGIC_DELTA_CI_LOWER,
-        help="G7: floor for the strategic-subset paired-bootstrap delta CI lower bound "
-        "(may only be raised)",
+        help="G7: floor for the strategic-subset paired-bootstrap delta CI lower bound (may only be raised)",
     )
     g.add_argument(
         "--min-accuracy",

--- a/tools/training/ingest_manasight.py
+++ b/tools/training/ingest_manasight.py
@@ -542,7 +542,9 @@ CAST_ACTION_TYPES = frozenset(
 # Playing a permanent from hand that is NOT a land (MDFC creature side, etc.).
 PLAY_ACTION_TYPES = frozenset({"ActionType_Play", "ActionType_PlayMDFC"})
 
-ACTIVATE_ACTION_TYPES = frozenset({"ActionType_Activate", "ActionType_Special", "ActionType_Special_TurnFaceUp"})
+ACTIVATE_ACTION_TYPES = frozenset(
+    {"ActionType_Activate", "ActionType_Special", "ActionType_Special_TurnFaceUp"}
+)
 
 COMBAT_ACTION_TYPES = frozenset({AT_DECLARE_ATTACKER, AT_DECLARE_BLOCKER})
 
@@ -558,7 +560,9 @@ STRATEGIC_ACTION_TYPES = (
 # toward "could have chosen differently" but never satisfy the "at least one
 # strategic action" test by themselves — otherwise "attack with nobody" alone
 # would qualify a menu with no creatures.
-NEUTRAL_OPTION_TYPES = frozenset({AT_NO_ATTACKS, AT_NO_BLOCKS, AT_SEARCH_FAIL, AT_OPTIONAL_NO, AT_OPTIONAL_YES})
+NEUTRAL_OPTION_TYPES = frozenset(
+    {AT_NO_ATTACKS, AT_NO_BLOCKS, AT_SEARCH_FAIL, AT_OPTIONAL_NO, AT_OPTIONAL_YES}
+)
 
 # Decision types that are mana/plumbing by construction.
 NON_STRATEGIC_DECISION_TYPES = frozenset({"pay_costs"})
@@ -1043,8 +1047,7 @@ def _write_attribution(path: Path, n: int) -> Path:
     """Every derived file must carry the upstream licence notice."""
     p = path.with_suffix(".ATTRIBUTION.txt")
     p.write_text(
-        f"{ATTRIBUTION}\n\nSource: {SOURCE_REPO}\nLicense: {SOURCE_LICENSE}\n"
-        f"Records: {n} in {path.name}\n",
+        f"{ATTRIBUTION}\n\nSource: {SOURCE_REPO}\nLicense: {SOURCE_LICENSE}\nRecords: {n} in {path.name}\n",
         encoding="utf-8",
     )
     return p

--- a/tools/training/magezero_filters.py
+++ b/tools/training/magezero_filters.py
@@ -172,9 +172,7 @@ def downsample_passes(
     d_needed = math.ceil((n_pass - max_frac * total) / (1.0 - max_frac))
 
     eligible_idx = [
-        i
-        for i, r in enumerate(rows)
-        if r.get("chosen") == "Pass" and r.get("decision_kind") == "priority"
+        i for i, r in enumerate(rows) if r.get("chosen") == "Pass" and r.get("decision_kind") == "priority"
     ]
     rng = random.Random(seed)
     order = list(eligible_idx)
@@ -214,12 +212,12 @@ def pass_rate_tripwire(rows: list[dict], max_frac: float = 0.40) -> None:
             f"  Total rows (post-filter): {total}\n"
             f"  Pass choices:             {n_pass}\n"
             f"  Non-Pass choices:         {n_nonpass}\n"
-            f"  Pass fraction:            {frac:.4f}  ({frac*100:.1f}%)\n"
-            f"  Max allowed fraction:     {max_frac}  ({max_frac*100:.0f}%)\n"
+            f"  Pass fraction:            {frac:.4f}  ({frac * 100:.1f}%)\n"
+            f"  Max allowed fraction:     {max_frac}  ({max_frac * 100:.0f}%)\n"
             f"\n"
             f"A prior corpus with a 56 % Pass rate trained a pass-reflex\n"
             f"into the model, wasting a week of training.  This corpus\n"
-            f"has a {frac*100:.1f} % Pass rate and is being rejected.\n",
+            f"has a {frac * 100:.1f} % Pass rate and is being rejected.\n",
             file=sys.stderr,
         )
         raise SystemExit(42)
@@ -336,9 +334,7 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def _counts_by_field(
-    rows: list[dict], field: str
-) -> dict[str, int]:
+def _counts_by_field(rows: list[dict], field: str) -> dict[str, int]:
     """Count occurrences of each distinct value of *field* in *rows*."""
     counts: dict[str, int] = {}
     for r in rows:

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -42,6 +42,22 @@ RE_HAND = re.compile(r"-> Hand: \[(.*?)\]")
 RE_PERMANENTS = re.compile(r"-> Permanents: \[(.*?)\]")
 RE_PLAYER_LIFE = re.compile(r"\[(Player[AB])\], life = (\d+)")
 
+# Name-attributed hand lines from ComputerPlayer.logList, e.g.
+#   [1:Beginning:UPKEEP]PlayerA hand: : Island,Soul Partition, =>[pool-3-thread-4] ComputerPlayer.logList
+# Unlike the positional `-> Hand:` block lines, these carry the PLAYER NAME,
+# the TURN, and the PHASE on the line itself, so attribution never depends on
+# which block header happened to precede them (the #452 defect family). All
+# 9,063 such lines on mz_train_smoke.log are `[N:Beginning:UPKEEP]PlayerA`.
+# The card list is comma-separated WITHOUT a space after separator commas,
+# while commas inside card names ("Kitsa, Otterball Elite") are followed by
+# one — see parse_named_hand_cards. 624 of the 9,063 lines carry an empty
+# list: a legitimately empty hand, distinct from "no line found".
+RE_NAMED_HAND = re.compile(r"\[(\d+):([^:\]]+):(\w+)\](\w+) hand: : (.*?)\s*(?:=>|$)")
+
+# The MCTS/primary player. Decisions carry actor="PlayerA"; only this
+# player's name-attributed hand lines may reach a training row.
+PRIMARY_PLAYER = "PlayerA"
+
 # The emitter tag at end of line disambiguates the two battlefield-block
 # grammars (#430). `ComputerPlayerMCTS.printBattlefieldScore` blocks are
 #   [PlayerX] header -> Hand -> Permanents (SELF) -> Permanents (OPPONENT)
@@ -66,7 +82,12 @@ RE_ACTION_TUPLE = re.compile(r"\[([^\]]+?) score: (-?[\d.eE+-]+) count: (\d+)\]"
 # rather than returned, because parse_log's 2-tuple signature has several
 # callers; the report reads this to surface the pass rate, which the B2
 # tripwire depends on being visible.
-LAST_PARSE_STATS: dict[str, int] = {"recovered_pass": 0, "ambiguous_unconsumed": 0}
+LAST_PARSE_STATS: dict[str, int] = {
+    "recovered_pass": 0,
+    "ambiguous_unconsumed": 0,
+    "hand_named_attributed": 0,
+    "hand_dropped_unattributed": 0,
+}
 
 
 # ── Phase → decision_kind mapping ───────────────────────────────────────
@@ -161,7 +182,6 @@ def _emit_pass_decision(
     state: _ThreadState,
     pending: _PendingPool,
     menu_raw: str,
-    decisions: list[dict],
     stats: dict[str, int],
 ) -> None:
     """Emit the decision for a pool line no `chose action` ever consumed.
@@ -210,9 +230,9 @@ def _emit_pass_decision(
         "_log": state.log_name,
         "session": "",
         "_recovered_pass": True,
+        "_hand_positional": [],
     }
     state.game_decisions.append(decision)
-    decisions.append(decision)
     stats["recovered_pass"] += 1
 
 
@@ -277,6 +297,23 @@ def parse_pool_actions(text: str) -> list[tuple[str, float, int]]:
 def parse_card_list(text: str) -> list[str]:
     text = text.strip()
     return [c.strip() for c in text.split(";")] if text else []
+
+
+# Separator commas in logList output are NOT followed by a space; commas
+# inside card names ("Kitsa, Otterball Elite") always are. Verified against
+# magezero_card_map.json: 10 names contain a comma, 0 contain a comma not
+# followed by a space.
+RE_NAMED_HAND_SEP = re.compile(r",(?!\s)")
+
+
+def parse_named_hand_cards(text: str) -> list[str]:
+    """Split a ComputerPlayer.logList card list (trailing comma, no-space seps)."""
+    text = text.strip()
+    if text.endswith(","):
+        text = text[:-1]
+    if not text:
+        return []
+    return [c.strip() for c in RE_NAMED_HAND_SEP.split(text) if c.strip()]
 
 
 def parse_permanents(text: str) -> list[dict[str, Any]]:
@@ -379,8 +416,13 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
     # entries are comma-joined and comma-containing, so the split needs the
     # paired pool's action names as anchors (see segment_menu).
     pending_menu: dict[str, str] = {}
-    # Recovery accounting, reported by --report so the pass rate is visible.
-    pass_stats: dict[str, int] = {"recovered_pass": 0, "ambiguous_unconsumed": 0}
+    # Recovery + hand-attribution accounting, reported by --report.
+    stats: dict[str, int] = {
+        "recovered_pass": 0,
+        "ambiguous_unconsumed": 0,
+        "hand_named_attributed": 0,
+        "hand_dropped_unattributed": 0,
+    }
 
     for line in all_lines:
         line = line.rstrip("\n\r")
@@ -402,8 +444,8 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             # boundary is the last window of the OUTGOING game.
             prev = pending_pool.pop(thread_id, None)
             if prev is not None:
-                _emit_pass_decision(state, prev, pending_menu.get(thread_id, ""), decisions, pass_stats)
-            _finalize_game(state, decisions)
+                _emit_pass_decision(state, prev, pending_menu.get(thread_id, ""), stats)
+            _finalize_game(state, decisions, stats)
             thread_game_seq[thread_id] += 1
             state.start_new_game(thread_game_seq[thread_id])
             pending_menu.pop(thread_id, None)
@@ -430,7 +472,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 prev = pending_pool.pop(thread_id, None)
                 if prev is not None:
                     _emit_pass_decision(
-                        state, prev, pending_menu.pop(thread_id, ""), decisions, pass_stats
+                        state, prev, pending_menu.pop(thread_id, ""), stats
                     )
                 pending_pool[thread_id] = _PendingPool(
                     actions=actions,
@@ -488,9 +530,9 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 "_game_seq": state.game_seq,
                 "_log": log_name,
                 "session": "",
+                "_hand_positional": [],
             }
             state.game_decisions.append(decision)
-            decisions.append(decision)
             continue
 
         # ── Player life: also opens a battlefield block (#430) ───
@@ -500,10 +542,22 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             state.on_block_header(pl.group(1), int(pl.group(2)), em.group(1) if em else None)
             continue
 
-        # ── Hand: PlayerA's backfills the decision; PlayerB's is the
-        # OPPONENT'S HAND (GameStateEvaluator2 prints both players' views)
-        # and must never enter a training row — the old parser backfilled
-        # it blindly, which is both wrong data and an L4 leak. ──────────
+        # ── Name-attributed hand (ComputerPlayer.logList): the ONLY source
+        # that may fill a training row's `hand`. The line itself names the
+        # player, the turn, and the phase — no positional inference. Lines
+        # naming any other player are ignored (their hand is hidden
+        # information; leak class L4). ──────────────────────────────────
+        nh = RE_NAMED_HAND.search(line)
+        if nh:
+            if nh.group(4) == PRIMARY_PLAYER:
+                state.named_hands[int(nh.group(1))] = parse_named_hand_cards(nh.group(5))
+            continue
+
+        # ── Positional `-> Hand:` block lines: DIAGNOSTIC ONLY. They are
+        # attributed by block-header adjacency (the #452 defect family), so
+        # they feed the internal `_hand_positional` shadow used by --report
+        # reconciliation, never the `hand` field itself. PlayerB blocks are
+        # the opponent's hidden hand and are skipped entirely (leak L4). ─
         hm = RE_HAND.search(line)
         if hm:
             cards = parse_card_list(hm.group(1))
@@ -524,17 +578,17 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
     for tid, prev in list(pending_pool.items()):
         st = threads.get(tid)
         if st is not None:
-            _emit_pass_decision(st, prev, pending_menu.get(tid, ""), decisions, pass_stats)
+            _emit_pass_decision(st, prev, pending_menu.get(tid, ""), stats)
     pending_pool.clear()
 
     # Finalize remaining games
     for state in threads.values():
-        _finalize_game(state, decisions)
+        _finalize_game(state, decisions, stats)
 
     # Enrich with sessions using per-thread game counts
     _enrich_sessions(decisions, sessions)
 
-    LAST_PARSE_STATS.update(pass_stats)
+    LAST_PARSE_STATS.update(stats)
 
     return decisions, sessions
 
@@ -549,6 +603,11 @@ class _ThreadState:
         self.life_a = 20
         self.life_b = 20
         self.latest_hand: list[str] = []
+        # Name-attributed hands from ComputerPlayer.logList, keyed by TURN.
+        # Reset per game. The value may legitimately be [] (empty hand at
+        # upkeep) — presence of the key means "attributed", absence means
+        # the row's hand cannot be sourced and the row is dropped+counted.
+        self.named_hands: dict[int, list[str]] = {}
         # Last known board per player (#430). "Self" for a decision row is
         # always PlayerA — the MCTS/primary player; decisions carry
         # actor="PlayerA" — so battlefield_self is boards["PlayerA"].
@@ -572,6 +631,7 @@ class _ThreadState:
         self.life_a = 20
         self.life_b = 20
         self.latest_hand = []
+        self.named_hands = {}
         self.boards = {"PlayerA": [], "PlayerB": []}
         self.last_log_life_a = None
         self.last_log_life_b = None
@@ -606,14 +666,14 @@ class _ThreadState:
         self._block_flushed = False
 
     def on_hand_line(self, cards: list[str]):
-        # Only the primary player's hand may reach a training row. A PlayerB
-        # hand line (GameStateEvaluator2 prints the opponent's view too) is
-        # the opponent's hidden hand: backfilling it poisons the `hand` field
-        # AND leaks information the model must never see (leak class L4).
+        # DIAGNOSTIC ONLY since the hand-attribution switch: positional
+        # `-> Hand:` block lines feed `_hand_positional` (reconciliation
+        # shadow), never the `hand` field. PlayerB blocks are the opponent's
+        # hidden hand (leak class L4) and are skipped entirely.
         if self._block_player == "PlayerB":
             return
         self.latest_hand = cards
-        _backfill_hand(self, cards)
+        _backfill_positional_hand(self, cards)
 
     def on_permanents_line(self, permanents: list[dict], emitter: str | None):
         # Attribution is positional WITHIN the current header block, which is
@@ -665,10 +725,17 @@ class _ThreadState:
         return "unknown"
 
 
-def _backfill_hand(state: _ThreadState, cards: list[str]):
+def _backfill_positional_hand(state: _ThreadState, cards: list[str]):
+    """Shadow of the PRE-switch hand flow, kept for --report reconciliation.
+
+    Fills the internal `_hand_positional` field exactly the way the old
+    parser filled `hand` (oldest-unfilled-first), so the report can measure
+    how often the positional source disagreed with the name-attributed one.
+    Stripped on write; never reaches a training row.
+    """
     for d in reversed(state.game_decisions):
-        if not d.get("hand"):
-            d["hand"] = list(cards)
+        if not d.get("_hand_positional"):
+            d["_hand_positional"] = list(cards)
             return
 
 
@@ -686,17 +753,40 @@ def _backfill_battlefield(state: _ThreadState):
             return
 
 
-def _finalize_game(state: _ThreadState, all_decisions: list[dict]):
+def _finalize_game(state: _ThreadState, all_decisions: list[dict],
+                   stats: dict[str, int]):
+    """Close out a game: assign hands, outcomes, boards; emit surviving rows.
+
+    Hand attribution is by NAME + THREAD + TURN: a row's hand comes from the
+    ComputerPlayer.logList line for the primary player on this thread-game
+    with the row's turn number. A row whose turn has no such line is DROPPED
+    and counted (`hand_dropped_unattributed`) — never guessed, never emitted
+    with a fabricated "empty hand" (an empty hand in a prompt asserts "you
+    hold nothing", which is an observation, not an absence of one).
+
+    Rows are appended to `all_decisions` here, not at creation, so a drop is
+    a real drop and not a mutation race.
+    """
     if not state.game_decisions:
         return
     outcome = state.infer_outcome()
     for d in state.game_decisions:
         d["outcome"] = outcome
-        if not d.get("hand"):
-            d["hand"] = list(state.latest_hand)
+        # Pre-switch shadow fallback, mirroring the old `hand` finalize path.
+        if not d.get("_hand_positional"):
+            d["_hand_positional"] = list(state.latest_hand)
         if not d.pop("_bf_filled", False):
             d["battlefield_self"] = list(state.boards["PlayerA"])
             d["battlefield_opp"] = list(state.boards["PlayerB"])
+
+        named = state.named_hands.get(d.get("turn", -1))
+        if named is None:
+            stats["hand_dropped_unattributed"] += 1
+            continue
+        d["hand"] = list(named)
+        stats["hand_named_attributed"] += 1
+        all_decisions.append(d)
+    state.game_decisions = []
 
 
 # ── Session enrichment ──────────────────────────────────────────────────
@@ -868,6 +958,29 @@ def _print_report(decisions: list[dict],
     print(f"    Pass fraction of `chosen`:  {n_pass}/{total} = {100 * n_pass / total:.1f}%")
     if n_pass / total > 0.40:
         print("    ** EXCEEDS the 40% B2 pass-reflex tripwire — corpus needs rebalancing **")
+
+    n_named = LAST_PARSE_STATS.get("hand_named_attributed", 0)
+    n_dropped = LAST_PARSE_STATS.get("hand_dropped_unattributed", 0)
+    print("\n  Hand attribution (name-attributed ComputerPlayer.logList only):")
+    print(f"    Rows with named hand:        {n_named}")
+    print(f"    Rows DROPPED (no named hand line for the row's turn): {n_dropped}")
+    # Reconciliation against the pre-switch positional source (diagnostic;
+    # `:N` evaluator score suffixes are stripped before comparing so only
+    # CONTENT differences count, not format pollution).
+    both = 0
+    differ = 0
+    _score_suffix = re.compile(r":\d+$")
+    for d in decisions:
+        pos = d.get("_hand_positional")
+        if not pos:
+            continue
+        both += 1
+        pos_norm = sorted(_score_suffix.sub("", c).strip() for c in pos)
+        if pos_norm != sorted(d.get("hand", [])):
+            differ += 1
+    if both:
+        print(f"    Positional-source disagreement (diagnostic): "
+              f"{differ}/{both} = {100 * differ / both:.1f}%")
 
     total_games: set[str] = set()
     total_by_kind: dict[str, int] = {}

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -106,8 +106,13 @@ DECISION_KIND_MAP = {
 }
 
 # Known opponent order for the smoke run (gen0: Standard-MonoR/G/B/W/U, gen1: same order)
-SMOKE_OPPONENTS_GEN0 = ["Standard-MonoR", "Standard-MonoG", "Standard-MonoB",
-                         "Standard-MonoW", "Standard-MonoU"]
+SMOKE_OPPONENTS_GEN0 = [
+    "Standard-MonoR",
+    "Standard-MonoG",
+    "Standard-MonoB",
+    "Standard-MonoW",
+    "Standard-MonoU",
+]
 
 
 class _PendingPool:
@@ -290,6 +295,7 @@ def classify_kind(phase_code: str, pool_actions: list[tuple]) -> str:
 
 # ── Parsing helpers ─────────────────────────────────────────────────────
 
+
 def parse_pool_actions(text: str) -> list[tuple[str, float, int]]:
     return [(m[0], float(m[1]), int(m[2])) for m in RE_ACTION_TUPLE.findall(text)]
 
@@ -333,6 +339,7 @@ def parse_permanents(text: str) -> list[dict[str, Any]]:
 
 
 # ── Session detection ───────────────────────────────────────────────────
+
 
 class SessionInfo:
     def __init__(self, seq: int, start_ts: str, opponent: str, n_games: int):
@@ -397,6 +404,7 @@ def _extract_ts(line: str, default: str) -> str:
 
 # ── Main parser ─────────────────────────────────────────────────────────
 
+
 def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
     log_name = os.path.basename(log_path)
     is_smoke = "smoke" in log_name
@@ -454,8 +462,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
         # ── logLife (turn/phase/life totals) ─────────────────────
         lm = RE_LOG_LIFE.search(line)
         if lm:
-            state.on_log_life(int(lm.group(1)), lm.group(2), lm.group(3),
-                              int(lm.group(4)), int(lm.group(5)))
+            state.on_log_life(int(lm.group(1)), lm.group(2), lm.group(3), int(lm.group(4)), int(lm.group(5)))
             continue
 
         # ── MCTS pool distribution ───────────────────────────────
@@ -471,9 +478,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
                 # them a case where the search concluded "do nothing".
                 prev = pending_pool.pop(thread_id, None)
                 if prev is not None:
-                    _emit_pass_decision(
-                        state, prev, pending_menu.pop(thread_id, ""), stats
-                    )
+                    _emit_pass_decision(state, prev, pending_menu.pop(thread_id, ""), stats)
                 pending_pool[thread_id] = _PendingPool(
                     actions=actions,
                     phase_code=pool_match.group(1),
@@ -504,9 +509,7 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
             # The chosen name comes from the (comma-safe) `chose action` line;
             # add it to the anchors in case the paired pool is a sub-decision
             # pool ("(top: X)pool=") whose names are not the menu's entries.
-            menu = segment_menu(
-                menu_raw, [name for name, _, _ in pool_actions] + [chosen]
-            )
+            menu = segment_menu(menu_raw, [name for name, _, _ in pool_actions] + [chosen])
 
             kind = classify_kind(phase_code, pool_actions)
             mcts_counts = {name: count for name, _, count in pool_actions}
@@ -641,8 +644,7 @@ class _ThreadState:
         self._block_perm_lines = 0
         self._block_flushed = False
 
-    def on_log_life(self, turn: int, phase_name: str, phase_code: str,
-                    life_a: int, life_b: int):
+    def on_log_life(self, turn: int, phase_name: str, phase_code: str, life_a: int, life_b: int):
         self.last_turn = turn
         self.life_a = life_a
         self.life_b = life_b
@@ -753,8 +755,7 @@ def _backfill_battlefield(state: _ThreadState):
             return
 
 
-def _finalize_game(state: _ThreadState, all_decisions: list[dict],
-                   stats: dict[str, int]):
+def _finalize_game(state: _ThreadState, all_decisions: list[dict], stats: dict[str, int]):
     """Close out a game: assign hands, outcomes, boards; emit surviving rows.
 
     Hand attribution is by NAME + THREAD + TURN: a row's hand comes from the
@@ -790,6 +791,7 @@ def _finalize_game(state: _ThreadState, all_decisions: list[dict],
 
 
 # ── Session enrichment ──────────────────────────────────────────────────
+
 
 def _enrich_sessions(decisions: list[dict], sessions: list[SessionInfo]):
     """Assign sessions and calibrate outcomes.
@@ -885,22 +887,14 @@ def _enrich_sessions(decisions: list[dict], sessions: list[SessionInfo]):
 
 # ── CLI ─────────────────────────────────────────────────────────────────
 
+
 def build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Parse MageZero XMage logs into decisions JSONL."
-    )
+    parser = argparse.ArgumentParser(description="Parse MageZero XMage logs into decisions JSONL.")
     parser.add_argument(
-        "--log", required=True, action="append", dest="logs",
-        help="Path(s) to mz_train.log file(s)"
+        "--log", required=True, action="append", dest="logs", help="Path(s) to mz_train.log file(s)"
     )
-    parser.add_argument(
-        "--out", required=True,
-        help="Output JSONL path"
-    )
-    parser.add_argument(
-        "--report", action="store_true",
-        help="Print reconciliation report"
-    )
+    parser.add_argument("--out", required=True, help="Output JSONL path")
+    parser.add_argument("--report", action="store_true", help="Print reconciliation report")
     return parser
 
 
@@ -921,11 +915,13 @@ def main():
             for line in f:
                 m = RE_WIN_RATE.search(line)
                 if m:
-                    wr_lines.append({
-                        "win_rate": float(m.group(1)),
-                        "n_wins": int(m.group(2)),
-                        "n_total": int(m.group(3)),
-                    })
+                    wr_lines.append(
+                        {
+                            "win_rate": float(m.group(1)),
+                            "n_wins": int(m.group(2)),
+                            "n_total": int(m.group(3)),
+                        }
+                    )
         win_rates_by_log[log_name] = wr_lines
 
     # Write output
@@ -940,10 +936,9 @@ def main():
         _print_report(all_decisions, win_rates_by_log, args.logs, out_path)
 
 
-def _print_report(decisions: list[dict],
-                  win_rates_by_log: dict[str, list[dict]],
-                  log_paths: list[str],
-                  out_path: Path):
+def _print_report(
+    decisions: list[dict], win_rates_by_log: dict[str, list[dict]], log_paths: list[str], out_path: Path
+):
 
     print("=" * 60)
     print("MAGEZERO LOG PARSE REPORT")
@@ -979,8 +974,9 @@ def _print_report(decisions: list[dict],
         if pos_norm != sorted(d.get("hand", [])):
             differ += 1
     if both:
-        print(f"    Positional-source disagreement (diagnostic): "
-              f"{differ}/{both} = {100 * differ / both:.1f}%")
+        print(
+            f"    Positional-source disagreement (diagnostic): {differ}/{both} = {100 * differ / both:.1f}%"
+        )
 
     total_games: set[str] = set()
     total_by_kind: dict[str, int] = {}
@@ -1030,10 +1026,16 @@ def _print_report(decisions: list[dict],
 
         # Aggregate per-session: count unique game outcomes
         for sess, out_data in session_outcomes.items():
-            games_won = {d.get("game_id", "") for d in log_decisions
-                         if d.get("session") == sess and d.get("outcome") == "won"}
-            games_lost = {d.get("game_id", "") for d in log_decisions
-                          if d.get("session") == sess and d.get("outcome") == "lost"}
+            games_won = {
+                d.get("game_id", "")
+                for d in log_decisions
+                if d.get("session") == sess and d.get("outcome") == "won"
+            }
+            games_lost = {
+                d.get("game_id", "")
+                for d in log_decisions
+                if d.get("session") == sess and d.get("outcome") == "lost"
+            }
             out_data["won"] = len(games_won)
             out_data["lost"] = len(games_lost)
             out_data["unknown"] = len(session_games[sess]) - len(games_won) - len(games_lost)
@@ -1049,20 +1051,24 @@ def _print_report(decisions: list[dict],
                 out_data = next((o for s, o in session_outcomes.items() if s.startswith(sess)), None)
                 inferred_wins = out_data["won"] if out_data else 0
                 inferred_games = out_data["won"] + out_data["lost"] + out_data["unknown"] if out_data else 0
-                expected_wins = round(wr["n_wins"] / wr["n_total"] * inferred_games) if wr["n_total"] > 0 else 0
+                expected_wins = (
+                    round(wr["n_wins"] / wr["n_total"] * inferred_games) if wr["n_total"] > 0 else 0
+                )
                 diff = abs(inferred_wins - expected_wins)
                 mark = "✅" if diff <= 2 else "⚠️"
-                print(f"      {mark} {sess}: logged {wr['n_wins']}/{wr['n_total']} "
-                      f"→ inferred {inferred_wins}/{inferred_games} (expected {expected_wins}, diff={diff})")
+                print(
+                    f"      {mark} {sess}: logged {wr['n_wins']}/{wr['n_total']} "
+                    f"→ inferred {inferred_wins}/{inferred_games} (expected {expected_wins}, diff={diff})"
+                )
 
             # Overall reconciliation (proportional)
-            total_inferred_wins = sum(
-                o["won"] for o in session_outcomes.values()
-            )
+            total_inferred_wins = sum(o["won"] for o in session_outcomes.values())
             total_inferred_games = len(log_games)
-            total_expected_wins = round(
-                total_logged_wins / total_logged_games * total_inferred_games
-            ) if total_logged_games > 0 else 0
+            total_expected_wins = (
+                round(total_logged_wins / total_logged_games * total_inferred_games)
+                if total_logged_games > 0
+                else 0
+            )
             diff = abs(total_inferred_wins - total_expected_wins)
             mark = "✅" if diff <= 2 else "⚠️"
             print(f"\n    RECONCILIATION ({mark}):")

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -296,9 +296,7 @@ def stage_leak_scan(
     re_menu_line = re.compile(r"^\s*\d+\.\s", re.MULTILINE)
 
     def _strip_menu_lines(text: str) -> str:
-        return "\n".join(
-            "" if re_menu_line.match(line) else line for line in text.splitlines()
-        )
+        return "\n".join("" if re_menu_line.match(line) else line for line in text.splitlines())
 
     for split_name, records in rendered.items():
         for i, rec in enumerate(records):

--- a/tools/training/split_combat_gate.py
+++ b/tools/training/split_combat_gate.py
@@ -551,6 +551,7 @@ def main() -> int:
     print("[4/4] manifest ...", flush=True)
     dists = {s: distributions(rows) for s, rows in by_split.items()}
     dists["source_all"] = distributions(index)
+
     def _slice_n(split: str, label: str) -> int:
         return dists[split]["answer_class"].get(label, {}).get("n", 0)
 

--- a/tools/training/taxonomy/build_taxonomy.py
+++ b/tools/training/taxonomy/build_taxonomy.py
@@ -201,8 +201,9 @@ ROLE_MAP = {
         # Give hexproof/indestructible/ward via pump
         {
             "primitive": "Pump",
-            "check": lambda p: any(kw in p.get("KW", "")
-                                   for kw in ("Hexproof", "Indestructible", "Ward", "Protection")),
+            "check": lambda p: any(
+                kw in p.get("KW", "") for kw in ("Hexproof", "Indestructible", "Ward", "Protection")
+            ),
         },
     ],
 }
@@ -224,16 +225,16 @@ def parse_card_script(text):
     """
     result = {
         "name": "",
-        "all_names": [],   # all Name: lines (for DFC lookup)
+        "all_names": [],  # all Name: lines (for DFC lookup)
         "mana_cost": "",
         "types": "",
-        "power": "",       # Power from PT: line (may be "*" for CDA)
-        "toughness": "",   # Toughness from PT: line
-        "keywords": [],    # Keywords from K: lines on front face
+        "power": "",  # Power from PT: line (may be "*" for CDA)
+        "toughness": "",  # Toughness from PT: line
+        "keywords": [],  # Keywords from K: lines on front face
         "primitives": [],  # list of {"primitive": str, "sp_ab": str, **params}
-        "svars": {},       # SVar definitions for sub-ability traversal
+        "svars": {},  # SVar definitions for sub-ability traversal
         "trigger_svars": [],  # SVar names referenced by T: line Execute$ fields
-        "static_lines": [],   # S: line dicts for static ability classification
+        "static_lines": [],  # S: line dicts for static ability classification
         "_alternate": False,  # internal: have we hit the ALTERNATE marker?
     }
 
@@ -248,7 +249,7 @@ def parse_card_script(text):
 
         # Name (collect ALL Name lines for DFC support)
         elif line.startswith("Name:"):
-            name_val = line[len("Name:"):].strip()
+            name_val = line[len("Name:") :].strip()
             result["all_names"].append(name_val)
             if not result["name"]:
                 result["name"] = name_val
@@ -293,11 +294,13 @@ def parse_card_script(text):
             if t_info and t_info.get("execute_svar") and not result["_alternate"]:
                 result["trigger_svars"].append(t_info["execute_svar"])
             if t_info and t_info.get("mode") and not result["_alternate"]:
-                result["static_lines"].append({
-                    "mode": "TRIGGER",
-                    "trigger_mode": t_info["mode"],
-                    "original": t_info,
-                })
+                result["static_lines"].append(
+                    {
+                        "mode": "TRIGGER",
+                        "trigger_mode": t_info["mode"],
+                        "original": t_info,
+                    }
+                )
 
         # S: lines — static/continuous ability definitions
         elif line.startswith("S:") and "Mode$" in line:
@@ -493,22 +496,26 @@ def resolve_primitives(card):
             # Lord pump effects: S:Mode$ Continuous | Affected$ ... | AddPower$ ...
             # This is functionally similar to PumpAll
             if s_info.get("add_power") or s_info.get("add_toughness") or s_info.get("add_keyword"):
-                all_primitives.append({
-                    "sp_ab": "ST",
-                    "primitive": "PumpAll",
-                    "affected": s_info.get("affected", ""),
-                    "is_present": s_info.get("is_present", ""),
-                    "_source": "static",
-                })
+                all_primitives.append(
+                    {
+                        "sp_ab": "ST",
+                        "primitive": "PumpAll",
+                        "affected": s_info.get("affected", ""),
+                        "is_present": s_info.get("is_present", ""),
+                        "_source": "static",
+                    }
+                )
         elif s_info.get("mode") == "RaiseCost":
             # Tax effects: S:Mode$ RaiseCost | ValidCard$ ... | Amount$ ...
-            all_primitives.append({
-                "sp_ab": "ST",
-                "primitive": "RaiseCost",
-                "valid_card": s_info.get("raised_cards", ""),
-                "amount": s_info.get("amount", ""),
-                "_source": "static",
-            })
+            all_primitives.append(
+                {
+                    "sp_ab": "ST",
+                    "primitive": "RaiseCost",
+                    "valid_card": s_info.get("raised_cards", ""),
+                    "amount": s_info.get("amount", ""),
+                    "_source": "static",
+                }
+            )
         elif s_info.get("mode") == "TRIGGER":
             # Some T: lines that don't reference SVars may still grant ability
             add_trigger = s_info.get("original", {}).get("add_trigger", "")

--- a/tools/training/wp3/PROGRESS-wp3-hand-attribution.md
+++ b/tools/training/wp3/PROGRESS-wp3-hand-attribution.md
@@ -1,0 +1,119 @@
+# PROGRESS — wp3-hand-attribution
+
+Remove the LAST positional assumption in `tools/training/parse_magezero_log.py`:
+hand sourcing. Hands previously came from positional `-> Hand:` block lines
+(attributed by header adjacency — the #452 board-swap defect family, plus a
+finalize-time "latest hand seen" guess). They now come ONLY from
+name-attributed `ComputerPlayer.logList` lines:
+
+    [1:Beginning:UPKEEP]PlayerA hand: : Island,Soul Partition, =>[pool-3-thread-4] ComputerPlayer.logList
+
+keyed by player NAME + THREAD + TURN (the line carries turn and phase itself;
+`named_hands` is reset at every die-roll game boundary). A row whose
+(thread-game, turn) has no such line is DROPPED and counted — never guessed,
+never emitted with a fabricated empty hand (an empty hand in a prompt is an
+observation, "you hold nothing"). An empty logList line (624 of 9,063 on the
+smoke log) IS a valid attribution: the hand really is empty at that upkeep.
+
+## What changed
+
+- `parse_magezero_log.py`:
+  - `RE_NAMED_HAND` + `parse_named_hand_cards` (separator commas carry no
+    trailing space; in-name commas — "Kitsa, Otterball Elite" — do; verified
+    against magezero_card_map.json: 0 of 510 names contain `,<non-space>`).
+  - `_ThreadState.named_hands: dict[turn -> cards]`, reset per game.
+  - Rows are appended to the output list at `_finalize_game` (not at
+    creation), so an unattributable-hand row is really dropped, and counted
+    (`hand_dropped_unattributed` in `LAST_PARSE_STATS` / `--report`).
+  - Lines naming any player other than PlayerA are ignored (hidden
+    information, leak class L4). The smoke log contains 0 such hand lines,
+    but the gate is by name, not by assumption.
+  - The old positional flow survives ONLY as an internal `_hand_positional`
+    shadow (stripped on write) so `--report` can print the
+    positional-vs-named disagreement rate.
+- `tests/test_parse_magezero_log.py`: fixtures gained named hand lines;
+  new `TestNamedHandAttribution` (8 tests: regex, comma names, empty hand,
+  fail-closed drop + count, PlayerB ignore, game-boundary reset, recovered
+  pass rows, underscore hygiene) and `TestHandDeckSignature` (2 fixture
+  guardrails + a real-smoke-log guardrail gated on `MZ_SMOKE_LOG`).
+
+## Measured numbers (mz_train_smoke.log, 210MB, 594 games)
+
+Named-source inventory: 9,063 `hand: :` lines, ALL `[N:Beginning:UPKEEP]PlayerA`
+(0 other phases, 0 other players); 624 with an empty list.
+
+Parser rows:
+- before: 21,609 emitted (18,644 with non-empty hand, 2,965 empty)
+- after:  21,557 emitted with attributed hands + 52 dropped fail-closed (0.24%)
+- decision_kind histogram before: priority 20,182 / binary 1,424 / blockers 3
+- decision_kind histogram after:  priority 20,130 / binary 1,424 / blockers 3
+  (all 52 drops were priority rows)
+
+Deck-signature guardrail (hand must be a subset of the 17 UWTempo names):
+- violations BEFORE: 5,422 rows (of 18,644 non-empty-hand rows, 29.1%) carried
+  non-deck entries — every one of them `:N` score-suffix pollution
+  ("Negate:5") from GameStateEvaluator2 block hands backfilled positionally.
+  After stripping `:N` for the check, off-DECK names before: 0 — the existing
+  PlayerB-block skip already stopped true off-color leaks; the residual
+  positional damage was format pollution + temporal misattribution.
+- violations AFTER: 0 rows (no normalization applied).
+  `MZ_SMOKE_LOG=... pytest tests/test_parse_magezero_log.py::TestHandDeckSignature`
+  = 3 passed (includes the full-log scan).
+
+Reconciliation old-vs-new (rows where the old source produced a hand; old
+side normalized by stripping `:N` so only CONTENT differences count):
+- rows with both sources: 18,592; differing: 15,770 → mismatch rate 84.8%
+- direction: 9,444 mixed / 4,691 named-superset / 1,635 positional-superset
+- 10 sampled diffs verified against raw log context (thread + game seq +
+  turn): in 10/10 the new hand matched the game's raw
+  `[N:Beginning:UPKEEP]PlayerA hand:` line EXACTLY — attribution correct.
+  In at least 4/10 (incl. an UPKEEP "Cast Bounce Off" row whose positional
+  hand lacked Bounce Off, and a turn-3 row whose positional hand contained
+  two Skrelvs impossible from that turn's card flow) the positional hand was
+  demonstrably wrong or post-decision. In the remainder the positional hand
+  was the fresher intra-turn snapshot — the named hand is the turn's UPKEEP
+  snapshot (see caveat below).
+- coherence check, chosen `Cast/Play X` with X present in hand:
+  before 1,075/7,649 = 14.1%; after 5,247/7,649 = 68.6%. The old source was
+  usually a POST-action hand (printBattlefieldScore prints after execution);
+  the new one is pre-action for upkeep decisions and turn-start for the rest.
+- VERDICT: the named source is the correct attribution in every verified
+  sample and far more decision-time-coherent; the 84.8% row-level mismatch is
+  dominated by the old source being post-action/misattributed, not by upkeep
+  staleness.
+
+run_wp3_pipeline.py (--balance downsample-pass; default run trips the 40%
+pass tripwire at 43.8% on both before and after):
+- before: 21,609 decisions → 5,835 filtered → 4,660 records
+  (train 4,061 / val 282 / test 317), pass rate 40.0%, leak scan 0
+- after:  21,557 decisions → 5,848 filtered → 4,649 records
+  (train 4,092 / val 265 / test 292), pass rate 40.0%, leak scan 0
+- net −11 records (−0.24%): no silent collapse. Split-level shifts are
+  dedupe-key churn (hand is part of the dedupe key).
+- 3 rendered train records eyeballed against the raw log: hands are
+  UWTempo-only, no `:N` suffixes, consistent with their game's upkeep lines.
+
+Tests:
+- tests/test_parse_magezero_log.py: 61 passed, 1 skipped (the smoke-log test
+  without MZ_SMOKE_LOG); with MZ_SMOKE_LOG the guardrail class is 3 passed.
+- Related files (magezero_filters/bridge_leaks/combat/run_wp3_pipeline/
+  card_map/deck_inventory/corpus_selfcheck): 134 passed, 2 skipped.
+- Full `pytest tests` under venv-train + PYTHONPATH=src: 1,405 passed,
+  5 failed, 29 skipped — the 5 failures (dynamic_cards, proxy_thinking,
+  server_bridge_overlay, settings_scryfall) are missing-dependency issues in
+  app modules (e.g. `No module named 'PIL'`) and reproduce with this branch's
+  changes stashed; not touched by this diff.
+
+## Known caveat / could not verify
+
+- The named hand is captured at the turn's UPKEEP, before the draw step: rows
+  later in the turn can show a hand missing cards drawn or still holding
+  cards already played that turn (31.4% of Cast/Play rows still lack the
+  chosen card in `hand`; the rendered menu's [OK] tags carry the truth about
+  castability). Reconstructing intra-turn hands from the upkeep snapshot plus
+  the turn's chose-action deltas would be a derivation (not a guess) and is a
+  possible follow-up; it was NOT done here.
+- Whether XMage can emit `hand: :` lines in other phases or for other player
+  names in other configurations was not verifiable from this log (this log
+  has only UPKEEP/PlayerA); the parser keys by the turn on the line and gates
+  by name, so either case is handled or safely ignored.

--- a/tools/training/wp3/baseline_plan.py
+++ b/tools/training/wp3/baseline_plan.py
@@ -26,8 +26,8 @@ References
 import math
 
 # ── standard normal quantiles ─────────────────────────────────
-Z_ALPHA_2 = 1.959964   # α = 0.05, two-sided
-Z_BETA = 0.841621       # β = 0.20 (power = 0.80)
+Z_ALPHA_2 = 1.959964  # α = 0.05, two-sided
+Z_BETA = 0.841621  # β = 0.20 (power = 0.80)
 
 
 def mde(p_baseline: float, n_baseline: int, n_net: int) -> float:
@@ -57,10 +57,9 @@ def mde(p_baseline: float, n_baseline: int, n_net: int) -> float:
     return (Z_ALPHA_2 + Z_BETA) * se * 100  # convert to pp
 
 
-def baseline_games_needed(p_baseline: float, n_net: int,
-                          target_mde_pp: float,
-                          min_games: int = 10,
-                          max_games: int = 50_000) -> int:
+def baseline_games_needed(
+    p_baseline: float, n_net: int, target_mde_pp: float, min_games: int = 10, max_games: int = 50_000
+) -> int:
     """Binary-search for the smallest n_baseline meeting target MDE.
 
     Parameters
@@ -119,10 +118,11 @@ def main():
     print("=" * 72)
     print()
     print("  Current observations")
-    print(f"    No-net (baseline): {cur['baseline_wins']}/{cur['baseline_games']}"
-          f"  = {p_bl:.4f}  ({p_bl*100:.2f}%)")
-    print(f"    Net-guided:        {cur['net_wins']}/{cur['net_games']}"
-          f"  = {p_net:.4f}  ({p_net*100:.2f}%)")
+    print(
+        f"    No-net (baseline): {cur['baseline_wins']}/{cur['baseline_games']}"
+        f"  = {p_bl:.4f}  ({p_bl * 100:.2f}%)"
+    )
+    print(f"    Net-guided:        {cur['net_wins']}/{cur['net_games']}  = {p_net:.4f}  ({p_net * 100:.2f}%)")
     print(f"    Observed gap:      {(p_net - p_bl) * 100:.2f} pp")
     print()
 
@@ -159,18 +159,24 @@ def main():
     for target in [3, 4, 5]:
         needed = baseline_games_needed(p_bl, n_net, target)
         if needed > 0:
-            print(f"     Target {target} pp  →  n_baseline ≥ {needed:,}  "
-                  f"(+{needed - n_bl:,} from current {n_bl})")
+            print(
+                f"     Target {target} pp  →  n_baseline ≥ {needed:,}  "
+                f"(+{needed - n_bl:,} from current {n_bl})"
+            )
         else:
             print(f"     Target {target} pp  →  impossible within 50,000 games")
     print()
 
     # ── Single-gen cost estimate ──────────────────────────────
     print("  ── Cost: single-generation config")
-    print("     games_per_gen: 1000  →  ~1,000 baseline games"
-          f"  (MDE ≈ {mde(p_bl, 1000, n_net):.2f} pp, net arm at current 1299)")
-    print("     games_per_gen: 1000  →  ~1,000 baseline games"
-          f"  (MDE ≈ {mde(p_bl, 1000, 1000):.2f} pp, symmetric n_net=1000)")
+    print(
+        "     games_per_gen: 1000  →  ~1,000 baseline games"
+        f"  (MDE ≈ {mde(p_bl, 1000, n_net):.2f} pp, net arm at current 1299)"
+    )
+    print(
+        "     games_per_gen: 1000  →  ~1,000 baseline games"
+        f"  (MDE ≈ {mde(p_bl, 1000, 1000):.2f} pp, symmetric n_net=1000)"
+    )
     print()
 
     # ── Key takeaway ──────────────────────────────────────────

--- a/tools/training/wp3/deck_inventory.py
+++ b/tools/training/wp3/deck_inventory.py
@@ -46,7 +46,11 @@ SKIP_PREFIXES = ("LAYOUT", "NAME:", "#")
 
 # Mana-symbol-to-colour map (for colour extraction from mana_cost)
 MANA_COLOUR_MAP = {
-    "W": "W", "U": "U", "B": "B", "R": "R", "G": "G",
+    "W": "W",
+    "U": "U",
+    "B": "B",
+    "R": "R",
+    "G": "G",
 }
 
 # Basic lands from type_line
@@ -61,6 +65,7 @@ BASIC_LAND_COLOURS = {
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def parse_deck(filepath: str) -> dict:
     """Parse a .dck file, returning structured card data.
@@ -89,27 +94,31 @@ def parse_deck(filepath: str) -> dict:
             # Try sideboard line first (it starts with SB:)
             m = SB_RE.match(raw)
             if m:
-                cards.append({
-                    "count": int(m.group(1)),
-                    "set": m.group(2),
-                    "num": m.group(3),
-                    "star": bool(m.group(4)),
-                    "name": m.group(5).strip(),
-                    "sideboard": True,
-                })
+                cards.append(
+                    {
+                        "count": int(m.group(1)),
+                        "set": m.group(2),
+                        "num": m.group(3),
+                        "star": bool(m.group(4)),
+                        "name": m.group(5).strip(),
+                        "sideboard": True,
+                    }
+                )
                 continue
 
             # Try normal card line
             m = CARD_RE.match(raw)
             if m:
-                cards.append({
-                    "count": int(m.group(1)),
-                    "set": m.group(2).strip(),
-                    "num": m.group(3).strip(),
-                    "star": bool(m.group(4)),
-                    "name": m.group(5).strip(),
-                    "sideboard": False,
-                })
+                cards.append(
+                    {
+                        "count": int(m.group(1)),
+                        "set": m.group(2).strip(),
+                        "num": m.group(3).strip(),
+                        "star": bool(m.group(4)),
+                        "name": m.group(5).strip(),
+                        "sideboard": False,
+                    }
+                )
                 continue
 
             # If we get here, it's an unrecognized line — skip silently
@@ -234,15 +243,14 @@ def compute_overlap(deck1_cards: list, deck2_cards: list) -> dict:
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     # Load card map
     card_map = load_card_map()
     print(f"Loaded card map: {len(card_map)} entries")
 
     # Find all .dck files
-    deck_files = sorted([
-        f for f in os.listdir(DECK_DIR) if f.endswith(".dck")
-    ])
+    deck_files = sorted([f for f in os.listdir(DECK_DIR) if f.endswith(".dck")])
     print(f"Found {len(deck_files)} deck files")
 
     # Parse all decks
@@ -325,11 +333,17 @@ def main():
     md_lines.append(f"**Primary deck**: `{primary_name}`  ")
     md_lines.append(f"**Total distinct cards (union)**: {len(union_all)}  ")
     md_lines.append(f"**Expected**: {EXPECTED_UNION}  ")
-    md_lines.append(f"**Reconciliation**: {'✓ matches' if len(union_all) == EXPECTED_UNION else f'Δ {len(union_all) - EXPECTED_UNION:+d}'}\n")
+    md_lines.append(
+        f"**Reconciliation**: {'✓ matches' if len(union_all) == EXPECTED_UNION else f'Δ {len(union_all) - EXPECTED_UNION:+d}'}\n"
+    )
 
     md_lines.append("## Per-Deck Summary\n")
-    md_lines.append("| Deck | Distinct Cards | Total Cards | Main | SB | Colours | New vs Primary | Overlap% | Unknown Colours |")
-    md_lines.append("|------|---------------|-------------|------|----|---------|---------------|----------|----------------|")
+    md_lines.append(
+        "| Deck | Distinct Cards | Total Cards | Main | SB | Colours | New vs Primary | Overlap% | Unknown Colours |"
+    )
+    md_lines.append(
+        "|------|---------------|-------------|------|----|---------|---------------|----------|----------------|"
+    )
 
     rows = []
     for dname, stats in stats_by_deck.items():
@@ -342,17 +356,19 @@ def main():
             ov = overlaps.get(dname, {})
             new_str = str(ov.get("deck2_only", "?"))
             ovpct_str = f"{ov.get('overlap_pct', 0):.1f}%"
-        rows.append((
-            dname,
-            stats["distinct_total"],
-            stats["total_cards"],
-            stats["main_total"],
-            stats["sb_total"],
-            stats["colours"],
-            new_str,
-            ovpct_str,
-            unknown_str,
-        ))
+        rows.append(
+            (
+                dname,
+                stats["distinct_total"],
+                stats["total_cards"],
+                stats["main_total"],
+                stats["sb_total"],
+                stats["colours"],
+                new_str,
+                ovpct_str,
+                unknown_str,
+            )
+        )
         # Print unknown cards for diagnosis
         if unknown_count:
             uc = stats["unknown_colour_cards"]
@@ -364,7 +380,13 @@ def main():
 
     # Current opponents section
     md_lines.append("\n## Current Opponents (in `configs/run.yml`)\n")
-    current_opponents = ["Standard-MonoR", "Standard-MonoG", "Standard-MonoB", "Standard-MonoW", "Standard-MonoU"]
+    current_opponents = [
+        "Standard-MonoR",
+        "Standard-MonoG",
+        "Standard-MonoB",
+        "Standard-MonoW",
+        "Standard-MonoU",
+    ]
     md_lines.append("| Deck | Distinct Cards | Colours | New vs Primary |")
     md_lines.append("|------|---------------|---------|---------------|")
     cur_distinct = set()
@@ -373,7 +395,9 @@ def main():
         if not stats:
             continue
         ov = overlaps.get(dname, {})
-        md_lines.append(f"| {dname} | {stats['distinct_total']} | {stats['colours']} | {ov.get('deck2_only', '?')} |")
+        md_lines.append(
+            f"| {dname} | {stats['distinct_total']} | {stats['colours']} | {ov.get('deck2_only', '?')} |"
+        )
         for c in all_decks[dname]["cards"]:
             cur_distinct.add(c["name"])
 
@@ -423,7 +447,9 @@ def main():
         md_lines.append("- Some cards counted here are not in the 471 (e.g., basic lands counted per-set)  ")
         md_lines.append("- The 471 may exclude certain cards (sideboard-only, etc.)  ")
     else:
-        md_lines.append(f"Union is **{diff} cards lower** than expected ({len(union_all)} vs {EXPECTED_UNION}).  ")
+        md_lines.append(
+            f"Union is **{diff} cards lower** than expected ({len(union_all)} vs {EXPECTED_UNION}).  "
+        )
 
     with open(OUTPUT_MD, "w") as f:
         f.write("\n".join(md_lines) + "\n")
@@ -432,9 +458,9 @@ def main():
     # -----------------------------------------------------------------------
     # Summary to stdout
     # -----------------------------------------------------------------------
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("DECK INVENTORY SUMMARY")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"  Decks parsed:     {len(all_decks)}")
     print(f"  Union (distinct): {len(union_all)}")
     print(f"  Expected:         {EXPECTED_UNION}")

--- a/tools/training/wp3/resolve_cards.py
+++ b/tools/training/wp3/resolve_cards.py
@@ -13,8 +13,12 @@ import urllib.request
 
 DECK_DIR = "/home/joshu/repos/magezero/xmage/decks"
 DECK_FILES = [
-    "UWTempo.dck", "Standard-MonoR.dck", "Standard-MonoG.dck",
-    "Standard-MonoB.dck", "Standard-MonoW.dck", "Standard-MonoU.dck",
+    "UWTempo.dck",
+    "Standard-MonoR.dck",
+    "Standard-MonoG.dck",
+    "Standard-MonoB.dck",
+    "Standard-MonoW.dck",
+    "Standard-MonoU.dck",
 ]
 CACHE_PATH = "tools/training/wp3/scryfall_cache.json"
 OUTPUT_PATH = "tools/training/magezero_card_map.json"
@@ -130,8 +134,7 @@ def resolve_card(name, cache):
 def main():
     names, layout_only = extract_card_names()
     print(f"Card names from lines: {len(names)}")
-    print(f"Layout-only refs: {len(layout_only)} items: "
-          f"{[f'{s}:{n}' for s, n in sorted(layout_only)]}")
+    print(f"Layout-only refs: {len(layout_only)} items: {[f'{s}:{n}' for s, n in sorted(layout_only)]}")
 
     cache = load_cache()
     card_map = {}


### PR DESCRIPTION
## What

Removes the last positional assumption in `tools/training/parse_magezero_log.py`: hand sourcing. Hands now come ONLY from name-attributed `ComputerPlayer.logList` lines (`[N:Beginning:UPKEEP]PlayerA hand: : ...`), keyed by player name + thread + turn, reset at every die-roll game boundary. A row whose (thread-game, turn) has no such line is DROPPED and counted — never guessed, never emitted with a fabricated empty hand. The old positional `-> Hand:` flow survives only as an internal `_hand_positional` shadow used by `--report` reconciliation (stripped on write).

## Measured (mz_train_smoke.log, 210MB, 594 games)

Named source: 9,063 `hand: :` lines, all `[N:Beginning:UPKEEP]PlayerA`; 624 legitimately empty.

Parser rows: 21,609 before -> 21,557 after + 52 dropped fail-closed (0.24%).
Kind histogram before: priority 20,182 / binary 1,424 / blockers 3; after: priority 20,130 / binary 1,424 / blockers 3.

Deck-signature guardrail (hand must be a subset of the 17 UWTempo names):
- BEFORE: 5,422 of 18,644 non-empty-hand rows (29.1%) violated — all `:N` score-suffix pollution from evaluator-block hands backfilled positionally (off-DECK names after normalization: 0; the PlayerB skip already blocked true off-color leaks).
- AFTER: 0 rows. Real-log test: `MZ_SMOKE_LOG=... pytest tests/test_parse_magezero_log.py::TestHandDeckSignature` = 3 passed.

Reconciliation old-vs-new (old side `:N`-normalized): 15,770 of 18,592 rows differ = 84.8% mismatch rate. 10 sampled diffs verified against raw log: 10/10 new hands match the game's raw upkeep line exactly; in at least 4/10 the positional hand was demonstrably wrong or post-decision (e.g. missing the very card being cast). Coherence (chosen `Cast/Play X` with X in hand): 14.1% before -> 68.6% after.

Pipeline (`run_wp3_pipeline.py --balance downsample-pass`):
- before: 21,609 decisions -> 4,660 records (4,061/282/317), pass rate 40.0%, leak scan 0
- after: 21,557 decisions -> 4,649 records (4,092/265/292), pass rate 40.0%, leak scan 0
- net -11 records (-0.24%): no silent collapse. 3 rendered records eyeballed against the raw log.

Tests: test_parse_magezero_log.py 61 passed / 1 skipped (env-gated smoke test); related magezero/wp3 files 134 passed. Full suite under venv-train: 1,405 passed, 5 failed — the 5 are missing-dependency failures in app modules (`No module named 'PIL'` etc.) that reproduce with this branch's changes stashed.

## Known caveat

The named hand is the turn's UPKEEP snapshot (pre-draw): 31.4% of Cast/Play rows still lack the chosen card in `hand` (drawn/changed later in the turn). Reconstructing intra-turn hands from the snapshot plus chose-action deltas would be a derivation, not a guess — possible follow-up, not done here.