### PR TITLE
WP-3: MageZero combat micro-decision adapter (3,213 attack + 788 block from real emitters, fail-closed)

### DIFF
--- a/tests/test_magezero_combat_micro.py
+++ b/tests/test_magezero_combat_micro.py
@@ -1,0 +1,476 @@
+"""Tests for the MageZero combat micro-decision adapter.
+
+Two fixture families:
+
+1. ``fixture_combat_interleaved.log`` — a REAL, unmodified excerpt of
+   mz_train_smoke.log (global lines 2270-2530) in which all six XMage threads
+   interleave. It contains exactly one attack micro-decision (thread-1,
+   Skrelv, Defector Mite, MCTS pool [false 104 / true 867]) and one block
+   micro-decision (thread-5, Malcolm declining to block Razorkin Needlehead /
+   Emberheart Challenger), plus a spell-targeting 'Targeting' line (thread-6)
+   that must NOT be mistaken for a block, plus priority pools on other
+   threads that must not cross-pair. Expected values below were read off the
+   raw log by hand.
+
+2. Synthetic orphan fixtures proving the scanner fails closed: unpaired
+   resolutions, missing openers, missing board context, cross-game context
+   and cross-thread interference each produce a counted drop, never a record.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+for p in (str(REPO / "src"), str(REPO)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from tools.training import magezero_combat_micro as C  # noqa: E402
+
+FIXTURE = REPO / "tools" / "training" / "wp3" / "fixtures" / "fixture_combat_interleaved.log"
+
+EM = "ComputerPlayerMCTS.printBattlefieldScore"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-line helpers (shape byte-compatible with the real log)
+# ---------------------------------------------------------------------------
+
+
+def L(text: str, thread: int, method: str) -> str:
+    return (
+        f"INFO  2026-07-28 21:34:00,000 {text}"
+        f"  =>[pool-3-thread-{thread}] {method} \n"
+    )
+
+
+def bf_block(thread: int, hand: str, self_perms: str, opp_perms: str) -> list[str]:
+    return [
+        L("[PlayerA], life = 20", thread, EM),
+        L(f"-> Hand: [{hand}]", thread, EM),
+        L(f"-> Permanents: [{self_perms}]", thread, EM),
+        L(f"-> Permanents: [{opp_perms}]", thread, EM),
+    ]
+
+
+def attack_seq(thread: int, name: str, verdict: str) -> list[str]:
+    return [
+        L(f"base choose use attack with: {name}?", thread, "ComputerPlayerMCTS.chooseUse"),
+        L(
+            "DECLARE_ATTACKERS0pool= actions: [false score: 0.013 count: 104] "
+            "[true score: 0.147 count: 867]",
+            thread,
+            "MCTSNode.bestChild",
+        ),
+        L(f"use attack with: {name}?: {verdict}", thread, "ComputerPlayerMCTS.chooseUse"),
+    ]
+
+
+def scan(tmp_path: Path, lines: list[str]):
+    p = tmp_path / "synthetic.log"
+    p.write_text("".join(lines), encoding="utf-8")
+    rows, acct = C.parse_combat_log(str(p))
+    C.verify_accounting(acct)
+    return rows, acct
+
+
+# ---------------------------------------------------------------------------
+# 1. Real interleaved excerpt
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def real():
+    rows, acct = C.parse_combat_log(str(FIXTURE))
+    C.verify_accounting(acct)
+    return rows, acct
+
+
+def test_real_fixture_yield(real):
+    rows, acct = real
+    assert len(rows) == 2
+    kinds = sorted(r["decision_kind"] for r in rows)
+    assert kinds == ["attack_commit", "block_assign"]
+
+
+def test_real_attack_record_matches_raw_log(real):
+    rows, _ = real
+    (atk,) = [r for r in rows if r["decision_kind"] == "attack_commit"]
+    assert atk["_thread"] == "pool-3-thread-1"
+    assert atk["creature"] == "Skrelv, Defector Mite"
+    assert atk["attack_committed"] is True
+    assert atk["chosen"] == "Attack with Skrelv, Defector Mite"
+    assert atk["mcts_counts"] == {"false": 104, "true": 867}
+    assert atk["mcts_scores"] == {"false": 0.013, "true": 0.147}
+    # Board owner check (#452's board-swap class): thread-1's OWN board holds
+    # Skrelv + Seachrome Coast + Island; the OPPONENT board is two Mountains.
+    self_names = [e["name"] for e in atk["battlefield_self"]]
+    opp_names = [e["name"] for e in atk["battlefield_opp"]]
+    assert self_names == ["Seachrome Coast", "Skrelv, Defector Mite", "Island"]
+    assert opp_names == ["Mountain", "Mountain"]
+    assert atk["provenance"]["creature_on_board"] is True
+    assert atk["hand"] == [
+        "Negate", "Soul Partition", "Skrelv, Defector Mite", "Meticulous Archive",
+    ]
+    assert atk["turn"] == 4
+    assert atk["active_life"] == 20 and atk["opp_life"] == 20
+    # provenance line numbers, checked against the fixture file itself
+    prov = atk["provenance"]
+    lines = FIXTURE.read_text(encoding="utf-8").splitlines()
+    assert "use attack with: Skrelv, Defector Mite?: true" in lines[prov["line_resolution"] - 1]
+    assert "DECLARE_ATTACKERS0pool=" in lines[prov["line_pool"] - 1]
+    assert "base choose use attack with" in lines[prov["line_opener"] - 1]
+    assert C.EMITTER_MCTS in lines[prov["line_context"] - 1]
+
+
+def test_real_block_record_matches_raw_log(real):
+    rows, _ = real
+    (blk,) = [r for r in rows if r["decision_kind"] == "block_assign"]
+    assert blk["_thread"] == "pool-3-thread-5"
+    assert blk["creature"] == "Malcolm, Alluring Scoundrel"
+    assert blk["blocked_attacker"] is None  # Targeting Stop Choosing
+    assert blk["candidates"] == ["Razorkin Needlehead", "Emberheart Challenger"]
+    assert blk["chosen"] == "Do not block with Malcolm, Alluring Scoundrel"
+    assert blk["mcts_counts"] == {
+        "Stop Choosing": 498, "Razorkin Needlehead": 35, "Emberheart Challenger": 189,
+    }
+    assert blk["possible_targets"] == 2
+    assert blk["possible_targets_matches_pool"] is True
+    # Board ownership: PlayerA (UW) holds Islands; PlayerB (mono-R) the
+    # Mountains + Razorkin. A swap here is exactly the #452 defect class.
+    assert [e["name"] for e in blk["battlefield_self"]] == ["Island", "Island"]
+    assert [e["name"] for e in blk["battlefield_opp"]] == [
+        "Mountain", "Mountain", "Razorkin Needlehead",
+    ]
+    assert blk["turn"] == 5
+    assert blk["active_life"] == 17 and blk["opp_life"] == 20
+
+
+def test_real_fixture_spell_targeting_not_a_block(real):
+    _, acct = real
+    # thread-6's 'Targeting Sleep-Cursed Faerie' has no block opener: ignored.
+    assert acct["seen_targeting_nonblock"] == 1
+    assert acct["seen_targeting_block_gated"] == 1
+
+
+def test_real_fixture_no_cross_thread_pairing(real):
+    _, acct = real
+    # Other threads run priority pools between thread-1's pool and its
+    # resolution; none of them may be consumed by the combat pairing.
+    assert acct["seen_pools_noncombat"] > 0
+    assert acct["emitted_attack"] == 1
+    assert acct["emitted_block"] == 1
+    assert acct.get("drop_attack_resolution_without_pool", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Synthetic fail-closed fixtures
+# ---------------------------------------------------------------------------
+
+CTX1 = bf_block(1, "Negate", "Island; Grizzly Bears", "Mountain")
+
+
+def test_orphan_resolution_without_pool_drops(tmp_path):
+    lines = CTX1 + [
+        L("base choose use attack with: Grizzly Bears?", 1, "ComputerPlayerMCTS.chooseUse"),
+        L("use attack with: Grizzly Bears?: true", 1, "ComputerPlayerMCTS.chooseUse"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["drop_attack_resolution_without_pool"] == 1
+
+
+def test_opener_name_mismatch_drops(tmp_path):
+    lines = CTX1 + [
+        L("base choose use attack with: Other Creature?", 1, "ComputerPlayerMCTS.chooseUse"),
+        L(
+            "DECLARE_ATTACKERS0pool= actions: [false score: 0.1 count: 10] "
+            "[true score: 0.2 count: 20]",
+            1,
+            "MCTSNode.bestChild",
+        ),
+        L("use attack with: Grizzly Bears?: true", 1, "ComputerPlayerMCTS.chooseUse"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["drop_attack_opener_name_mismatch"] == 1
+
+
+def test_attack_without_board_context_drops(tmp_path):
+    rows, acct = scan(tmp_path, attack_seq(1, "Grizzly Bears", "true"))
+    assert rows == []
+    assert acct["drop_attack_no_board_context"] == 1
+
+
+def test_context_from_previous_game_drops(tmp_path):
+    lines = (
+        CTX1
+        + [L("Player A won the die roll", 1, "ParallelDataGenerator.runSingleGame")]
+        + attack_seq(1, "Grizzly Bears", "true")
+    )
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    # die roll resets the thread's context entirely
+    assert acct["drop_attack_no_board_context"] == 1
+
+
+def test_cross_thread_pool_is_never_paired(tmp_path):
+    # pool arrives on thread 2; resolution on thread 1 must NOT consume it.
+    lines = CTX1 + [
+        L("base choose use attack with: Grizzly Bears?", 1, "ComputerPlayerMCTS.chooseUse"),
+        L(
+            "DECLARE_ATTACKERS0pool= actions: [false score: 0.1 count: 10] "
+            "[true score: 0.2 count: 20]",
+            2,
+            "MCTSNode.bestChild",
+        ),
+        L("use attack with: Grizzly Bears?: true", 1, "ComputerPlayerMCTS.chooseUse"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["drop_attack_resolution_without_pool"] == 1
+
+
+def test_intervening_priority_decision_invalidates_pool(tmp_path):
+    lines = CTX1 + [
+        L("base choose use attack with: Grizzly Bears?", 1, "ComputerPlayerMCTS.chooseUse"),
+        L(
+            "DECLARE_ATTACKERS0pool= actions: [false score: 0.1 count: 10] "
+            "[true score: 0.2 count: 20]",
+            1,
+            "MCTSNode.bestChild",
+        ),
+        L(
+            "[4:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Negate success ratio: 0.5",
+            1,
+            "ComputerPlayerMCTS.priority",
+        ),
+        L("use attack with: Grizzly Bears?: true", 1, "ComputerPlayerMCTS.chooseUse"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["pool_attack_abandoned_at_priority_decision"] == 1
+    assert acct["drop_attack_resolution_without_pool"] == 1
+
+
+def test_targeting_without_block_opener_is_spell_targeting(tmp_path):
+    lines = CTX1 + [L("Targeting Grizzly Bears", 1, "ComputerPlayerMCTS.makeChoice")]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["seen_targeting_nonblock"] == 1
+
+
+def test_block_targeting_without_pool_drops(tmp_path):
+    lines = CTX1 + [
+        L(
+            "base choose target choose which creature to block for Grizzly Bears",
+            1,
+            "ComputerPlayerMCTS.makeChoice",
+        ),
+        L("Targeting Stop Choosing", 1, "ComputerPlayerMCTS.makeChoice"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["drop_block_targeting_without_pool"] == 1
+
+
+def test_block_chosen_not_in_pool_drops(tmp_path):
+    lines = CTX1 + [
+        L(
+            "base choose target choose which creature to block for Grizzly Bears",
+            1,
+            "ComputerPlayerMCTS.makeChoice",
+        ),
+        L("possible targets: 1", 1, "ComputerPlayerMCTS.makeChoice"),
+        L(
+            "DECLARE_BLOCKERS0pool= actions: [Stop Choosing score: -0.1 count: 50] "
+            "[Raging Goblin score: -0.2 count: 5]",
+            1,
+            "MCTSNode.bestChild",
+        ),
+        L("Targeting Some Other Creature", 1, "ComputerPlayerMCTS.makeChoice"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert rows == []
+    assert acct["drop_block_chosen_not_in_pool"] == 1
+
+
+def test_block_happy_path_and_chosen_attacker(tmp_path):
+    lines = CTX1 + [
+        L(
+            "base choose target choose which creature to block for Grizzly Bears",
+            1,
+            "ComputerPlayerMCTS.makeChoice",
+        ),
+        L("possible targets: 1", 1, "ComputerPlayerMCTS.makeChoice"),
+        L(
+            "DECLARE_BLOCKERS0pool= actions: [Stop Choosing score: -0.1 count: 50] "
+            "[Raging Goblin score: 0.4 count: 500]",
+            1,
+            "MCTSNode.bestChild",
+        ),
+        L("Targeting Raging Goblin", 1, "ComputerPlayerMCTS.makeChoice"),
+    ]
+    rows, acct = scan(tmp_path, lines)
+    assert acct["emitted_block"] == 1
+    (blk,) = rows
+    assert blk["blocked_attacker"] == "Raging Goblin"
+    assert blk["chosen"] == "Block Raging Goblin with Grizzly Bears"
+    assert blk["menu"][-1] == "Do not block with Grizzly Bears"
+
+
+def test_attack_decline_records_no_attack(tmp_path):
+    rows, acct = scan(tmp_path, CTX1 + attack_seq(1, "Grizzly Bears", "false"))
+    (atk,) = rows
+    assert atk["attack_committed"] is False
+    assert atk["chosen"] == "Do not attack with Grizzly Bears"
+
+
+# ---------------------------------------------------------------------------
+# 3. Renderer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def rendered_real():
+    rows, _ = C.parse_combat_log(str(FIXTURE))
+    out = []
+    for r in rows:
+        r = dict(r)
+        r["outcome"] = "won"
+        rec, reason = C.build_combat_record(r)
+        assert rec is not None, reason
+        out.append(rec)
+    return out
+
+
+def test_render_shapes(rendered_real):
+    BRIDGE, _ = C._lazy_imports()
+    for rec in rendered_real:
+        assert rec["system"] == BRIDGE.AUTOPILOT_SYSTEM_PROMPT
+        assert rec["user"].count("Legal: (pick by number)") == 1
+        assert rec["source"] == "magezero_combat_micro"
+        assert rec["kind"] in ("attack_commit", "block_assign")
+
+
+def test_render_no_leaks(rendered_real):
+    for rec in rendered_real:
+        u = rec["user"]
+        assert "score:" not in u
+        assert "count:" not in u
+        assert "Computed optimal" not in u
+        # MCTS visit counts from the fixture must not appear anywhere
+        for count in ("867", "498", "189"):
+            assert count not in u
+
+
+def test_render_attack_answer(rendered_real):
+    (atk,) = [r for r in rendered_real if r["kind"] == "attack_commit"]
+    assert atk["response"] == '{"actions": [{"pick": 1}]}'
+    assert atk["meta"]["attack_committed"] is True
+    assert "1. Attack with Skrelv, Defector Mite" in atk["user"]
+
+
+def test_render_block_answer_and_opp_turn(rendered_real):
+    (blk,) = [r for r in rendered_real if r["kind"] == "block_assign"]
+    assert blk["response"] == '{"actions": [{"pick": 3}]}'
+    assert blk["meta"]["block_class"] == "no_block"
+    # blocking happens on the opponent's turn
+    assert "T5 OPP" in blk["user"]
+
+
+def test_render_unknown_outcome_fails_closed():
+    rows, _ = C.parse_combat_log(str(FIXTURE))
+    rec, reason = C.build_combat_record(rows[0])  # outcome still "unknown"
+    assert rec is None
+    assert reason == "outcome_unknown"
+
+
+# ---------------------------------------------------------------------------
+# 4. Histograms and floors
+# ---------------------------------------------------------------------------
+
+
+def _atk(chain: str, committed: bool) -> dict:
+    return {
+        "decision_kind": "attack_commit",
+        "attack_committed": committed,
+        "_chain": chain,
+        "game_id": chain,
+    }
+
+
+def _blk(blocked) -> dict:
+    return {"decision_kind": "block_assign", "blocked_attacker": blocked, "game_id": "g"}
+
+
+def test_all_in_floor_breach_is_flagged_not_rebalanced():
+    rows = [_atk("c1", True), _atk("c1", True), _atk("c2", True), _atk("c3", False)]
+    hist = C.combat_histograms(rows)
+    assert hist["attack_chains"] == 3
+    assert hist["attack_chain_hist"] == {"all_in": 2, "no_attack": 1}
+    # combat_histograms rounds shares to 4 decimals
+    assert hist["all_in_share"] == pytest.approx(2 / 3, abs=1e-4)
+    assert hist["floor_breach_all_in"] is True
+    assert hist["floor_breach"] is True
+
+
+def test_no_block_floor_breach():
+    rows = [_blk(None)] * 8 + [_blk("Goblin")] * 2
+    hist = C.combat_histograms(rows)
+    assert hist["no_block_share"] == pytest.approx(0.8)
+    assert hist["floor_breach_no_block"] is True
+
+
+def test_floors_pass_when_balanced():
+    rows = [_atk("c1", True), _atk("c2", False), _atk("c3", False)] + [
+        _blk(None), _blk("Goblin"),
+    ]
+    hist = C.combat_histograms(rows)
+    assert hist["floor_breach"] is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Pipeline wiring: --include-combat default OFF
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_flag_default_off_drops_combat_rows():
+    from collections import Counter
+
+    from tools.training import run_wp3_pipeline as P
+
+    rows, _ = C.parse_combat_log(str(FIXTURE))
+    for r in rows:
+        r["outcome"] = "won"
+    drops: dict[str, Counter] = {}
+    rendered = P.stage_render({"train": rows}, drops, {}, include_combat=False)
+    assert rendered["train"] == []
+    assert drops["train"]["dk_attack_commit_flag_off"] == 1
+    assert drops["train"]["dk_block_assign_flag_off"] == 1
+
+
+def test_pipeline_flag_on_renders_combat_rows():
+    from collections import Counter
+
+    from tools.training import run_wp3_pipeline as P
+
+    rows, _ = C.parse_combat_log(str(FIXTURE))
+    for r in rows:
+        r["outcome"] = "won"
+    drops: dict[str, Counter] = {}
+    rendered = P.stage_render({"train": rows}, drops, {}, include_combat=True)
+    assert len(rendered["train"]) == 2
+    kinds = sorted(rec["kind"] for rec in rendered["train"])
+    assert kinds == ["attack_commit", "block_assign"]
+
+
+def test_cli_default_is_off():
+    from tools.training import run_wp3_pipeline as P
+
+    args = P.build_arg_parser().parse_args(["--log", "x.log"])
+    assert args.include_combat is False

--- a/tools/training/magezero_combat_micro.py
+++ b/tools/training/magezero_combat_micro.py
@@ -1,0 +1,1045 @@
+#!/usr/bin/env python3
+"""MageZero COMBAT micro-decision adapter: XMage text logs -> training records.
+
+Why this file exists
+--------------------
+#453 found that the previous combat converter (build_magezero_combat.py)
+reverse-engineered declarations from stale board markers and produced 89
+fabricated labels out of 90 records; it now fails closed to zero. The
+retraction in rl-pipeline-fix.md ("COMBAT IS BLOCKED UPSTREAM -- RETRACTED")
+established that the MCTS agent's combat decisions ARE in the log, at
+per-creature granularity, under emitters nobody had grepped for:
+
+Attack micro-decision (one per available attacker; the pool= line immediately
+precedes the resolution line ON THE SAME THREAD):
+
+    ... DECLARE_ATTACKERS0pool= actions: [false score: 0.013 count: 104]
+        [true score: 0.147 count: 867]           =>[pool-3-thread-1] MCTSNode.bestChild
+    ... use attack with: Skrelv, Defector Mite?: true
+                                                 =>[pool-3-thread-1] ComputerPlayerMCTS.chooseUse
+
+('base choose use attack with: <name>?' opens the deliberation ~2s earlier on
+the same thread.)
+
+Block micro-decision (one per available blocker):
+
+    ... base choose target choose which creature to block for Malcolm, ...
+                                                 =>[pool-3-thread-5] ComputerPlayerMCTS.makeChoice
+    ... possible targets: 2                      =>[...same thread] ComputerPlayerMCTS.makeChoice
+    ... DECLARE_BLOCKERS0pool= actions: [Stop Choosing score: -0.976 count: 250] ...
+                                                 =>[...] MCTSNode.bestChild
+    ... Targeting Stop Choosing                  =>[...same thread] ComputerPlayerMCTS.makeChoice
+
+'Targeting <attacker>' = blocked that attacker; 'Targeting Stop Choosing' =
+declined to block with this creature. A 'Targeting ...' line ALSO appears for
+ordinary spell targeting, so a Targeting line only counts as a block decision
+when the same thread has an open 'choose which creature to block for' context
+with a DECLARE_BLOCKERS pool= attached.
+
+Fail-closed rules (the #452/#453 lessons, mechanised)
+-----------------------------------------------------
+* All pairing is done per THREAD TAG. Nothing is ever paired across threads.
+* A resolution pairs with a pool only if that pool is still pending on the
+  same thread (any intervening decision-class event abandons it, with a
+  counted reason) and the same-thread line distance is within
+  MAX_POOL_GAP_THREAD_LINES.
+* Board/hand context comes from the thread's own battlefield state machine
+  (same grammar handling as parse_magezero_log, #430) and is only accepted if
+  a COMPLETE ComputerPlayerMCTS.printBattlefieldScore block was seen on that
+  thread, in the SAME game, within MAX_CTX_GAP_THREAD_LINES same-thread lines.
+* Every combat line seen (opener, pool, resolution, Targeting) ends up either
+  consumed into a record or counted under an explicit reason;
+  :func:`verify_accounting` asserts the identities and is run on every scan.
+* Nothing is ever guessed: an unpaired / ambiguous / out-of-window line is a
+  counted drop, never a labelled record.
+
+Record shape
+------------
+Scanner output rows use the shared WP-3 decisions schema (same field names as
+parse_magezero_log) with decision_kind 'attack_commit' / 'block_assign', plus
+combat extras (creature, candidates, mcts_scores, provenance). The renderer
+turns a row into a production-shaped training record via the SAME functions
+build_magezero_bridge uses (gate_play_decisions.build_user_message ->
+ActionPlanner._build_action_prompt), with the production 'combat_attackers' /
+'combat_blockers' triggers and a {"pick": N} answer. MCTS counts/scores stay
+in meta and never enter prompt text (the pipeline leak scan re-checks this).
+
+Usage
+-----
+    python3 tools/training/magezero_combat_micro.py \
+        --log /home/joshu/mz_train_smoke.log \
+        --out tools/training/data/wp3/combat_decisions.jsonl --report
+
+Wired into run_wp3_pipeline.py behind --include-combat (default OFF).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SRC = REPO / "src"
+for _p in (str(SRC), str(REPO)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from tools.training import parse_magezero_log as PARSER  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Regexes (shared ones come straight from the reviewed parser, #430)
+# ---------------------------------------------------------------------------
+
+RE_THREAD = PARSER.RE_THREAD
+RE_DIE_ROLL = PARSER.RE_DIE_ROLL
+RE_LOG_LIFE = PARSER.RE_LOG_LIFE
+RE_CHOSE_ACTION = PARSER.RE_CHOSE_ACTION
+RE_POOL = PARSER.RE_POOL
+RE_POOL_TOP = PARSER.RE_POOL_TOP
+RE_PLAYER_LIFE = PARSER.RE_PLAYER_LIFE
+RE_HAND = PARSER.RE_HAND
+RE_PERMANENTS = PARSER.RE_PERMANENTS
+RE_EMITTER = PARSER.RE_EMITTER
+EMITTER_MCTS = PARSER.EMITTER_MCTS
+
+# Combat emitters (verified verbatim against mz_train_smoke.log 2026-07-30).
+# The resolution line has '?: true|false'; the opener does not, so the two
+# cannot be confused by these patterns.
+RE_ATTACK_OPEN = re.compile(r"base choose use attack with: (.+)\?\s*=>")
+RE_ATTACK_RES = re.compile(r"use attack with: (.+)\?: (true|false)\s*=>")
+RE_BLOCK_OPEN = re.compile(
+    r"base choose target choose which creature to block for (.+?)\s*=>"
+)
+RE_TARGET_OPEN = re.compile(r"base choose target ")
+RE_TARGETING = re.compile(r"Targeting (.+?)\s*=>")
+RE_POSSIBLE = re.compile(r"possible targets: (\d+)")
+
+PHASE_ATTACK = "DECLARE_ATTACKERS"
+PHASE_BLOCK = "DECLARE_BLOCKERS"
+
+# Pairing windows, in SAME-THREAD line counts. Measured on mz_train_smoke.log:
+# pool -> resolution is same-thread-adjacent in 3213/3213 clean attack pairs
+# and 788/788 block pairs (only battlefield-print / 'possible targets' lines
+# ever sit between); 12 allows a full 4-line battlefield block plus slack
+# without ever reaching back to a stale pool from a previous window.
+MAX_POOL_GAP_THREAD_LINES = 12
+# Context window: distance from the last complete printBattlefieldScore block
+# to the decision. Measured p95 on the smoke log is ~16 extracted events
+# (a few hundred raw thread lines across 2s searches); 800 bounds it while
+# the same-game check does the semantic work.
+MAX_CTX_GAP_THREAD_LINES = 800
+
+# Pre-registered trivial-policy floors (tools/training/gate_combat_decisions.py,
+# measured on combat_gate_test.jsonl n=6,852):
+#   always_no_block accuracy 0.6983  -> the "69% no-block" floor
+#   best combined reflex (always_all_in + always_no_block) 0.3859 -> "38.6%"
+NO_BLOCK_FLOOR = 0.69
+ALL_IN_FLOOR = 0.386
+
+STOP_CHOOSING = "Stop Choosing"
+
+ATTRIBUTION = "MageZero self-play (XMage-based AlphaZero engine)"
+SOURCE = "magezero_combat_micro"
+
+_COMBAT_SUFFIXES = (",attacking", ",blocking")
+
+
+def _strip_combat_suffix(name: str) -> tuple[str, str | None]:
+    for suffix in _COMBAT_SUFFIXES:
+        if name.endswith(suffix):
+            return name[: -len(suffix)], suffix[1:]
+    return name, None
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+
+
+class _Pending:
+    """Per-thread pending combat context."""
+
+    __slots__ = (
+        "attack_open_name",
+        "attack_open_line",
+        "attack_pool",  # (actions, global_line, thread_line)
+        "block_open_name",
+        "block_open_line",
+        "block_possible",
+        "block_pool",  # (actions, global_line, thread_line)
+    )
+
+    def __init__(self):
+        self.attack_open_name = None
+        self.attack_open_line = 0
+        self.attack_pool = None
+        self.block_open_name = None
+        self.block_open_line = 0
+        self.block_possible = None
+        self.block_pool = None
+
+    # -- counted state transitions (nothing vanishes uncounted) -----------
+
+    def consume_attack(self, acct: Counter) -> None:
+        """A resolution line takes whatever attack context is pending."""
+        if self.attack_open_name is not None:
+            acct["opener_attack_consumed_at_resolution"] += 1
+        if self.attack_pool is not None:
+            acct["pool_attack_consumed_at_resolution"] += 1
+        self.attack_open_name = None
+        self.attack_open_line = 0
+        self.attack_pool = None
+
+    def abandon_attack(self, acct: Counter, why: str) -> None:
+        if self.attack_open_name is not None:
+            acct[f"opener_attack_{why}"] += 1
+        if self.attack_pool is not None:
+            acct[f"pool_attack_{why}"] += 1
+        self.attack_open_name = None
+        self.attack_open_line = 0
+        self.attack_pool = None
+
+    def consume_block(self, acct: Counter) -> None:
+        if self.block_open_name is not None:
+            acct["opener_block_consumed_at_targeting"] += 1
+        if self.block_pool is not None:
+            acct["pool_block_consumed_at_targeting"] += 1
+        self.block_open_name = None
+        self.block_open_line = 0
+        self.block_possible = None
+        self.block_pool = None
+
+    def abandon_block(self, acct: Counter, why: str) -> None:
+        if self.block_open_name is not None:
+            acct[f"opener_block_{why}"] += 1
+        if self.block_pool is not None:
+            acct[f"pool_block_{why}"] += 1
+        self.block_open_name = None
+        self.block_open_line = 0
+        self.block_possible = None
+        self.block_pool = None
+
+
+class _Ctx:
+    """Last complete printBattlefieldScore block on a thread."""
+
+    __slots__ = ("global_line", "thread_line", "game_seq", "turn")
+
+    def __init__(self, global_line: int, thread_line: int, game_seq: int, turn: int):
+        self.global_line = global_line
+        self.thread_line = thread_line
+        self.game_seq = game_seq
+        self.turn = turn
+
+
+def parse_combat_log(log_path: str) -> tuple[list[dict], dict[str, int]]:
+    """One streaming pass -> (combat rows, accounting dict).
+
+    The accounting dict contains drop reasons (``drop_*``), abandoned-context
+    counters (``opener_*`` / ``pool_*``) and seen counters (``seen_*``);
+    :func:`verify_accounting` asserts the closed-ledger identities.
+    """
+    log_name = os.path.basename(log_path)
+
+    threads: dict[str, PARSER._ThreadState] = {}
+    thread_game_seq: dict[str, int] = {}
+    pendings: dict[str, _Pending] = {}
+    thread_lines: dict[str, int] = {}
+    # printBattlefieldScore block tracking (context anchor)
+    mcts_block_open: dict[str, int] = {}  # thread -> perm lines seen in open block
+    mcts_ctx: dict[str, _Ctx] = {}
+    # attack chain id per thread (increments whenever the combat window closes)
+    chain_seq: dict[str, int] = {}
+    chain_open: dict[str, bool] = {}
+    declared_before: dict[str, list] = {}
+    block_assignments_before: dict[str, dict] = {}
+
+    rows: list[dict] = []
+    game_rows: dict[str, list[dict]] = {}  # thread -> rows of current game
+    acct: Counter = Counter()
+
+    def _reset_chain(tid: str):
+        if chain_open.get(tid):
+            chain_seq[tid] = chain_seq.get(tid, 0) + 1
+            chain_open[tid] = False
+        declared_before[tid] = []
+        block_assignments_before[tid] = {}
+
+    def _finalize_game(tid: str):
+        state = threads.get(tid)
+        if state is None:
+            return
+        outcome = state.infer_outcome()
+        for r in game_rows.get(tid, []):
+            r["outcome"] = outcome
+        game_rows[tid] = []
+
+    with open(log_path, encoding="utf-8", errors="replace") as f:
+        for global_line, raw in enumerate(f, start=1):
+            line = raw.rstrip("\n\r")
+            tm = RE_THREAD.search(line)
+            if not tm:
+                continue
+            tid = tm.group(1)
+            thread_lines[tid] = thread_lines.get(tid, 0) + 1
+            tline = thread_lines[tid]
+
+            state = threads.get(tid)
+            if state is None:
+                thread_game_seq[tid] = 0
+                # game_seq numbering identical to parse_magezero_log so that
+                # game_ids line up with the priority corpus for outcome joins
+                # and game-level splits.
+                state = PARSER._ThreadState(tid, log_name, thread_game_seq[tid] + 1)
+                threads[tid] = state
+                pendings[tid] = _Pending()
+                chain_seq[tid] = 0
+                chain_open[tid] = False
+                declared_before[tid] = []
+                block_assignments_before[tid] = {}
+                game_rows[tid] = []
+            p = pendings[tid]
+
+            em_m = RE_EMITTER.search(line)
+            emitter = em_m.group(1) if em_m else None
+
+            # -- game boundary --------------------------------------------
+            if RE_DIE_ROLL.search(line):
+                _finalize_game(tid)
+                p.abandon_attack(acct, "abandoned_at_game_end")
+                p.abandon_block(acct, "abandoned_at_game_end")
+                _reset_chain(tid)
+                thread_game_seq[tid] += 1
+                state.start_new_game(thread_game_seq[tid])
+                mcts_ctx.pop(tid, None)
+                mcts_block_open.pop(tid, None)
+                continue
+
+            # -- turn/phase/life ------------------------------------------
+            lm = RE_LOG_LIFE.search(line)
+            if lm:
+                state.on_log_life(
+                    int(lm.group(1)), lm.group(2), lm.group(3),
+                    int(lm.group(4)), int(lm.group(5)),
+                )
+                continue
+
+            # -- MCTS pool ------------------------------------------------
+            pool_match = RE_POOL.search(line) or RE_POOL_TOP.search(line)
+            if pool_match:
+                actions = PARSER.parse_pool_actions(pool_match.group(3))
+                if not actions:
+                    continue
+                phase = pool_match.group(1)
+                names = {a[0] for a in actions}
+                if phase == PHASE_ATTACK and names == {"true", "false"}:
+                    acct["seen_attack_pools_binary"] += 1
+                    if p.attack_pool is not None:
+                        p.abandon_attack(acct, "abandoned_replaced_by_new_pool")
+                    p.attack_pool = (actions, global_line, tline)
+                elif phase == PHASE_BLOCK and p.block_open_name is not None:
+                    acct["seen_block_pools_gated"] += 1
+                    if p.block_pool is not None:
+                        acct["pool_block_abandoned_replaced_by_new_pool"] += 1
+                        p.block_pool = None
+                    p.block_pool = (actions, global_line, tline)
+                else:
+                    # A priority-window pool (any phase). Not a combat
+                    # micro-decision, but a decision-class event: any pending
+                    # combat context is now stale, and the combat window is
+                    # closed for chain purposes.
+                    acct["seen_pools_noncombat"] += 1
+                    p.abandon_attack(acct, "abandoned_by_noncombat_pool")
+                    p.abandon_block(acct, "abandoned_by_noncombat_pool")
+                    _reset_chain(tid)
+                continue
+
+            # -- chose action: a priority decision closes combat windows --
+            if RE_CHOSE_ACTION.search(line):
+                p.abandon_attack(acct, "abandoned_at_priority_decision")
+                p.abandon_block(acct, "abandoned_at_priority_decision")
+                _reset_chain(tid)
+                continue
+
+            # -- attack deliberation opener -------------------------------
+            am = RE_ATTACK_OPEN.search(line)
+            if am:
+                acct["seen_attack_openers"] += 1
+                if p.attack_open_name is not None or p.attack_pool is not None:
+                    p.abandon_attack(acct, "abandoned_by_new_attack_opener")
+                p.abandon_block(acct, "abandoned_by_attack_opener")
+                p.attack_open_name = am.group(1)
+                p.attack_open_line = global_line
+                continue
+
+            # -- attack resolution ----------------------------------------
+            rm = RE_ATTACK_RES.search(line)
+            if rm:
+                acct["seen_attack_resolutions"] += 1
+                name, verdict = rm.group(1), rm.group(2)
+                row = _try_emit_attack(
+                    state, p, acct, name, verdict, global_line, tline,
+                    mcts_ctx.get(tid), log_name,
+                    chain_seq.get(tid, 0), declared_before[tid],
+                )
+                if row is not None:
+                    chain_open[tid] = True
+                    if verdict == "true":
+                        declared_before[tid] = declared_before[tid] + [name]
+                    rows.append(row)
+                    game_rows[tid].append(row)
+                p.consume_attack(acct)
+                continue
+
+            # -- block deliberation opener --------------------------------
+            bm = RE_BLOCK_OPEN.search(line)
+            if bm:
+                acct["seen_block_openers"] += 1
+                if p.block_open_name is not None:
+                    p.abandon_block(acct, "abandoned_by_new_block_opener")
+                p.abandon_attack(acct, "abandoned_by_block_opener")
+                p.block_open_name = bm.group(1)
+                p.block_open_line = global_line
+                p.block_possible = None
+                p.block_pool = None
+                continue
+
+            # -- other target opener (spell targeting) closes block window -
+            if RE_TARGET_OPEN.search(line):
+                p.abandon_block(acct, "abandoned_by_spell_targeting")
+                continue
+
+            pmatch = RE_POSSIBLE.search(line)
+            if pmatch:
+                if p.block_open_name is not None and p.block_pool is None:
+                    p.block_possible = int(pmatch.group(1))
+                continue
+
+            # -- Targeting resolution -------------------------------------
+            tg = RE_TARGETING.search(line)
+            if tg:
+                acct["seen_targeting_total"] += 1
+                if p.block_open_name is None:
+                    acct["seen_targeting_nonblock"] += 1
+                    continue
+                acct["seen_targeting_block_gated"] += 1
+                blocker = p.block_open_name
+                row = _try_emit_block(
+                    state, p, acct, tg.group(1), global_line, tline,
+                    mcts_ctx.get(tid), log_name,
+                    chain_seq.get(tid, 0), block_assignments_before[tid],
+                )
+                if row is not None:
+                    chain_open[tid] = True
+                    if tg.group(1) != STOP_CHOOSING:
+                        nxt = dict(block_assignments_before[tid])
+                        nxt[blocker] = tg.group(1)
+                        block_assignments_before[tid] = nxt
+                    rows.append(row)
+                    game_rows[tid].append(row)
+                p.consume_block(acct)
+                continue
+
+            # -- battlefield block header ---------------------------------
+            pl = RE_PLAYER_LIFE.search(line)
+            if pl:
+                state.on_block_header(pl.group(1), int(pl.group(2)), emitter)
+                if emitter == EMITTER_MCTS and pl.group(1) == "PlayerA":
+                    mcts_block_open[tid] = 0
+                else:
+                    mcts_block_open.pop(tid, None)
+                continue
+
+            hm = RE_HAND.search(line)
+            if hm:
+                state.on_hand_line(PARSER.parse_card_list(hm.group(1)))
+                continue
+
+            perm = RE_PERMANENTS.search(line)
+            if perm:
+                state.on_permanents_line(
+                    PARSER.parse_permanents(perm.group(1)), emitter
+                )
+                if emitter == EMITTER_MCTS and tid in mcts_block_open:
+                    mcts_block_open[tid] += 1
+                    if mcts_block_open[tid] == 2:
+                        # complete MCTS block: both boards freshly attributed
+                        mcts_ctx[tid] = _Ctx(
+                            global_line, tline, state.game_seq, state.last_turn
+                        )
+                        mcts_block_open.pop(tid, None)
+                continue
+
+    # EOF: finalize outcomes, count still-pending windows
+    for tid, p in pendings.items():
+        p.abandon_attack(acct, "abandoned_at_eof")
+        p.abandon_block(acct, "abandoned_at_eof")
+    for tid in threads:
+        _finalize_game(tid)
+
+    return rows, dict(acct)
+
+
+def _context_ok(
+    acct: Counter, ctx: _Ctx | None, state, tline: int, kind: str
+) -> bool:
+    """Fail-closed board-context gate. Counts the reason on failure."""
+    if ctx is None:
+        acct[f"drop_{kind}_no_board_context"] += 1
+        return False
+    if ctx.game_seq != state.game_seq:
+        acct[f"drop_{kind}_board_context_previous_game"] += 1
+        return False
+    if tline - ctx.thread_line > MAX_CTX_GAP_THREAD_LINES:
+        acct[f"drop_{kind}_board_context_out_of_window"] += 1
+        return False
+    return True
+
+
+def _board_entry(p: dict) -> dict:
+    name, marker = _strip_combat_suffix(p["name"])
+    out = {"name": name, "tapped": bool(p.get("tapped", False))}
+    if marker:
+        out[marker] = True
+    return out
+
+
+def _base_row(
+    state, log_name: str, phase: str, kind: str, chain: int
+) -> dict:
+    return {
+        "game_id": state.game_id,
+        "turn": state.last_turn,
+        "phase": phase,
+        "active_life": state.life_a,
+        "opp_life": state.life_b,
+        "hand": list(state.latest_hand),
+        "battlefield_self": [_board_entry(p) for p in state.boards["PlayerA"]],
+        "battlefield_opp": [_board_entry(p) for p in state.boards["PlayerB"]],
+        "actor": "PlayerA",
+        "outcome": "unknown",
+        "session": "",
+        "decision_kind": kind,
+        "_thread": state.thread_id,
+        "_game_seq": state.game_seq,
+        "_log": log_name,
+        "_chain": f"{state.game_id}:combat{chain}",
+    }
+
+
+def _try_emit_attack(
+    state, p: _Pending, acct: Counter, name: str, verdict: str,
+    global_line: int, tline: int, ctx: _Ctx | None, log_name: str,
+    chain: int, declared_before: list,
+) -> dict | None:
+    if p.attack_pool is None:
+        acct["drop_attack_resolution_without_pool"] += 1
+        return None
+    actions, pool_line, pool_tline = p.attack_pool
+    if tline - pool_tline > MAX_POOL_GAP_THREAD_LINES:
+        acct["drop_attack_pool_too_far"] += 1
+        return None
+    if p.attack_open_name is None:
+        acct["drop_attack_opener_missing"] += 1
+        return None
+    if p.attack_open_name != name:
+        acct["drop_attack_opener_name_mismatch"] += 1
+        return None
+    if not _context_ok(acct, ctx, state, tline, "attack"):
+        return None
+
+    menu = [f"Attack with {name}", f"Do not attack with {name}"]
+    chosen = menu[0] if verdict == "true" else menu[1]
+    row = _base_row(state, log_name, PHASE_ATTACK, "attack_commit", chain)
+    creature_on_board = any(e["name"] == name for e in row["battlefield_self"])
+    row.update({
+        "menu": menu,
+        "chosen": chosen,
+        "creature": name,
+        "attack_committed": verdict == "true",
+        "declared_before": list(declared_before),
+        "mcts_counts": {a: c for a, _s, c in actions},
+        "mcts_scores": {a: s for a, s, _c in actions},
+        "provenance": {
+            "log": log_name,
+            "thread": state.thread_id,
+            "line_opener": p.attack_open_line,
+            "line_pool": pool_line,
+            "line_resolution": global_line,
+            "line_context": ctx.global_line,
+            "context_emitter": EMITTER_MCTS,
+            "context_thread_line_gap": tline - ctx.thread_line,
+            "creature_on_board": creature_on_board,
+        },
+    })
+    acct["emitted_attack"] += 1
+    return row
+
+
+def _try_emit_block(
+    state, p: _Pending, acct: Counter, chosen_raw: str,
+    global_line: int, tline: int, ctx: _Ctx | None, log_name: str,
+    chain: int, assignments_before: dict,
+) -> dict | None:
+    blocker = p.block_open_name
+    if p.block_pool is None:
+        acct["drop_block_targeting_without_pool"] += 1
+        return None
+    actions, pool_line, pool_tline = p.block_pool
+    if tline - pool_tline > MAX_POOL_GAP_THREAD_LINES:
+        acct["drop_block_pool_too_far"] += 1
+        return None
+    pool_names = [a for a, _s, _c in actions]
+    if chosen_raw not in pool_names:
+        acct["drop_block_chosen_not_in_pool"] += 1
+        return None
+    # Candidates: attacker names from the pool, in pool order, minus the
+    # decline sentinel. Duplicate names get " #k" disambiguators so menu
+    # entries stay unique (chosen maps to the first occurrence, which is
+    # name-accurate: the log does not identify the instance).
+    candidates = [n for n in pool_names if n != STOP_CHOOSING]
+    if not candidates:
+        acct["drop_block_pool_has_no_attackers"] += 1
+        return None
+    if not _context_ok(acct, ctx, state, tline, "block"):
+        return None
+
+    counts = Counter(candidates)
+    seen: dict[str, int] = {}
+    display: list[str] = []
+    for n in candidates:
+        if counts[n] > 1:
+            seen[n] = seen.get(n, 0) + 1
+            display.append(f"{n} #{seen[n]}")
+        else:
+            display.append(n)
+    menu = [f"Block {d} with {blocker}" for d in display]
+    menu.append(f"Do not block with {blocker}")
+    if chosen_raw == STOP_CHOOSING:
+        chosen = menu[-1]
+    else:
+        idx = candidates.index(chosen_raw)  # first occurrence
+        chosen = menu[idx]
+
+    row = _base_row(state, log_name, PHASE_BLOCK, "block_assign", chain)
+    blocker_on_board = any(e["name"] == blocker for e in row["battlefield_self"])
+    attackers_on_board = sum(
+        1 for n in set(candidates)
+        if any(e["name"] == n for e in row["battlefield_opp"])
+    )
+    row.update({
+        "menu": menu,
+        "chosen": chosen,
+        "creature": blocker,
+        "candidates": candidates,
+        "candidates_display": display,
+        "blocked_attacker": None if chosen_raw == STOP_CHOOSING else chosen_raw,
+        "possible_targets": p.block_possible,
+        "possible_targets_matches_pool": (
+            p.block_possible is not None and p.block_possible == len(candidates)
+        ),
+        "duplicate_candidates": any(v > 1 for v in counts.values()),
+        "assignments_before": dict(assignments_before),
+        "mcts_counts": {a: c for a, _s, c in actions},
+        "mcts_scores": {a: s for a, s, _c in actions},
+        "provenance": {
+            "log": log_name,
+            "thread": state.thread_id,
+            "line_opener": p.block_open_line,
+            "line_pool": pool_line,
+            "line_resolution": global_line,
+            "line_context": ctx.global_line,
+            "context_emitter": EMITTER_MCTS,
+            "context_thread_line_gap": tline - ctx.thread_line,
+            "creature_on_board": blocker_on_board,
+            "attackers_on_board": attackers_on_board,
+            "attackers_total": len(set(candidates)),
+        },
+    })
+    acct["emitted_block"] += 1
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Accounting verification (requirement: total accounted == total seen)
+# ---------------------------------------------------------------------------
+
+ATTACK_DROP_REASONS = (
+    "drop_attack_resolution_without_pool",
+    "drop_attack_pool_too_far",
+    "drop_attack_opener_missing",
+    "drop_attack_opener_name_mismatch",
+    "drop_attack_no_board_context",
+    "drop_attack_board_context_previous_game",
+    "drop_attack_board_context_out_of_window",
+)
+
+BLOCK_DROP_REASONS = (
+    "drop_block_targeting_without_pool",
+    "drop_block_pool_too_far",
+    "drop_block_chosen_not_in_pool",
+    "drop_block_pool_has_no_attackers",
+    "drop_block_no_board_context",
+    "drop_block_board_context_previous_game",
+    "drop_block_board_context_out_of_window",
+)
+
+
+def _sum_prefixed(acct: dict[str, int], prefix: str) -> int:
+    return sum(v for k, v in acct.items() if k.startswith(prefix))
+
+
+def verify_accounting(acct: dict[str, int]) -> None:
+    """Assert the closed ledger: every combat line consumed or counted."""
+    # resolutions
+    seen_att = acct.get("seen_attack_resolutions", 0)
+    acc_att = acct.get("emitted_attack", 0) + sum(
+        acct.get(k, 0) for k in ATTACK_DROP_REASONS
+    )
+    assert acc_att == seen_att, (
+        f"attack accounting mismatch: seen={seen_att} accounted={acc_att} — "
+        f"a resolution line was neither emitted nor counted"
+    )
+    # targeting
+    seen_tgt = acct.get("seen_targeting_total", 0)
+    acc_tgt = acct.get("seen_targeting_nonblock", 0) + acct.get(
+        "seen_targeting_block_gated", 0
+    )
+    assert acc_tgt == seen_tgt, (
+        f"targeting accounting mismatch: seen={seen_tgt} accounted={acc_tgt}"
+    )
+    seen_gated = acct.get("seen_targeting_block_gated", 0)
+    acc_gated = acct.get("emitted_block", 0) + sum(
+        acct.get(k, 0) for k in BLOCK_DROP_REASONS
+    )
+    assert acc_gated == seen_gated, (
+        f"block accounting mismatch: gated={seen_gated} accounted={acc_gated} — "
+        f"a Targeting line was neither emitted nor counted"
+    )
+    # openers and pools: consumed + abandoned == seen
+    for seen_key, prefix in (
+        ("seen_attack_openers", "opener_attack_"),
+        ("seen_attack_pools_binary", "pool_attack_"),
+        ("seen_block_openers", "opener_block_"),
+        ("seen_block_pools_gated", "pool_block_"),
+    ):
+        seen = acct.get(seen_key, 0)
+        accounted = _sum_prefixed(acct, prefix)
+        assert accounted == seen, (
+            f"{seen_key} ledger mismatch: seen={seen} accounted={accounted}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Histograms and trivial-policy floors
+# ---------------------------------------------------------------------------
+
+
+def combat_histograms(rows: list[dict]) -> dict:
+    """Class histograms + pre-registered floor checks.
+
+    * no_block share (record level) vs the 69% always-no-block floor.
+    * all-in share (combat-chain level: every emitted attack decision in the
+      chain said "attack") vs the 38.6% floor.
+    On breach the caller prints loudly and records the flag in the manifest.
+    No silent rebalancing, ever.
+    """
+    attack = [r for r in rows if r.get("decision_kind") == "attack_commit"]
+    block = [r for r in rows if r.get("decision_kind") == "block_assign"]
+
+    n_commit = sum(1 for r in attack if r.get("attack_committed"))
+    attack_hist = {
+        "attack": n_commit,
+        "no_attack": len(attack) - n_commit,
+    }
+    attack_true_share = n_commit / len(attack) if attack else 0.0
+
+    n_no_block = sum(1 for r in block if r.get("blocked_attacker") is None)
+    block_hist = {
+        "no_block": n_no_block,
+        "block": len(block) - n_no_block,
+    }
+    no_block_share = n_no_block / len(block) if block else 0.0
+
+    # chain-level attack classes (emitted rows only; a dropped micro-decision
+    # inside a chain removes it from this grouping, which is reported)
+    chains: dict[str, list[bool]] = {}
+    for r in attack:
+        key = r.get("_chain") or (r.get("meta", {}) or {}).get("combat_chain") or r.get("game_id", "?")
+        chains.setdefault(key, []).append(bool(r.get("attack_committed")))
+    chain_classes: Counter = Counter()
+    for verdicts in chains.values():
+        if all(verdicts):
+            chain_classes["all_in"] += 1
+        elif not any(verdicts):
+            chain_classes["no_attack"] += 1
+        else:
+            chain_classes["proper_subset"] += 1
+    n_chains = sum(chain_classes.values())
+    all_in_share = chain_classes.get("all_in", 0) / n_chains if n_chains else 0.0
+
+    breach_no_block = no_block_share > NO_BLOCK_FLOOR
+    breach_all_in = all_in_share > ALL_IN_FLOOR
+    return {
+        "attack_records": len(attack),
+        "block_records": len(block),
+        "attack_hist": attack_hist,
+        "attack_true_share": round(attack_true_share, 4),
+        "block_hist": block_hist,
+        "no_block_share": round(no_block_share, 4),
+        "attack_chains": n_chains,
+        "attack_chain_hist": dict(chain_classes),
+        "all_in_share": round(all_in_share, 4),
+        "floors": {
+            "no_block_floor": NO_BLOCK_FLOOR,
+            "all_in_floor": ALL_IN_FLOOR,
+        },
+        "floor_breach_no_block": breach_no_block,
+        "floor_breach_all_in": breach_all_in,
+        "floor_breach": breach_no_block or breach_all_in,
+    }
+
+
+def print_floor_check(hist: dict, out=sys.stderr) -> None:
+    print("\n  Combat class histograms:", file=out)
+    print(
+        f"    attack records: {hist['attack_records']}  "
+        f"{hist['attack_hist']}  (attack share "
+        f"{hist['attack_true_share']:.1%})",
+        file=out,
+    )
+    print(
+        f"    attack chains:  {hist['attack_chains']}  "
+        f"{hist['attack_chain_hist']}  (all-in share "
+        f"{hist['all_in_share']:.1%} vs floor {ALL_IN_FLOOR:.1%})",
+        file=out,
+    )
+    print(
+        f"    block records:  {hist['block_records']}  "
+        f"{hist['block_hist']}  (no-block share "
+        f"{hist['no_block_share']:.1%} vs floor {NO_BLOCK_FLOOR:.1%})",
+        file=out,
+    )
+    if hist["floor_breach"]:
+        print(
+            "\n  ********************************************************\n"
+            "  ** TRIVIAL-POLICY FLOOR BREACHED — corpus is NOT being **\n"
+            "  ** rebalanced silently. floor_breach=true is recorded  **\n"
+            "  ** in the manifest; the gate decision is the owner's.  **\n"
+            "  ********************************************************",
+            file=out,
+        )
+        if hist["floor_breach_no_block"]:
+            print(
+                f"  ** no_block share {hist['no_block_share']:.1%} > "
+                f"{NO_BLOCK_FLOOR:.1%} always-no-block floor",
+                file=out,
+            )
+        if hist["floor_breach_all_in"]:
+            print(
+                f"  ** all-in share {hist['all_in_share']:.1%} > "
+                f"{ALL_IN_FLOOR:.1%} floor",
+                file=out,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Renderer: combat row -> production-shaped training record
+# ---------------------------------------------------------------------------
+
+_BRIDGE = None
+_G = None
+
+
+def _lazy_imports():
+    """build_magezero_bridge pulls in the production prompt stack; keep the
+    scanner importable without it."""
+    global _BRIDGE, _G
+    if _BRIDGE is None:
+        from tools.training import build_magezero_bridge as B
+        from tools.training import gate_play_decisions as G
+        _BRIDGE = B
+        _G = G
+    return _BRIDGE, _G
+
+
+TRIGGER_BY_KIND = {
+    "attack_commit": "combat_attackers",
+    "block_assign": "combat_blockers",
+}
+
+
+def build_combat_record(row: dict) -> tuple[dict | None, str]:
+    """Combat decisions row -> training record, or (None, drop_reason)."""
+    BRIDGE, G = _lazy_imports()
+
+    kind = row.get("decision_kind", "")
+    trigger = TRIGGER_BY_KIND.get(kind)
+    if trigger is None:
+        return None, f"decision_kind_{kind or 'missing'}"
+
+    outcome = row.get("outcome", "unknown")
+    if outcome == "unknown":
+        return None, "outcome_unknown"
+
+    menu = row.get("menu", [])
+    if len(menu) < 2:
+        return None, "menu_too_small"
+    chosen = row.get("chosen", "")
+    if chosen not in menu:
+        return None, "chosen_not_in_menu"
+    answer_idx = menu.index(chosen) + 1
+
+    gs_row = dict(row)
+    gs_row["phase"] = (
+        "COMBAT_DECLARE_ATTACKERS" if kind == "attack_commit"
+        else "COMBAT_DECLARE_BLOCKERS"
+    )
+    game_state = BRIDGE.build_game_state(gs_row)
+
+    # Log-derived combat markers -> formatter [ATK]/[BLK] flags, SELF board
+    # only. Evidence sources (all from the log, never inferred):
+    #   1. ',attacking'/',blocking' suffixes on the battlefield print itself
+    #      (index-aligned: build_game_state keeps battlefield_self order);
+    #   2. this combat's earlier commitments on this thread (declared_before /
+    #      assignments_before), marked only when the name matches exactly one
+    #      board entry — with duplicates the instance is unknowable from the
+    #      log, so nothing is marked (fail closed on ambiguity).
+    # OPP cards are deliberately NEVER marked is_attacking: MageZero carries
+    # no power/toughness, and an attacking-marked opponent board makes the
+    # production formatter run its block solver on fabricated 0/0 stats and
+    # print "Computed optimal blocks: ..." — combat math from invented
+    # numbers AND, for a no-block gold answer, a literal label leak. The
+    # attacker roster reaches the model through the menu rows instead
+    # ("Block <attacker> with <blocker>"), which is log-authoritative.
+    bf = game_state.get("battlefield", [])
+    for i, src in enumerate(row.get("battlefield_self", [])):
+        if src.get("attacking"):
+            bf[i]["is_attacking"] = True
+        if src.get("blocking"):
+            bf[i]["is_blocking"] = True
+
+    def _mark_unique_self(names: list[str], flag: str) -> None:
+        for name in names:
+            hits = [
+                c for c in bf
+                if c["controller_seat_id"] == BRIDGE.LOCAL_SEAT
+                and c["name"] == name
+            ]
+            if len(hits) == 1:
+                hits[0][flag] = True
+
+    if kind == "attack_commit":
+        _mark_unique_self(row.get("declared_before", []), "is_attacking")
+    else:
+        _mark_unique_self(
+            list(row.get("assignments_before", {}).keys()), "is_blocking"
+        )
+        # Blocking happens on the opponent's turn.
+        game_state["turn"]["active_player"] = BRIDGE.OPP_SEAT
+
+    user = G.build_user_message(game_state, menu, trigger=trigger)
+    if "Computed optimal" in user:
+        # A solver line would be combat math computed from fabricated card
+        # stats, and can restate the gold answer. Fail closed.
+        return None, "solver_line_rendered"
+    if user.count("Legal: (pick by number)") != 1:
+        return None, "menu_header_not_production"
+
+    meta = {
+        "game_id": row.get("game_id", ""),
+        "turn": row.get("turn", 0),
+        "phase": row.get("phase", ""),
+        "outcome": outcome,
+        "actor": row.get("actor", ""),
+        "session": row.get("session", ""),
+        "decision_kind": kind,
+        "prompt_shape": "production_legal_menu",
+        "system_is_autopilot_prompt": True,
+        "trigger": trigger,
+        "answer_pick": answer_idx,
+        "menu_size": len(menu),
+        "creature": row.get("creature", ""),
+        "mcts_counts": row.get("mcts_counts", {}),
+        "mcts_scores": row.get("mcts_scores", {}),
+        "provenance": row.get("provenance", {}),
+        "combat_chain": row.get("_chain", ""),
+    }
+    if kind == "attack_commit":
+        meta["attack_committed"] = bool(row.get("attack_committed"))
+        meta["declared_before"] = row.get("declared_before", [])
+    else:
+        meta["candidates"] = row.get("candidates", [])
+        meta["blocked_attacker"] = row.get("blocked_attacker")
+        meta["block_class"] = (
+            "no_block" if row.get("blocked_attacker") is None else "block"
+        )
+        meta["possible_targets"] = row.get("possible_targets")
+        meta["assignments_before"] = row.get("assignments_before", {})
+        meta["duplicate_candidates"] = bool(row.get("duplicate_candidates"))
+
+    record = {
+        "system": BRIDGE.AUTOPILOT_SYSTEM_PROMPT,
+        "user": user,
+        "response": json.dumps({"actions": [{"pick": answer_idx}]}),
+        "source": SOURCE,
+        "attribution": ATTRIBUTION,
+        "kind": kind,
+        "meta": meta,
+    }
+    # The label must not be readable from the prompt: both menu options are
+    # present by design (that is the pick mechanism), but no MCTS artifact
+    # may appear.
+    assert "score:" not in user and "count:" not in user, "MCTS leak in prompt"
+    return record, ""
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Extract MageZero combat micro-decisions into decisions JSONL."
+    )
+    ap.add_argument("--log", required=True, action="append", dest="logs")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--report", action="store_true")
+    args = ap.parse_args(argv)
+
+    all_rows: list[dict] = []
+    total_acct: Counter = Counter()
+    for lp in args.logs:
+        rows, acct = parse_combat_log(lp)
+        verify_accounting(acct)
+        all_rows.extend(rows)
+        total_acct.update(acct)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        for r in all_rows:
+            clean = {k: v for k, v in r.items() if not k.startswith("_")}
+            f.write(json.dumps(clean, ensure_ascii=False, sort_keys=True) + "\n")
+
+    if args.report:
+        print("=" * 60, file=sys.stderr)
+        print("MAGEZERO COMBAT MICRO-DECISION SCAN", file=sys.stderr)
+        print("=" * 60, file=sys.stderr)
+        print(f"  rows emitted: {len(all_rows)}", file=sys.stderr)
+        for k in sorted(total_acct):
+            print(f"  {k}: {total_acct[k]}", file=sys.stderr)
+        hist = combat_histograms(all_rows)
+        print_floor_check(hist)
+        print(f"  output: {out_path.resolve()}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -50,6 +50,7 @@ for p in [str(SRC), str(REPO)]:
 
 # ── WP-3 module imports ───────────────────────────────────────────────────
 from tools.training import build_magezero_bridge as BRIDGE
+from tools.training import magezero_combat_micro as COMBAT
 from tools.training import magezero_filters as FILTERS
 from tools.training import parse_magezero_log as PARSER
 
@@ -209,10 +210,17 @@ def stage_render(
     splits: dict[str, list[dict]],
     split_filter_counts: dict[str, Counter],
     attackers_blockers_counts: dict[str, int],
+    include_combat: bool = False,
 ) -> dict[str, list[dict]]:
-    """Render priority rows in each split via build_record.
+    """Render rows in each split via the kind-appropriate builder.
 
-    Attackers/blockers rows are skipped and counted per split.
+    * ``priority`` rows -> build_magezero_bridge.build_record (unchanged).
+    * ``attack_commit`` / ``block_assign`` rows -> magezero_combat_micro.
+      build_combat_record, only when ``include_combat`` (they cannot appear
+      otherwise; if one does with the flag off, it is counted, not rendered).
+    * legacy ``attackers``/``blockers`` rows are skipped and counted per
+      split, exactly as before (#453: those labels were fabricated upstream).
+
     Returns {split_name: [training_records]}.
     """
     result: dict[str, list[dict]] = {}
@@ -225,7 +233,13 @@ def stage_render(
             if kind in ("attackers", "blockers"):
                 drops[f"dk_{kind}"] += 1
                 continue
-            record, reason = BRIDGE.build_record(row)
+            if kind in ("attack_commit", "block_assign"):
+                if not include_combat:
+                    drops[f"dk_{kind}_flag_off"] += 1
+                    continue
+                record, reason = COMBAT.build_combat_record(row)
+            else:
+                record, reason = BRIDGE.build_record(row)
             if record is None:
                 drops[reason] += 1
                 continue
@@ -359,6 +373,7 @@ def stage_write(
     pass_rate: float,
     attackers_blockers_total: int,
     elapsed: float,
+    combat_info: dict[str, Any] | None = None,
 ) -> dict:
     """Write per-split JSONL files and manifest. Returns manifest dict."""
     outdir.mkdir(parents=True, exist_ok=True)
@@ -375,6 +390,33 @@ def stage_write(
         "filter_counts": dict(filter_counts),
         "splits": {},
     }
+
+    if combat_info is not None:
+        hist = combat_info.get("histograms_filtered", {})
+        manifest["combat"] = {
+            "included": True,
+            "accounting": combat_info.get("accounting", {}),
+            "filter_counts": combat_info.get("filter_counts", {}),
+            "histograms_raw": combat_info.get("histograms_raw", {}),
+            "histograms_filtered": hist,
+            "floor_breach": bool(hist.get("floor_breach", False)),
+        }
+        # Rendered combat record counts per split (post-render truth).
+        by_split: dict[str, dict[str, int]] = {}
+        for split_name, records in rendered.items():
+            c: Counter = Counter(
+                rec.get("kind", "?")
+                for rec in records
+                if rec.get("kind") in ("attack_commit", "block_assign")
+            )
+            by_split[split_name] = dict(c)
+        manifest["combat"]["rendered_by_split"] = by_split
+        manifest["combat"]["rendered_attack"] = sum(
+            v.get("attack_commit", 0) for v in by_split.values()
+        )
+        manifest["combat"]["rendered_block"] = sum(
+            v.get("block_assign", 0) for v in by_split.values()
+        )
 
     for split_name in sorted(rendered.keys()):
         records = rendered[split_name]
@@ -483,6 +525,40 @@ def stage_report(
         pass
     lines.append("(Counted and excluded before split rendering — no attackers/blockers appear in any split.)")
     lines.append("")
+    combat = manifest.get("combat")
+    if combat:
+        lines.append("## Combat Micro-Decisions (--include-combat)")
+        lines.append("")
+        lines.append(
+            f"Rendered: {combat.get('rendered_attack', 0)} attack_commit + "
+            f"{combat.get('rendered_block', 0)} block_assign"
+        )
+        hist = combat.get("histograms_filtered", {})
+        lines.append("")
+        lines.append("Post-filter class histograms (pre-registered floors:")
+        lines.append(
+            f"no_block {COMBAT.NO_BLOCK_FLOOR:.0%}, all-in {COMBAT.ALL_IN_FLOOR:.1%}):"
+        )
+        lines.append("")
+        lines.append(f"- attack records: {hist.get('attack_records', 0)} — {hist.get('attack_hist', {})}")
+        lines.append(
+            f"- attack chains: {hist.get('attack_chains', 0)} — {hist.get('attack_chain_hist', {})}"
+            f" (all-in share {hist.get('all_in_share', 0.0):.1%})"
+        )
+        lines.append(
+            f"- block records: {hist.get('block_records', 0)} — {hist.get('block_hist', {})}"
+            f" (no-block share {hist.get('no_block_share', 0.0):.1%})"
+        )
+        if combat.get("floor_breach"):
+            lines.append("")
+            lines.append("**TRIVIAL-POLICY FLOOR BREACHED — not rebalanced; gate decision is the owner's.**")
+        lines.append("")
+        lines.append("Drop/accounting ledger (scanner):")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(combat.get("accounting", {}), indent=2, sort_keys=True))
+        lines.append("```")
+        lines.append("")
     lines.append("## Split Sizes")
     lines.append("")
     lines.append("| Split | Records |")
@@ -525,12 +601,69 @@ def stage_report(
 # ---------------------------------------------------------------------------
 
 
+def stage_combat(
+    log_paths: list[Path],
+    raw_decisions: list[dict],
+    outdir: Path,
+) -> tuple[list[dict], dict[str, Any]]:
+    """Scan the same logs for combat micro-decisions (--include-combat only).
+
+    Outcomes and sessions are JOINED from the priority parse by game_id —
+    game numbering is identical by construction (same die-roll boundaries,
+    same per-thread counters), so a combat row inherits the calibrated
+    outcome of its game. A game with no priority row keeps the scanner's
+    life-inferred outcome (usually "unknown", which the outcome filter then
+    drops and counts).
+    """
+    combat_rows: list[dict] = []
+    total_acct: Counter = Counter()
+    for lp in log_paths:
+        print(f"  Combat-scanning {lp} ...", end=" ", flush=True)
+        rows, acct = COMBAT.parse_combat_log(str(lp))
+        COMBAT.verify_accounting(acct)
+        combat_rows.extend(rows)
+        total_acct.update(acct)
+        print(f"{len(rows)} combat rows")
+
+    outcome_map: dict[str, str] = {}
+    session_map: dict[str, str] = {}
+    for d in raw_decisions:
+        gid = d.get("game_id", "")
+        if gid:
+            outcome_map[gid] = d.get("outcome", "unknown")
+            session_map[gid] = d.get("session", "")
+    joined = 0
+    for r in combat_rows:
+        gid = r.get("game_id", "")
+        if gid in outcome_map:
+            r["outcome"] = outcome_map[gid]
+            r["session"] = session_map[gid]
+            joined += 1
+        else:
+            total_acct["note_outcome_join_miss"] += 1
+    print(
+        f"  outcome join: {joined}/{len(combat_rows)} rows joined to the "
+        f"priority parse ({total_acct.get('note_outcome_join_miss', 0)} misses "
+        f"keep the scanner's life-inferred outcome)"
+    )
+
+    combat_path = outdir / "combat_decisions.jsonl"
+    with open(combat_path, "w", encoding="utf-8") as f:
+        for r in combat_rows:
+            f.write(json.dumps(r, sort_keys=True, ensure_ascii=False) + "\n")
+    print(f"  Wrote {len(combat_rows)} combat decisions -> {combat_path}")
+
+    info: dict[str, Any] = {"accounting": dict(total_acct)}
+    return combat_rows, info
+
+
 def run_pipeline(
     log_paths: list[Path],
     outdir: Path,
     max_pass_frac: float = 0.40,
     seed: int = 7,
     balance: str | None = None,
+    include_combat: bool = False,
 ) -> dict[str, Any]:
     """Run the full WP-3 pipeline.
 
@@ -551,6 +684,13 @@ def run_pipeline(
             f.write(json.dumps(d, sort_keys=True, ensure_ascii=False) + "\n")
     print(f"  Wrote {raw_count} decisions -> {decisions_path}")
 
+    # ── Stage 1b: Combat micro-decision scan (--include-combat only) ──────
+    combat_rows: list[dict] = []
+    combat_info: dict[str, Any] | None = None
+    if include_combat:
+        print("Stage 1b — Combat micro-decision scan (magezero_combat_micro)")
+        combat_rows, combat_info = stage_combat(log_paths, raw_decisions, outdir)
+
     # ── Stage 2: Filter ────────────────────────────────────────────────────
     print("Stage 2/5 — Filter decisions")
     filtered, filter_counts = stage_filter(
@@ -566,12 +706,44 @@ def run_pipeline(
     print(f"  Wrote {filtered_count} filtered -> {filtered_path}")
 
     # ── Stage 3: Tripwire ──────────────────────────────────────────────────
+    # The pass-rate tripwire is computed on the PRIORITY corpus only, exactly
+    # as pre-registered. Combat rows are filtered separately below and never
+    # dilute the pass fraction — a 56%-pass priority corpus must still trip
+    # even when thousands of combat rows are added.
     print("Stage 3/5 — Pass rate tripwire")
     pass_rate = stage_tripwire(filtered, max_pass_frac)
 
+    # ── Stage 2b: Filter combat rows (separately, counted separately) ─────
+    combat_filtered: list[dict] = []
+    if include_combat:
+        print("Stage 2b — Filter combat rows")
+        combat_filtered, cn1 = FILTERS.drop_single_option(combat_rows)
+        print(f"  drop_single_option: {cn1} dropped ({len(combat_filtered)} kept)")
+        combat_filtered, cn2 = FILTERS.outcome_filter(combat_filtered, "won_only")
+        print(f"  outcome_filter (won_only): {cn2} dropped ({len(combat_filtered)} kept)")
+        combat_filtered, cn3 = FILTERS.dedupe(combat_filtered)
+        print(f"  dedupe: {cn3} dropped ({len(combat_filtered)} kept)")
+        assert combat_info is not None
+        combat_info["filter_counts"] = {
+            "drop_single_option": cn1,
+            "outcome_filter": cn2,
+            "dedupe": cn3,
+        }
+        # Class histograms + pre-registered trivial-policy floors, on both the
+        # raw scan and the post-filter corpus (the one that trains).
+        combat_info["histograms_raw"] = COMBAT.combat_histograms(combat_rows)
+        combat_info["histograms_filtered"] = COMBAT.combat_histograms(combat_filtered)
+        print("  Combat histograms (raw scan):")
+        COMBAT.print_floor_check(combat_info["histograms_raw"], out=sys.stdout)
+        print("  Combat histograms (post-filter):")
+        COMBAT.print_floor_check(combat_info["histograms_filtered"], out=sys.stdout)
+
     # ── Stage 4: Split ─────────────────────────────────────────────────────
+    # Split on the UNION so that all rows of a game — priority and combat —
+    # land in the same split (game-level leak safety across kinds).
     print("Stage 4/5 — Split by game")
-    splits = FILTERS.split_by_game(filtered, seed=seed)
+    split_input = filtered + combat_filtered if include_combat else filtered
+    splits = FILTERS.split_by_game(split_input, seed=seed)
     for name, group in splits.items():
         unique_games = len(set(FILTERS._game_id(r) for r in group))
         print(f"  split '{name}': {len(group)} rows ({unique_games} games)")
@@ -583,7 +755,7 @@ def run_pipeline(
     # ── Stage 5: Render ────────────────────────────────────────────────────
     print("Stage 5/5 — Render training records via build_magezero_bridge")
     split_drops: dict[str, Counter] = {}
-    rendered = stage_render(splits, split_drops, {})
+    rendered = stage_render(splits, split_drops, {}, include_combat=include_combat)
 
     # Surface the per-reason drop tally. It was computed into split_drops and
     # then never read, so the PR body's claim about WHY rows were dropped could
@@ -602,8 +774,10 @@ def run_pipeline(
             print(f"    {reason}: {n}")
 
     # ── Leak scan ──────────────────────────────────────────────────────────
+    # Combat rows' MCTS counts join the scan set so a combat count leaking
+    # into ANY prompt (priority or combat) is caught.
     print("Leak scan — checking rendered prompts for training-set artifacts...")
-    stage_leak_scan(rendered, raw_decisions)
+    stage_leak_scan(rendered, raw_decisions + combat_rows)
 
     # ── Write output ────────────────────────────────────────────────────────
     elapsed = time.time() - t0
@@ -616,6 +790,7 @@ def run_pipeline(
         pass_rate,
         attackers_blockers_total,
         elapsed,
+        combat_info=combat_info,
     )
 
     # ── Report ──────────────────────────────────────────────────────────────
@@ -639,6 +814,15 @@ def run_pipeline(
     print(f"  Training records:  {total_records}")
     print(f"  Attackers/blockers excluded: {attackers_blockers_total}")
     print(f"  Pass rate:         {pass_rate:.4f} ({pass_rate * 100:.1f}%)")
+    if include_combat and combat_info is not None:
+        print(
+            f"  Combat rows:       {len(combat_rows)} scanned, "
+            f"{len(combat_filtered)} post-filter, "
+            f"{manifest.get('combat', {}).get('rendered_attack', 0)} attack + "
+            f"{manifest.get('combat', {}).get('rendered_block', 0)} block rendered"
+        )
+        if manifest.get("combat", {}).get("floor_breach"):
+            print("  ** COMBAT TRIVIAL-POLICY FLOOR BREACHED — see manifest **")
     print(f"  Elapsed:           {elapsed:.1f}s")
     print(f"  Output:            {outdir}")
 
@@ -687,6 +871,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Drop surplus PRIORITY passes to meet --max-pass-frac before the "
         "tripwire (see magezero_filters.downsample_passes). Combat declines are "
         "never dropped. Off by default so the raw corpus shape is not altered.",
+    )
+    parser.add_argument(
+        "--include-combat",
+        action="store_true",
+        default=False,
+        help="Also extract combat micro-decisions (attack_commit/block_assign) "
+        "via magezero_combat_micro and render them into the same splits. "
+        "OFF by default: without this flag the pipeline output is unchanged.",
     )
     return parser
 
@@ -762,6 +954,7 @@ def main(argv: list[str] | None = None) -> int:
             max_pass_frac=args.max_pass_frac,
             seed=args.seed,
             balance=args.balance,
+            include_combat=args.include_combat,
         )
     except SystemExit as e:
         if e.code == 42:

--- a/tools/training/wp3/PROGRESS-wp3-combat-adapter2.md
+++ b/tools/training/wp3/PROGRESS-wp3-combat-adapter2.md
@@ -1,0 +1,175 @@
+# PROGRESS — wp3-combat-adapter2 (MageZero COMBAT micro-decision adapter)
+
+Date: 2026-07-30. Source log: /home/joshu/mz_train_smoke.log (210MB, 594 games,
+6 XMage threads). Context: #453 found 89/90 fabricated combat labels in the old
+adapter (build_magezero_combat.py, now fail-closed to zero); the retraction in
+rl-pipeline-fix.md ("COMBAT IS BLOCKED UPSTREAM — RETRACTED") identified the
+real per-creature emitters this adapter consumes.
+
+## What was built
+
+- `tools/training/magezero_combat_micro.py` — streaming scanner + renderer.
+  - Attack micro-decisions: `base choose use attack with: <name>?` opener ->
+    binary `DECLARE_ATTACKERS*pool= actions: [false ...] [true ...]` ->
+    `use attack with: <name>?: true|false` resolution, all paired by thread
+    tag with a 12 same-thread-line pool window. Kind `attack_commit`.
+  - Block micro-decisions: `choose which creature to block for <blocker>`
+    opener gates the `DECLARE_BLOCKERS*pool=` and the `Targeting <attacker>` /
+    `Targeting Stop Choosing` resolution. A bare `Targeting` line is NEVER
+    a block (4,296 spell-targeting lines correctly bypassed). Kind
+    `block_assign`.
+  - Board/hand context from the thread's own battlefield state machine
+    (same grammar as parse_magezero_log, incl. the #430 emitter-attribution
+    rules); a record requires a complete MCTS printBattlefieldScore block on
+    the same thread, same game, within 800 same-thread lines — else dropped
+    and counted.
+  - `verify_accounting()` asserts the closed ledger (every seen line is
+    emitted or counted) and runs on every scan, including in the pipeline.
+  - Renderer emits production-shaped records (AUTOPILOT_SYSTEM_PROMPT +
+    gate_play_decisions.build_user_message, `combat_attackers` /
+    `combat_blockers` triggers, `{"pick": N}` answers). MCTS counts/scores
+    stay in `meta`; an assert plus the pipeline leak scan enforce that no
+    `score:`/`count:` text reaches a prompt. OPP cards are never marked
+    is_attacking (MageZero has no P/T; the production formatter would run its
+    block solver on fabricated 0/0s and could restate a no-block answer —
+    a label leak). The attacker roster reaches the model via the menu rows,
+    which are log-authoritative.
+- `tools/training/run_wp3_pipeline.py` — `--include-combat` flag, default
+  OFF (default behavior unchanged; a combat row appearing with the flag off
+  is counted, not rendered). Combat rows are filtered separately (the
+  pass-rate tripwire stays priority-only as pre-registered), split together
+  with priority rows by game (cross-kind game-level leak safety), rendered,
+  leak-scanned, and reported in manifest + REPORT.md.
+- Tests: `tests/test_magezero_combat_micro.py` (27 tests) on
+  `tools/training/wp3/fixtures/fixture_combat_interleaved.log` — a REAL,
+  unmodified 261-line excerpt of the smoke log with all 6 threads
+  interleaved (13/13 sampled lines verified verbatim against the source) —
+  plus synthetic orphan fixtures proving fail-closed drops (orphan
+  resolution, opener-name mismatch, missing/previous-game board context,
+  cross-thread pool, intervening priority decision, spell-targeting
+  bypass, chosen-not-in-pool).
+- `tools/training/wp3/sample_combat_records.py` — eyeball helper (renders
+  sampled records next to the raw log lines their provenance points at).
+
+## Measured numbers (full smoke log)
+
+Scanner (standalone, `--report`):
+
+- 3,213 attack_commit + 788 block_assign = 4,001 rows.
+- Accounting ledger (all identities asserted):
+  - seen_attack_openers 3,352; seen_attack_resolutions 3,352;
+    seen_attack_pools_binary 3,289; emitted_attack 3,213;
+    drop_attack_resolution_without_pool 139
+    (pool abandoned: 41 at_priority_decision, 29 by_noncombat_pool,
+    4 by_block_opener, 2 replaced_by_new_pool = 76; plus 63 searches that
+    never printed a binary pool, see reconciliation).
+  - seen_block_openers 1,088; seen_targeting_total 5,384 =
+    4,296 nonblock (spell targeting) + 1,088 block-gated;
+    seen_block_pools_gated 788; emitted_block 788;
+    drop_block_targeting_without_pool 300.
+  - Zero drops for missing/stale board context (MCTS prints the battlefield
+    at every search; context gap p50/p90/p99/max = 45/111/223/578
+    same-thread lines, window 800).
+
+Class histograms (raw scan) vs pre-registered trivial-policy floors:
+
+- attack records: {attack: 2,296, no_attack: 917} — attack share 71.5%.
+- attack chains: 2,355 {all_in: 1,558, no_attack: 428, proper_subset: 369}
+  — **all-in share 66.2% vs 38.6% floor: BREACHED.**
+- block records: {no_block: 398, block: 390} — no-block share 50.5% vs 69%
+  floor: not breached.
+- Post-filter (won_only + dedupe, the corpus that trains): all-in 74.4%
+  (still breached), no-block 51.1% (not breached). NOT rebalanced;
+  `combat.floor_breach: true` recorded in the manifest, loud banner in the
+  report. Gate decision is the owner's.
+
+Pipeline end-to-end (`--include-combat --balance downsample-pass`):
+
+- 21,609 priority decisions + 4,001 combat rows scanned; outcome join
+  4,001/4,001 by game_id (game numbering is shared with the priority parser
+  by construction).
+- Combat post-filter: 1,478 (2,505 dropped by won_only, 18 dedupe, 0
+  single-option). All 1,478 rendered: 1,304 attack_commit + 174
+  block_assign, distributed train/val/test by game together with priority
+  rows. Leak scan: 0 violations. Manifest carries the full accounting,
+  filter counts, both histograms, floor_breach, and per-split rendered
+  combat counts.
+- Without `--balance downsample-pass` the pipeline aborts on the
+  pre-existing PRIORITY pass-rate tripwire (43.8% > 40%) — unrelated to
+  combat (combat rows never enter that computation).
+
+## Reconciliation vs raw grep (every gap explained)
+
+- `grep -ac "attack with"` = 6,705 = 3,352 openers + 3,352 resolutions + 1
+  card-text mention ("Whenever you attack with one or more Lizards" inside a
+  DECLARE_ATTACKERS2 pool line, L~..., thread-5 21:58:22) — verified by
+  inverse grep.
+- 3,352 resolutions -> 3,213 emitted + 139 dropped without a usable pool:
+  76 pools were invalidated by an intervening decision-class event on the
+  same thread (counted per reason above); the remaining 63 searches never
+  printed a binary pool at all. Eyeballed instances show the MCTS reusing a
+  cached tree ("required visits reached, ending search", "Ran 1
+  simulations", COMPOSITE CHILDREN: [999] — single root child), so
+  MCTSNode.bestChild has no alternatives to print. No pool = no MCTS
+  stats = fail-closed drop.
+- `grep -ac "choose which creature to block"` = 1,088 openers -> 788
+  emitted + 300 dropped without a DECLARE_BLOCKERS pool. Measured on the
+  raw log: 172 of the 300 had `possible targets: 1` (XMage auto-picks a
+  forced choice without running a search — no pool exists); the other 128
+  are the same cached-tree/no-bestChild-print pattern as the attacks
+  (verified on raw excerpts, e.g. thread-5 L3894-3906).
+- `Targeting` grep total 5,384: 1,088 attributed to gated block windows,
+  4,296 correctly rejected as spell targeting.
+
+## Manual record validation (requirement 8)
+
+Rendered 5 attack + 5 block records (seed 42, sample_combat_records.py) and
+checked each against the raw log lines in its provenance:
+
+- All 10: opener/pool/resolution on the same thread, adjacent, creature name
+  identical, pick matches the logged verdict/Targeting, and the pool argmax
+  agrees with the resolution (incl. a declined attack: false 0.546 > true
+  0.525 -> pick 2, and a chosen block: 0.571 > 0.533 -> pick 1).
+- Board owner correct in all 10 (blocker under YOUR BOARD, attacker
+  candidates under OPP BOARD / menu; block records set active_player=OPP).
+- No label leak: no `score:`/`count:` text in any prompt; the answer is not
+  recoverable from the prompt (both/all menu options are present by design —
+  that IS the pick mechanism).
+- One soft spot found and quantified: board context can be stale within the
+  window — in one sampled block record the blocker was missing from the
+  printed YOUR BOARD (cast after the last battlefield print). Rates on the
+  full corpus: creature_on_board true for 3,209/3,213 attacks (99.9%) and
+  750/788 blocks (95.2%); every record carries `provenance.creature_on_board`
+  (and blocks `attackers_on_board`/`attackers_total`) so downstream can
+  filter harder if desired. `possible_targets_matches_pool` true for
+  634/788.
+
+## Tests
+
+- `tests/test_magezero_combat_micro.py`: 27/27 pass
+  (`/home/joshu/venv-train/bin/python3 -m pytest`).
+- Full suite (`PYTHONPATH=src:. pytest tests -q --ignore
+  tests/test_draft_guidance_wiring.py`): 1,422 passed, 4 failed, 28
+  skipped. The 4 failures are environment-only in modules this branch does
+  not touch (missing `PIL` and `mcp` packages in venv-train; the FastMCP
+  mocks are test-order dependent) — the same modules error at collection on
+  a clean checkout of master in this venv. test_draft_guidance_wiring is
+  excluded for the same missing-`mcp` reason.
+
+## Not verified / known limits
+
+- Chain-level "all_in" classification uses emitted rows only: a chain that
+  lost a micro-decision to a fail-closed drop is classified from the
+  surviving rows (drops are ~4% of resolutions, so the effect is small,
+  but it is not zero).
+- Board context freshness is bounded (800 same-thread lines + same-game),
+  not exact: ~0.1% of attack and ~4.8% of block records name a creature not
+  present in the printed board snapshot (flagged per-record, see above).
+- Duplicate attacker names in a block pool cannot be mapped to instances
+  (the log has names only); menus disambiguate with "#k" and `chosen` maps
+  to the first occurrence, which is name-accurate. `duplicate_candidates`
+  is set on those records.
+- Outcome for combat rows joins the priority parser's calibrated outcome by
+  game_id (4,001/4,001 joined on the smoke log); a hypothetical game with
+  zero priority decisions would fall back to the scanner's life-inferred
+  outcome.

--- a/tools/training/wp3/fixtures/fixture_combat_interleaved.log
+++ b/tools/training/wp3/fixtures/fixture_combat_interleaved.log
@@ -1,0 +1,261 @@
+INFO  2026-07-28 21:34:05,161 Total: simulated 2586 evaluations in 23.68699819 seconds - Average: 109.17381676044279     =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,161 0 illegals purged, 37 valid duplicates purged, 11 invalid duplicates purged.               =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,161 PRECOMBAT_MAIN0pool= actions: [Pass score: 0.014 count: 117] [Cast Combat Research score: 0.115 count: 678]  =>[pool-3-thread-1] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:05,163 base choose target Cast Combat Research                                                    =>[pool-3-thread-1] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:05,163 possible targets: 1                                                                        =>[pool-3-thread-1] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:05,164 playable abilities: [Cast Combat Research, Pass]                                           =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,164 [4:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Combat Research success ratio: 0.1148229506068113 =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,164 [4:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:20]                    =>[pool-3-thread-1] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:05,164 [PlayerA], life = 20                                                                       =>[pool-3-thread-1] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,164 -> Hand: [Negate; Soul Partition; Skrelv, Defector Mite; Meticulous Archive]               =>[pool-3-thread-1] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,164 -> Permanents: [Seachrome Coast,tapped; Skrelv, Defector Mite; Island,tapped]              =>[pool-3-thread-1] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,164 -> Permanents: [Mountain,tapped; Mountain,tapped]                                          =>[pool-3-thread-1] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,166 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,170 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,176 STARTING ROOT VISITS: 678                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,932 timed out, ending search                                                                   =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,932 Pending Nodes: 0                                                                           =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,932 Ran 260 simulations.                                                                       =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,933 COMPOSITE CHILDREN: [324, 326]                                                             =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,933 Player: PlayerA simulated 260 evaluations in 2.006033723 seconds - nodes in tree: 1316     =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,933 Total: simulated 2685 evaluations in 24.508289450999996 seconds - Average: 109.55476943293755 =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,933 0 illegals purged, 21 valid duplicates purged, 0 invalid duplicates purged.                =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,933 PRECOMBAT_MAIN1 (top: Cast Combat Research)pool= actions: [Hired Claw score: 0.055 count: 324] [Sleep-Cursed Faerie score: 0.055 count: 326]  =>[pool-3-thread-6] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:05,972 required visits reached, ending search                                                     =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,979 Targeting Sleep-Cursed Faerie                                                              =>[pool-3-thread-6] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:05,979 Pending Nodes: 0                                                                           =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,979 Ran 218 simulations.                                                                       =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,979 COMPOSITE CHILDREN: [258, 741]                                                             =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,980 Player: PlayerA simulated 218 evaluations in 1.967433253 seconds - nodes in tree: 1784     =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,980 Total: simulated 2997 evaluations in 24.313928567 seconds - Average: 123.26268014407464    =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,980 0 illegals purged, 26 valid duplicates purged, 4 invalid duplicates purged.                =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,980 UPKEEP0pool= actions: [Pass score: -0.233 count: 258] [Cast Malcolm, Alluring Scoundrel score: -0.183 count: 741]  =>[pool-3-thread-5] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:05,981 playable abilities: [Cast Bounce Off, Cast Combat Research, Cast Combat Research, Cast Shardmage's Rescue, Cast Kitsa, Otterball Elite, {1}{U}: Untap {this}., Pass] =>[pool-3-thread-6] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,981 [3:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Combat Research success ratio: 0.05429622374279548 =>[pool-3-thread-6] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,981 [3:Precombat Main:PRECOMBAT_MAIN][player PlayerA:19][player PlayerB:20]                    =>[pool-3-thread-6] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:05,981 [PlayerA], life = 19                                                                       =>[pool-3-thread-6] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,981 -> Hand: [Bounce Off; Combat Research; Shardmage's Rescue; Kitsa, Otterball Elite]         =>[pool-3-thread-6] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,981 -> Permanents: [Adarkar Wastes; Sleep-Cursed Faerie,tapped; Island,tapped]                 =>[pool-3-thread-6] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,981 -> Permanents: [Mountain,tapped; Hired Claw]                                               =>[pool-3-thread-6] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,982 playable abilities: [Cast Malcolm, Alluring Scoundrel, Pass]                               =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,982 [5:Beginning:UPKEEP]chose action:Cast Malcolm, Alluring Scoundrel success ratio: -0.18283560149873831 =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,982 [5:Beginning:UPKEEP][player PlayerA:17][player PlayerB:20]                                 =>[pool-3-thread-5] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:05,982 [PlayerA], life = 17                                                                       =>[pool-3-thread-5] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,982 -> Hand: [Adarkar Wastes; Floodfarm Verge; No More Lies; Shardmage's Rescue; Kitsa, Otterball Elite; Spell Pierce] =>[pool-3-thread-5] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,982 -> Permanents: [Island,tapped; Island,tapped]                                              =>[pool-3-thread-5] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,982 -> Permanents: [Mountain; Mountain; Razorkin Needlehead]                                   =>[pool-3-thread-5] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:05,985 auto pass                                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,987 STARTING ROOT VISITS: 326                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,989 timed out, ending search                                                                   =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:05,990 auto pass                                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:05,993 auto pass                                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,010 STARTING ROOT VISITS: 229                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:06,025 ===> SELECTED ACTION for PlayerB: Emberheart Challenger [1d6]: Cast Emberheart Challenger  =>[pool-3-thread-5] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:06,027 found matching root with 738 visits                                                        =>[pool-3-thread-5] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:06,030 auto pass                                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,032 auto pass                                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,038 STARTING ROOT VISITS: 336                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:06,078 timed out, ending search                                                                   =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:06,082 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,085 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,086 [PlayerB], life = 20, score = 2485 (Life:10000, Hand:20, Perm:2775)                        =>[pool-3-thread-3] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,086 -> Hand: [Ojer Axonil, Deepest Might:5; Burnout Bashtronaut:5; Burnout Bashtronaut:5; Razorkin Needlehead:5] =>[pool-3-thread-3] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,086 -> Permanents: [Mountain,tapped:280; Hired Claw:2215; Mountain,tapped:280]                 =>[pool-3-thread-3] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,086 -> Graveyard: [Full Bore]                                                                  =>[pool-3-thread-3] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,087 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,088 [4:Beginning:UPKEEP]PlayerA hand: : Meticulous Archive,No More Lies,Soul Partition,Combat Research,Malcolm, Alluring Scoundrel,Combat Research, =>[pool-3-thread-3] ComputerPlayer.logList 
+INFO  2026-07-28 21:34:06,089 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,091 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,098 STARTING ROOT VISITS: 449                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:06,608 timed out, ending search                                                                   =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:06,614 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,617 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,619 [PlayerB], life = 20, score = 385 (Life:10000, Hand:30, Perm:560)                          =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,619 -> Hand: [Mountain:5; Mountain:5; Lightning Strike:5; Nova Hellkite:5; Mountain:5; Emberheart Challenger:5] =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,619 -> Permanents: [Mountain,tapped:280; Mountain,tapped:280]                                  =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,619 -> Graveyard: [Burst Lightning]                                                            =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:06,620 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,621 [5:Beginning:UPKEEP]PlayerA hand: : Island,Meticulous Archive,No More Lies,Combat Research,Combat Research, =>[pool-3-thread-2] ComputerPlayer.logList 
+INFO  2026-07-28 21:34:06,622 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,625 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:06,632 STARTING ROOT VISITS: 778                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,183 timed out, ending search                                                                   =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,190 base choose use attack with: Skrelv, Defector Mite?                                        =>[pool-3-thread-1] ComputerPlayerMCTS.chooseUse 
+INFO  2026-07-28 21:34:07,194 prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[]}       =>[pool-3-thread-1] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:07,194 opponent prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[Pass]} =>[pool-3-thread-1] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:07,195 STARTING ROOT VISITS: 806                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 timed out, ending search                                                                   =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 Pending Nodes: 0                                                                           =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 Ran 189 simulations.                                                                       =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 COMPOSITE CHILDREN: [504]                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 Player: PlayerA simulated 189 evaluations in 2.001516726 seconds - nodes in tree: 980      =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,989 Total: simulated 2874 evaluations in 26.509806176999994 seconds - Average: 108.41271266983057 =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:07,990 0 illegals purged, 24 valid duplicates purged, 8 invalid duplicates purged.                =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,001 STARTING ROOT VISITS: 504                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,020 timed out, ending search                                                                   =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,026 ===> SELECTED ACTION for PlayerB: Pass                                                     =>[pool-3-thread-4] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:08,030 found matching root with 407 visits                                                        =>[pool-3-thread-4] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:08,038 STARTING ROOT VISITS: 406                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,045 timed out, ending search                                                                   =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,063 STARTING ROOT VISITS: 231                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,100 timed out, ending search                                                                   =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 Pending Nodes: 0                                                                           =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 Ran 204 simulations.                                                                       =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 COMPOSITE CHILDREN: [48, 513, 91]                                                          =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 Player: PlayerA simulated 204 evaluations in 2.002750069 seconds - nodes in tree: 1126     =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 Total: simulated 2891 evaluations in 25.984045095000006 seconds - Average: 111.26058277032094 =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 0 illegals purged, 7 valid duplicates purged, 0 invalid duplicates purged.                 =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,101 PRECOMBAT_MAIN0pool= actions: [Pass score: -0.291 count: 48] [Cast Combat Research score: -0.170 count: 513] [Play Meticulous Archive score: -0.228 count: 91]  =>[pool-3-thread-3] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:08,102 base choose target Cast Combat Research                                                    =>[pool-3-thread-3] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:08,102 possible targets: 1                                                                        =>[pool-3-thread-3] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:08,103 playable abilities: [Play Meticulous Archive, Cast Combat Research, Cast Combat Research, Pass] =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,103 [4:Precombat Main:PRECOMBAT_MAIN]chose action:Cast Combat Research success ratio: -0.1700671103135156 =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,103 [4:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:20]                    =>[pool-3-thread-3] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:08,103 [PlayerA], life = 20                                                                       =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,103 -> Hand: [Meticulous Archive; No More Lies; Soul Partition; Malcolm, Alluring Scoundrel; Combat Research; Shardmage's Rescue] =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,103 -> Permanents: [Island,tapped]                                                             =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,103 -> Permanents: [Mountain,tapped; Hired Claw; Mountain,tapped]                              =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,105 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,112 STARTING ROOT VISITS: 513                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,641 timed out, ending search                                                                   =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 Pending Nodes: 0                                                                           =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 Ran 217 simulations.                                                                       =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 COMPOSITE CHILDREN: [118, 448, 428]                                                        =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 Player: PlayerA simulated 217 evaluations in 2.009257283 seconds - nodes in tree: 1559     =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 Total: simulated 3388 evaluations in 27.177958471999997 seconds - Average: 124.65984166877273 =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 0 illegals purged, 45 valid duplicates purged, 0 invalid duplicates purged.                =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:08,642 PRECOMBAT_MAIN0pool= actions: [Pass score: -0.104 count: 118] [Play Island score: -0.056 count: 448] [Play Meticulous Archive score: -0.056 count: 428]  =>[pool-3-thread-2] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:08,642 playable abilities: [Play Island, Play Meticulous Archive, Play Island, Pass]              =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,642 [5:Precombat Main:PRECOMBAT_MAIN]chose action:Play Island success ratio: -0.055936018564980095 =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,642 [5:Precombat Main:PRECOMBAT_MAIN][player PlayerA:18][player PlayerB:20]                    =>[pool-3-thread-2] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:08,642 [PlayerA], life = 18                                                                       =>[pool-3-thread-2] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,642 -> Hand: [Island; Meticulous Archive; No More Lies; Combat Research; Combat Research]      =>[pool-3-thread-2] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,643 -> Permanents: [Island; Floodfarm Verge; Island]                                           =>[pool-3-thread-2] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,643 -> Permanents: [Mountain,tapped; Mountain,tapped]                                          =>[pool-3-thread-2] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:08,645 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:08,651 STARTING ROOT VISITS: 448                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,197 timed out, ending search                                                                   =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 Pending Nodes: 0                                                                           =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 Ran 213 simulations.                                                                       =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 COMPOSITE CHILDREN: [104, 867]                                                             =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 Player: PlayerA simulated 213 evaluations in 2.002673354 seconds - nodes in tree: 1982     =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 Total: simulated 2991 evaluations in 27.696506284999998 seconds - Average: 107.99196004081857 =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,198 0 illegals purged, 32 valid duplicates purged, 13 invalid duplicates purged.               =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:09,199 DECLARE_ATTACKERS0pool= actions: [false score: 0.013 count: 104] [true score: 0.147 count: 867]  =>[pool-3-thread-1] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:09,199 use attack with: Skrelv, Defector Mite?: true                                              =>[pool-3-thread-1] ComputerPlayerMCTS.chooseUse 
+INFO  2026-07-28 21:34:09,207 STARTING ROOT VISITS: 867                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 timed out, ending search                                                                   =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 Pending Nodes: 0                                                                           =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 Ran 260 simulations.                                                                       =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 COMPOSITE CHILDREN: [572, 159]                                                             =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 Player: PlayerA simulated 260 evaluations in 2.002476192 seconds - nodes in tree: 1363     =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 Total: simulated 3134 evaluations in 28.512282368999994 seconds - Average: 109.91754218201221 =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 0 illegals purged, 35 valid duplicates purged, 8 invalid duplicates purged.                =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,004 PRECOMBAT_MAIN0pool= actions: [Pass score: 0.050 count: 572] [Cast Shardmage's Rescue score: 0.016 count: 159]  =>[pool-3-thread-6] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:10,013 STARTING ROOT VISITS: 572                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,038 timed out, ending search                                                                   =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,052 STARTING ROOT VISITS: 545                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,066 timed out, ending search                                                                   =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,067 base choose target choose which creature to block for Malcolm, Alluring Scoundrel          =>[pool-3-thread-5] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:10,067 possible targets: 2                                                                        =>[pool-3-thread-5] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:10,070 prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[Pass]}   =>[pool-3-thread-5] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:10,070 opponent prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[]} =>[pool-3-thread-5] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:10,070 STARTING ROOT VISITS: 478                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,115 timed out, ending search                                                                   =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,115 Pending Nodes: 0                                                                           =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,115 Ran 223 simulations.                                                                       =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,115 COMPOSITE CHILDREN: [290, 445]                                                             =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,115 Player: PlayerA simulated 223 evaluations in 2.003357723 seconds - nodes in tree: 1430     =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,116 Total: simulated 3114 evaluations in 27.987402818000007 seconds - Average: 111.26434347088616 =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,116 0 illegals purged, 19 valid duplicates purged, 0 invalid duplicates purged.                =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,116 PRECOMBAT_MAIN0pool= actions: [Pass score: -0.185 count: 290] [Play Meticulous Archive score: -0.168 count: 445]  =>[pool-3-thread-3] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:10,117 playable abilities: [Play Meticulous Archive, Pass]                                        =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,117 [4:Precombat Main:PRECOMBAT_MAIN]chose action:Play Meticulous Archive success ratio: -0.16798117693820905 =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,117 [4:Precombat Main:PRECOMBAT_MAIN][player PlayerA:20][player PlayerB:20]                    =>[pool-3-thread-3] ComputerPlayerMCTS.logLife 
+INFO  2026-07-28 21:34:10,117 [PlayerA], life = 20                                                                       =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:10,117 -> Hand: [No More Lies; Soul Partition; Malcolm, Alluring Scoundrel; Combat Research; Shardmage's Rescue] =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:10,117 -> Permanents: [Island,tapped; Combat Research; Meticulous Archive,tapped]                 =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:10,117 -> Permanents: [Mountain,tapped; Hired Claw; Mountain,tapped]                              =>[pool-3-thread-3] ComputerPlayerMCTS.printBattlefieldScore 
+INFO  2026-07-28 21:34:10,120 auto pass                                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,122 base choose target When {this} enters, surveil 1.                                          =>[pool-3-thread-3] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:10,122 possible targets: 1                                                                        =>[pool-3-thread-3] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:10,127 prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[Play Meticulous Archive, Pass]} =>[pool-3-thread-3] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:10,127 opponent prefix at root: PlayerScript{targets=[], choices=[], uses=[], modes=[], priority=[Pass]} =>[pool-3-thread-3] ComputerPlayerMCTS2.getNextAction 
+INFO  2026-07-28 21:34:10,128 STARTING ROOT VISITS: 445                                                                  =>[pool-3-thread-3] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,351 required visits reached, ending search                                                     =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,380 STARTING ROOT VISITS: 998                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,396 required visits reached, ending search                                                     =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,405 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,407 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,410 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,415 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,417 [PlayerA], life = 20, score = 2383 (Life:10000, Hand:25, Perm:2548)                        =>[pool-3-thread-1] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:10,417 -> Hand: [Negate:5; Soul Partition:5; Skrelv, Defector Mite:5; Meticulous Archive:5; Soul Partition:5] =>[pool-3-thread-1] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:10,417 -> Permanents: [Seachrome Coast,tapped:280; Skrelv, Defector Mite,tapped:1588; Island,tapped:280; Combat Research:400] =>[pool-3-thread-1] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:10,417 -> Graveyard: [Bounce Off]                                                                 =>[pool-3-thread-1] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:10,419 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,423 [5:Beginning:UPKEEP]PlayerA hand: : Negate,Soul Partition,Skrelv, Defector Mite,Meticulous Archive,Soul Partition, =>[pool-3-thread-1] ComputerPlayer.logList 
+INFO  2026-07-28 21:34:10,424 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,428 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:10,652 timed out, ending search                                                                   =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,660 STARTING ROOT VISITS: 792                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:10,819 ===> SELECTED ACTION for PlayerB: Razorkin Needlehead [b56]: Cast Razorkin Needlehead      =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:10,821 found matching root with 998 visits                                                        =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:10,823 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,002 ===> SELECTED ACTION for PlayerB: Mountain [709]: Play Mountain                            =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,004 found matching root with 568 visits                                                        =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,025 ===> SELECTED ACTION for PlayerB: Full Bore [697]: Cast Full Bore -> Razorkin Needlehead [b56] =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,027 found matching root with 296 visits                                                        =>[pool-3-thread-1] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,032 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,037 auto pass                                                                                  =>[pool-3-thread-1] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,048 STARTING ROOT VISITS: 0                                                                    =>[pool-3-thread-1] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:11,625 required visits reached, ending search                                                     =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:11,633 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,636 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,638 [PlayerA], life = 18, score = -65 (Life:9600, Hand:25, Perm:900)                           =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:11,638 -> Hand: [Island:5; Meticulous Archive:5; No More Lies:5; Combat Research:5; Combat Research:5] =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:11,638 -> Permanents: [Island:300; Floodfarm Verge:300; Island:300]                               =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:11,638 -> Graveyard: [Bounce Off]                                                                 =>[pool-3-thread-2] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:11,639 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,642 [6:Beginning:UPKEEP]PlayerA hand: : Island,Meticulous Archive,No More Lies,Combat Research,Combat Research, =>[pool-3-thread-2] ComputerPlayer.logList 
+INFO  2026-07-28 21:34:11,643 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,646 auto pass                                                                                  =>[pool-3-thread-2] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:11,818 ===> SELECTED ACTION for PlayerB: Mountain [3b8]: Play Mountain                            =>[pool-3-thread-2] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,820 found matching root with 176 visits                                                        =>[pool-3-thread-2] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,908 ===> SELECTED ACTION for PlayerB: Nova Hellkite [83c]: Cast Nova Hellkite with Warp        =>[pool-3-thread-2] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,911 found matching root with 87 visits                                                         =>[pool-3-thread-2] ComputerPlayer8.act 
+INFO  2026-07-28 21:34:11,928 STARTING ROOT VISITS: 24                                                                   =>[pool-3-thread-2] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,017 timed out, ending search                                                                   =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,017 Pending Nodes: 0                                                                           =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,017 Ran 281 simulations.                                                                       =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,017 COMPOSITE CHILDREN: [816]                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,018 Player: PlayerA simulated 281 evaluations in 2.004385361 seconds - nodes in tree: 1498     =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,018 Total: simulated 3415 evaluations in 30.516667729999995 seconds - Average: 111.90605836176599 =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,018 0 illegals purged, 28 valid duplicates purged, 6 invalid duplicates purged.                =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,027 STARTING ROOT VISITS: 815                                                                  =>[pool-3-thread-6] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,057 timed out, ending search                                                                   =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,065 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,069 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,073 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,076 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,077 timed out, ending search                                                                   =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 Pending Nodes: 0                                                                           =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 Ran 281 simulations.                                                                       =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 COMPOSITE CHILDREN: [498, 35, 189]                                                         =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 Player: PlayerA simulated 281 evaluations in 2.007264724 seconds - nodes in tree: 1414     =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 Total: simulated 3716 evaluations in 30.331085849 seconds - Average: 122.51457196421191    =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 18 illegals purged, 13 valid duplicates purged, 3 invalid duplicates purged.               =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,078 DECLARE_BLOCKERS0pool= actions: [Stop Choosing score: -0.149 count: 498] [Razorkin Needlehead score: -0.383 count: 35] [Emberheart Challenger score: -0.198 count: 189]  =>[pool-3-thread-5] MCTSNode.bestChild 
+INFO  2026-07-28 21:34:12,078 Targeting Stop Choosing                                                                    =>[pool-3-thread-5] ComputerPlayerMCTS.makeChoice 
+INFO  2026-07-28 21:34:12,079 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,082 [PlayerB], life = 20, score = 2935 (Life:10000, Hand:40, Perm:3275)                        =>[pool-3-thread-4] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:12,082 -> Hand: [Lightning Strike:5; Lightning Strike:5; Burst Lightning:5; Nova Hellkite:5; Hired Claw:5; Nova Hellkite:5; Burst Lightning:5; Razorkin Needlehead:5] =>[pool-3-thread-4] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:12,082 -> Permanents: [Mountain,tapped:280; Hired Claw,tapped:2995]                               =>[pool-3-thread-4] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:12,082 -> Graveyard: [Full Bore]                                                                  =>[pool-3-thread-4] GameStateEvaluator2.printBattlefield 
+INFO  2026-07-28 21:34:12,083 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,085 possible targets: 8                                                                        =>[pool-3-thread-4] ComputerPlayer.makeChoice 
+INFO  2026-07-28 21:34:12,090 [5:Beginning:UPKEEP]PlayerA hand: : Meticulous Archive,Sheltered by Ghosts,Sheltered by Ghosts,Combat Research, =>[pool-3-thread-4] ComputerPlayer.logList 
+INFO  2026-07-28 21:34:12,092 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,096 auto pass                                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS.priority 
+INFO  2026-07-28 21:34:12,097 STARTING ROOT VISITS: 497                                                                  =>[pool-3-thread-5] ComputerPlayerMCTS2.applyMCTS 
+INFO  2026-07-28 21:34:12,103 STARTING ROOT VISITS: 379                                                                  =>[pool-3-thread-4] ComputerPlayerMCTS2.applyMCTS 

--- a/tools/training/wp3/sample_combat_records.py
+++ b/tools/training/wp3/sample_combat_records.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Eyeball helper: sample rendered combat records + show raw log context.
+
+Not part of the pipeline; used for the manual validation step of the
+combat-adapter PR (render N records and check them against the raw log).
+"""
+import argparse
+import json
+import random
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outdir", required=True)
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--n", type=int, default=5)
+    ap.add_argument("--seed", type=int, default=42)
+    args = ap.parse_args()
+
+    recs = []
+    for split in ("train", "val", "test"):
+        with open(f"{args.outdir}/{split}.jsonl", encoding="utf-8") as f:
+            for line in f:
+                r = json.loads(line)
+                if r.get("kind") in ("attack_commit", "block_assign"):
+                    r["_split"] = split
+                    recs.append(r)
+    atk = [r for r in recs if r["kind"] == "attack_commit"]
+    blk = [r for r in recs if r["kind"] == "block_assign"]
+    random.seed(args.seed)
+    sample = random.sample(atk, args.n) + random.sample(blk, args.n)
+
+    wanted = {}
+    for i, r in enumerate(sample):
+        p = r["meta"]["provenance"]
+        for key in ("line_opener", "line_pool", "line_resolution", "line_context"):
+            wanted.setdefault(p[key], []).append((i, key))
+
+    raw = {}
+    with open(args.log, encoding="utf-8", errors="replace") as f:
+        for ln, line in enumerate(f, 1):
+            if ln in wanted:
+                raw[ln] = line.rstrip()[:240]
+
+    for i, r in enumerate(sample):
+        m = r["meta"]
+        print("=" * 110)
+        print(
+            f"RECORD {i}: {r['kind']} split={r['_split']} "
+            f"creature={m['creature']!r} pick={m['answer_pick']}/{m['menu_size']} "
+            f"game={m['game_id']} turn={m['turn']} outcome={m['outcome']}"
+        )
+        p = m["provenance"]
+        for key in ("line_opener", "line_pool", "line_resolution", "line_context"):
+            print(f"  RAW {key} L{p[key]}: {raw.get(p[key], '<not read>')}")
+        print("- USER PROMPT " + "-" * 60)
+        print(r["user"])
+        print("- RESPONSE -", r["response"])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Builds the combat half of the WP-3 corpus from the REAL emitters identified in the rl-pipeline-fix.md retraction (the previous adapter, build_magezero_combat.py, fails closed to zero since #453 found 89/90 fabricated labels). All numbers below are measured on /home/joshu/mz_train_smoke.log (210MB, 594 games).

## What

- `tools/training/magezero_combat_micro.py`: streaming scanner + renderer for per-creature combat micro-decisions.
  - `attack_commit`: `base choose use attack with: <name>?` opener -> binary `DECLARE_ATTACKERS*pool=` -> `use attack with: <name>?: true|false`, paired by thread tag, 12 same-thread-line pool window, opener-name equality asserted.
  - `block_assign`: `choose which creature to block for <blocker>` gates the `DECLARE_BLOCKERS*pool=` and the `Targeting <attacker>` / `Targeting Stop Choosing` resolution. Bare `Targeting` lines are never blocks: 4,296 spell-targeting lines correctly bypassed.
  - Board/hand context from the thread's own battlefield state machine (parse_magezero_log grammar, #430 attribution); fail-closed if no complete same-thread, same-game MCTS battlefield block within 800 same-thread lines.
  - `verify_accounting()` asserts the closed ledger on every scan: every seen line is emitted or counted under an explicit reason.
- `run_wp3_pipeline.py`: `--include-combat`, default OFF (default output unchanged). Combat rows are filtered separately (the pass-rate tripwire stays priority-only as pre-registered), split by game together with priority rows, rendered production-shaped ({"pick": N}; MCTS counts/scores in meta only), and leak-scanned. Combat accounting, histograms, and floor_breach land in the manifest.

## Measured yield (smoke log)

- Scanner: 3,213 attack_commit + 788 block_assign = 4,001 rows.
- Reconciliation vs raw grep, every gap explained (details in PROGRESS-wp3-combat-adapter2.md):
  - 6,705 "attack with" lines = 3,352 openers + 3,352 resolutions + 1 card-text mention inside a pool line.
  - 3,352 resolutions -> 3,213 emitted + 139 dropped (76 pools invalidated by intervening decision-class events, counted per reason; 63 searches never printed a bestChild pool: cached tree, single root child).
  - 1,088 block openers -> 788 emitted + 300 dropped without a pool (172 were `possible targets: 1` forced auto-picks with no search; 128 cached-tree, same as attacks).
- Class histograms vs pre-registered floors (raw scan): attack {attack 2,296 / no_attack 917}; chains {all_in 1,558, no_attack 428, proper_subset 369} — **all-in share 66.2% > 38.6% floor: BREACHED** (74.4% post-filter). block {no_block 398 / block 390} — no-block share 50.5% vs 69% floor: ok (51.1% post-filter). NOT rebalanced; `combat.floor_breach: true` in the manifest, loud banner in report. Gate decision is the owner's.
- Pipeline end-to-end (`--include-combat --balance downsample-pass`): 4,001 scanned -> 1,478 post-filter (won_only 2,505, dedupe 18) -> 1,304 attack + 174 block rendered into train/val/test; outcome join 4,001/4,001 by game_id; leak scan 0 violations. Without `--balance downsample-pass` the run aborts on the pre-existing PRIORITY pass-rate tripwire (43.8% > 40%), unrelated to combat.

## Validation

- Fixture is a real, unmodified 261-line excerpt of the smoke log with all 6 threads interleaved (13/13 sampled lines verified verbatim), plus synthetic orphan fixtures proving fail-closed drops (orphan resolution, opener-name mismatch, missing/previous-game context, cross-thread pool, intervening priority decision, spell-targeting bypass, chosen-not-in-pool).
- Manually rendered 5 attack + 5 block records and checked each against its raw log lines: same thread, adjacent, creature correct, pick matches the logged verdict, pool argmax agrees, board owner correct, no MCTS text in any prompt, answer not recoverable from the prompt.
- Known soft spot, quantified: board context can be stale within the window — creature_on_board true for 3,209/3,213 attacks (99.9%) and 750/788 blocks (95.2%); flagged per record in provenance for downstream filtering.

## Tests

- 27 new tests, all pass (`venv-train` python).
- Full suite: 1,422 passed, 4 failed, 28 skipped — the 4 failures are environment-only (missing PIL/mcp in venv-train) in modules this branch does not touch; they also fail on a clean master checkout in this venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSt4VJgNx8TnBrTrxDKkcf
