### PR TITLE
train: --val_file — game-disjoint validation (gate v1 postmortem fix)

### DIFF
--- a/tools/training/train.py
+++ b/tools/training/train.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -186,6 +187,18 @@ def main():
     p.add_argument("--max_length", type=int, default=4096, help="Max token sequence length")
     p.add_argument("--val_split", type=float, default=0.05, help="Validation set split ratio (e.g. 0.05)")
     p.add_argument(
+        "--val_file",
+        type=Path,
+        default=None,
+        help=(
+            "Explicit validation set (JSON/JSONL). Takes precedence over --val_split. "
+            "Use the WP-3 pipeline's game-disjoint val.jsonl: a random --val_split over "
+            "records leaks near-duplicate states from the same games into eval, which "
+            "saturates eval metrics (eval_token_accuracy=1.0, gate v1 postmortem) and "
+            "blinds early stopping."
+        ),
+    )
+    p.add_argument(
         "--save_steps", type=int, default=25, help="Checkpoint every N optimizer steps (0 = per-epoch only)"
     )
     p.add_argument("--save_total_limit", type=int, default=3, help="Max checkpoints to retain")
@@ -248,7 +261,21 @@ def main():
     # Load dataset from JSON
     full_dataset = load_dataset("json", data_files=str(args.dataset))
 
-    if args.val_split > 0.0 and "train" in full_dataset:
+    if args.val_file is not None:
+        if not args.val_file.exists():
+            sys.exit(f"--val_file not found: {args.val_file}")
+        train_ds = full_dataset["train"]
+        eval_ds = load_dataset("json", data_files=str(args.val_file))["train"]
+        logger.info(
+            f"Using explicit val set {args.val_file} ({len(eval_ds)} records); "
+            "--val_split ignored"
+        )
+    elif args.val_split > 0.0 and "train" in full_dataset:
+        logger.warning(
+            "--val_split holds out a RANDOM record subset; for WP-3 corpora this "
+            "leaks near-duplicate states across the split — prefer --val_file "
+            "with the pipeline's game-disjoint val.jsonl"
+        )
         split_data = full_dataset["train"].train_test_split(test_size=args.val_split, seed=42)
         train_ds = split_data["train"]
         eval_ds = split_data["test"]


### PR DESCRIPTION
Cause #1 in the §26 addendum 19 gate-v1 postmortem: train.py's --val_split re-splits records randomly, leaking near-duplicate states from the same games between train and val. Result: eval_token_accuracy=1.0 / eval_loss 4e-05 on the v1 run — a memorization mirage that also blinds early stopping (the metric saturates immediately).

This adds --val_file (takes precedence over --val_split) so runs consume the WP-3 pipeline's game-disjoint val.jsonl, and logs a warning when the old random split is used.

Measured basis: v1 LoRA scored eval_token_accuracy=1.0 in-training, then 0.240 vs the 0.4727 gate floor on session-disjoint prompts.

DO NOT MERGE until the overnight v2 arms finish — they run from the shared working tree and their experiment should not change mid-flight. Merge before any v3 training.