### PR TITLE
wp3: next-run prep — diverse run config, holdout validator, mixture manifest prototype

### DIFF
--- a/tests/test_build_mixture_manifest.py
+++ b/tests/test_build_mixture_manifest.py
@@ -1,0 +1,217 @@
+"""Unit tests for tools/training/wp3/build_mixture_manifest.py helpers.
+
+Fixture-only — no dependence on the (gitignored) corpora under
+tools/training/data/ or on ~/.arenamcp. The demo run against the real corpora
+is recorded in PROGRESS-wp3-next-run-prep.md and the PR body.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from tools.training.wp3 import build_mixture_manifest as M  # noqa: E402
+
+VOCAB = {
+    "island": {"name": "Island", "type_line": "Basic Land — Island"},
+    "plains": {"name": "Plains", "type_line": "Basic Land — Plains"},
+    "seachrome coast": {"name": "Seachrome Coast", "type_line": "Land"},
+    "no more lies": {"name": "No More Lies", "type_line": "Instant"},
+    "skrelv, defector mite": {"name": "Skrelv, Defector Mite", "type_line": "Legendary Creature — Phyrexian Mite"},
+    "veteran survivor": {"name": "Veteran Survivor", "type_line": "Creature — Human Survivor"},
+}
+
+MZ_USER = """TRIGGER: Your turn started (Main Phase 1). Plan your plays.
+
+=== GAME ===
+Legal: (pick by number)
+  1. Play Island
+  2. Cast No More Lies
+  3. Pass
+T2 YOUR | Main1 | Pri:You
+
+YOUR BOARD:
+  Seachrome Coast
+OPP BOARD:
+  (empty)
+
+HAND:
+  Island  [S,LAND]
+  Skrelv, Defector Mite  [S,OK]
+
+Respond with ONLY a JSON action plan matching the schema.
+"""
+
+CANDIDATE_USER = """TRIGGER: Your turn started (Main Phase 1). Plan your plays.
+
+=== GAME ===
+Candidate: (pick by number — RECONSTRUCTED, NOT a complete legal-action list)
+  1. Cast Veteran Survivor
+  2. Play Land: Plains
+  3. Pass
+T1 YOUR | Main1 | Pri:You
+
+HAND:
+  Veteran Survivor {W} 1/1 (Creature — Human Survivor) - Survival — stuff.
+  Plains (Basic Land — Plains) - ({T}: Add {W}.)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Menu parsing + classification
+# ---------------------------------------------------------------------------
+
+
+def test_parse_menu_production_shape():
+    assert M.parse_menu(MZ_USER) == ["Play Island", "Cast No More Lies", "Pass"]
+
+
+def test_parse_menu_candidate_shape():
+    assert M.parse_menu(CANDIDATE_USER) == ["Cast Veteran Survivor", "Play Land: Plains", "Pass"]
+
+
+def test_parse_menu_absent():
+    assert M.parse_menu("no menu here\n  1. not after a header\n") == []
+
+
+def test_classify_entries():
+    assert M.classify_entry("Pass", VOCAB) == ("pass", None)
+    assert M.classify_entry("Cast No More Lies", VOCAB) == ("cast", "No More Lies")
+    assert M.classify_entry("Play Land: Plains", VOCAB) == ("play_land", "Plains")
+    assert M.classify_entry("Play Island", VOCAB) == ("play", "Island")
+    assert M.classify_entry("Declare Attackers (Attack All)", VOCAB) == ("attack", None)
+
+
+def test_play_entry_land_detection_uses_type_line():
+    ac, card = M.classify_entry("Play Island", VOCAB)
+    assert M._entry_is_land_play(ac, card, VOCAB)
+    ac, card = M.classify_entry("Cast No More Lies", VOCAB)
+    assert not M._entry_is_land_play(ac, card, VOCAB)
+
+
+# ---------------------------------------------------------------------------
+# Card extraction (vocab-validated, drop-and-count)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cards_mz_shape():
+    from collections import Counter
+
+    unrec = Counter()
+    cards = M.extract_cards_from_user(MZ_USER, VOCAB, unrec)
+    assert cards == {"Island", "No More Lies", "Seachrome Coast", "Skrelv, Defector Mite"}
+
+
+def test_extract_cards_candidate_shape_strips_cost_and_oracle():
+    from collections import Counter
+
+    unrec = Counter()
+    cards = M.extract_cards_from_user(CANDIDATE_USER, VOCAB, unrec)
+    assert cards == {"Veteran Survivor", "Plains"}
+
+
+def test_unknown_tokens_are_counted_not_silently_included():
+    from collections import Counter
+
+    unrec = Counter()
+    user = "Legal: (pick by number)\n  1. Cast Totally Fake Card\n  2. Pass\n"
+    cards = M.extract_cards_from_user(user, VOCAB, unrec)
+    assert cards == set()
+    assert unrec["Totally Fake Card"] == 1
+
+
+def test_display_disambiguator_stripped():
+    from collections import Counter
+
+    cards = M.extract_cards_from_user("HAND:\n  Plains #2  [S,LAND]\n", VOCAB, Counter())
+    assert cards == {"Plains"}
+
+
+# ---------------------------------------------------------------------------
+# Gold pick extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_gold_pick_shapes():
+    assert M.extract_gold_pick('{"actions": [{"pick": 4}]}') == 4
+    assert M.extract_gold_pick('{"pick": 2}') == 2
+    assert M.extract_gold_pick("not json") is None
+    assert M.extract_gold_pick('{"actions": []}') is None
+
+
+# ---------------------------------------------------------------------------
+# Mixture math
+# ---------------------------------------------------------------------------
+
+
+def test_plan_mixture_hits_requested_weight():
+    plan = M.plan_mixture(n_mz=4808, n_human_avail=14659, human_weight=0.2, seed=1)
+    assert plan["human_records_sampled"] == 1202
+    assert not plan["capped_by_availability"]
+    assert abs(plan["realized_human_share"] - 0.2) < 0.001
+
+
+def test_plan_mixture_caps_at_availability_and_reports_it():
+    plan = M.plan_mixture(n_mz=100, n_human_avail=10, human_weight=0.5, seed=1)
+    assert plan["human_records_sampled"] == 10
+    assert plan["capped_by_availability"]
+    assert plan["realized_human_share"] < 0.5
+
+
+def test_plan_mixture_zero_weight():
+    plan = M.plan_mixture(n_mz=100, n_human_avail=10, human_weight=0.0, seed=1)
+    assert plan["human_records_sampled"] == 0
+    assert plan["realized_human_share"] == 0.0
+
+
+def test_plan_mixture_rejects_weight_one():
+    with pytest.raises(ValueError):
+        M.plan_mixture(n_mz=1, n_human_avail=1, human_weight=1.0, seed=1)
+
+
+# ---------------------------------------------------------------------------
+# scan_corpus end-to-end on a tiny fixture
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+
+
+def test_scan_corpus_fixture(tmp_path):
+    recs = [
+        {"system": "You are an MTG Arena autopilot. ...", "user": MZ_USER, "response": '{"actions": [{"pick": 1}]}', "source": "magezero_bridge", "meta": {}},
+        {"system": "You are an MTG Arena autopilot. ...", "user": CANDIDATE_USER, "response": '{"actions": [{"pick": 2}]}', "source": "17lands-replay_data", "meta": {}},
+        {"system": "x", "user": "no menu at all", "response": '{"actions": [{"pick": 1}]}', "source": "junk"},
+    ]
+    p = tmp_path / "corpus.jsonl"
+    _write_jsonl(p, recs)
+    out = M.scan_corpus(str(p), VOCAB)
+    s = out["stats"]
+    assert s["records_usable"] == 3
+    assert s["production_shape"]["production_n"] == 1
+    assert s["production_shape"]["candidate_n"] == 1
+    assert s["production_shape"]["neither_n"] == 1
+    assert s["drops"]["no_parseable_menu"] == 1
+    # Both parseable records chose a land drop (Play Island / Play Land: Plains)
+    assert s["trivial_policies"]["computable_n"] == 2
+    assert s["trivial_policies"]["always_land_else_first"] == 1.0
+    assert out["cards"] >= {"Island", "Plains", "Veteran Survivor"}
+
+
+def test_scan_corpus_drop_and_count_bad_lines(tmp_path):
+    p = tmp_path / "corpus.jsonl"
+    p.write_text('not json\n{"user": 5, "response": "x"}\n', encoding="utf-8")
+    s = M.scan_corpus(str(p), VOCAB)["stats"]
+    assert s["records_usable"] == 0
+    assert s["drops"]["bad_json"] == 1
+    assert s["drops"]["missing_user_or_response"] == 1

--- a/tests/test_validate_run_config.py
+++ b/tests/test_validate_run_config.py
@@ -1,0 +1,163 @@
+"""Tests for tools/training/wp3/validate_run_config.py — the permanent-holdout
+contract that keeps the unseen-deck gate slice honest.
+
+The contract: HighNoonControl, BGRoots, BWBats appear in NO training config,
+ever — not as primary, not as opponent. The validator must fail CLOSED on
+configs it cannot positively clear.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+pytest.importorskip("yaml", reason="pyyaml required for run-config validation")
+
+from tools.training.wp3 import validate_run_config as V  # noqa: E402
+
+WP3 = REPO / "tools" / "training" / "wp3"
+
+CLEAN_CONFIG = """\
+deck: UWTempo
+opponents:
+  - deck: Standard-MonoR
+    mode: minimax
+  - deck: Oathbreaker_UR
+    mode: minimax
+"""
+
+
+def _write(tmp_path: Path, text: str, name: str = "cfg.yml") -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# The contract itself
+# ---------------------------------------------------------------------------
+
+
+def test_holdout_set_is_exactly_the_three_pinned_decks():
+    # Growing this set is an owner decision; shrinking it invalidates every
+    # unseen-deck gate number measured while the deck was held out.
+    assert V.HOLDOUT_DECKS == {"HighNoonControl", "BGRoots", "BWBats"}
+
+
+def test_clean_config_passes(tmp_path):
+    p = _write(tmp_path, CLEAN_CONFIG)
+    assert V.validate_config(p) == []
+
+
+@pytest.mark.parametrize("holdout", sorted(V.HOLDOUT_DECKS))
+def test_holdout_as_opponent_fails(tmp_path, holdout):
+    p = _write(
+        tmp_path,
+        f"deck: UWTempo\nopponents:\n  - deck: {holdout}\n    mode: minimax\n",
+    )
+    violations = V.validate_config(p)
+    assert violations, f"{holdout} as opponent must be a violation"
+    assert holdout in "\n".join(violations)
+
+
+@pytest.mark.parametrize("holdout", sorted(V.HOLDOUT_DECKS))
+def test_holdout_as_primary_fails(tmp_path, holdout):
+    p = _write(
+        tmp_path,
+        f"deck: {holdout}\nopponents:\n  - deck: Standard-MonoR\n    mode: minimax\n",
+    )
+    violations = V.validate_config(p)
+    assert violations, f"{holdout} as primary must be a violation"
+
+
+def test_holdout_matching_is_normalized(tmp_path):
+    # Case / whitespace / .dck-suffix variants must not dodge the check.
+    for variant in ("highnooncontrol", "HIGHNOONCONTROL", " HighNoonControl ", "HighNoonControl.dck"):
+        p = _write(tmp_path, f"deck: UWTempo\nopponents:\n  - deck: '{variant}'\n")
+        assert V.validate_config(p), f"variant {variant!r} must still be caught"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_fails_closed(tmp_path):
+    assert V.validate_config(tmp_path / "does_not_exist.yml")
+
+
+def test_unparseable_yaml_fails_closed(tmp_path):
+    p = _write(tmp_path, "deck: [unclosed\n")
+    assert V.validate_config(p)
+
+
+def test_missing_deck_key_fails_closed(tmp_path):
+    p = _write(tmp_path, "opponents:\n  - deck: Standard-MonoR\n")
+    assert V.validate_config(p)
+
+
+def test_missing_opponents_fails_closed(tmp_path):
+    p = _write(tmp_path, "deck: UWTempo\n")
+    assert V.validate_config(p)
+
+
+def test_opponent_entry_without_deck_field_fails_closed(tmp_path):
+    p = _write(tmp_path, "deck: UWTempo\nopponents:\n  - mode: minimax\n")
+    assert V.validate_config(p)
+
+
+def test_non_mapping_top_level_fails_closed(tmp_path):
+    p = _write(tmp_path, "- just\n- a\n- list\n")
+    assert V.validate_config(p)
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes + the tracked configs stay clean
+# ---------------------------------------------------------------------------
+
+
+def test_main_exit_2_on_violation(tmp_path, capsys):
+    p = _write(tmp_path, "deck: BGRoots\nopponents:\n  - deck: BWBats\n")
+    assert V.main([str(p)]) == 2
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+
+
+def test_main_exit_0_on_clean(tmp_path, capsys):
+    p = _write(tmp_path, CLEAN_CONFIG)
+    assert V.main([str(p)]) == 0
+
+
+def test_tracked_next_run_diverse_config_is_clean():
+    # THE deliverable config for the next curriculum run must never regress.
+    cfg = WP3 / "next_run_diverse.yml"
+    assert cfg.is_file(), "tracked next-run config missing"
+    assert V.validate_config(cfg) == []
+
+
+def test_default_targets_all_clean():
+    # No-args invocation validates every tracked run config in wp3/.
+    assert V.main([]) == 0
+
+
+def test_next_run_diverse_has_438_opponents_and_scale():
+    import yaml
+
+    cfg = yaml.safe_load((WP3 / "next_run_diverse.yml").read_text(encoding="utf-8"))
+    opponent_decks = {o["deck"] for o in cfg["opponents"]}
+    # The #438 greedy-optimal five, exact .dck basenames per deck_inventory.json.
+    assert {
+        "Oathbreaker_UR",
+        "GBLegends",
+        "EVG_Elves",
+        "EVG_Goblins",
+        "Mind(MindvsMight)",
+    } <= opponent_decks
+    assert cfg["games_per_gen"] == 550
+    assert cfg["generations"] == 6

--- a/tools/training/wp3/PROGRESS-wp3-next-run-prep.md
+++ b/tools/training/wp3/PROGRESS-wp3-next-run-prep.md
@@ -1,0 +1,167 @@
+# WP3: Next-curriculum-run prep — Progress (MORNING PRIORITY items 3+4)
+
+Branch: `wp3-next-run-prep`. Config + prototype + validation only — NO
+training was run, NO live-run file was touched (the live run's
+`configs/run.yml` in the magezero repo is unmodified; `run_diverse.yml` there
+is also unmodified — deploy is a deliberate one-file copy, below).
+
+## Deliverables
+
+- [x] `tools/training/wp3/next_run_diverse.yml` — finalized, tracked config
+      for the NEXT curriculum run
+- [x] `tools/training/wp3/validate_run_config.py` — fail-closed permanent-
+      holdout validator (HighNoonControl, BGRoots, BWBats)
+- [x] `tests/test_validate_run_config.py` — 20 tests, wires the contract
+- [x] `tools/training/wp3/build_mixture_manifest.py` — breadth-vs-depth
+      mixture manifest PROTOTYPE (manifest only; refuses to write training
+      data without `--emit`)
+- [x] `tests/test_build_mixture_manifest.py` — 16 tests (fixtures only,
+      no dependence on gitignored corpora)
+- [x] Demo manifest at `--human-weight 0.2`:
+      `tools/training/data/mixture_manifest_w020.json` (gitignored data dir;
+      numbers reproduced below)
+
+Tests: `pytest tests/test_validate_run_config.py tests/test_build_mixture_manifest.py -q`
+→ **36 passed** (venv-train Python 3.12).
+
+## 1. Diversity run config (item 3)
+
+`tools/training/wp3/next_run_diverse.yml` finalizes the magezero-repo
+`configs/run_diverse.yml` draft:
+
+- **Opponents**: the 5 retained Standard-Mono baselines + the #438
+  greedy-optimal five, exact `.dck` basenames verified against
+  `deck_inventory.json`: `Oathbreaker_UR`, `GBLegends`, `EVG_Elves`,
+  `EVG_Goblins`, `Mind(MindvsMight)`. Pool 83 → 235 distinct cards (2.8x,
+  measured in #438).
+- **Scale**: `games_per_gen: 550`, `generations: 6` — the draft still had the
+  pre-bump 200; finalized to the scale the current run's 550-bump paid for.
+- **No holdout decks** (validated, see below).
+- `start_from_version: null` left as an explicit owner call at deploy time
+  (fresh bootstrap vs resume from the current run's final checkpoint).
+
+**Deploy step (the magezero repo is separate; run only BETWEEN curriculum
+runs, never mid-run):**
+
+```bash
+cp tools/training/wp3/next_run_diverse.yml \
+   /home/joshu/repos/magezero/configs/run_diverse.yml
+```
+
+Difference vs the current magezero draft: games_per_gen 200 → 550, plus the
+holdout-contract provenance header. Opponent set is unchanged from the draft
+(it already matched #438).
+
+## 2. Permanent-holdout validator (the unseen-deck gate contract)
+
+`validate_run_config.py` FAILS (exit 2) if any run config lists
+**HighNoonControl, BGRoots, or BWBats** as `deck:` (primary) or any
+`opponents[].deck`. Fail closed: unreadable file, YAML error, non-mapping top
+level, missing `deck`/`opponents`, or an opponent entry without a `deck`
+field are all violations — never skips. Matching is normalized
+(case/whitespace/`.dck` suffix) so filename variants cannot dodge it.
+
+- No-args default validates the tracked wp3 configs
+  (`next_run_diverse.yml`, `run_baseline.yml`).
+- `--configs-dir /home/joshu/repos/magezero/configs` scans the live configs
+  (known non-run configs `curriculum.yml`/`game.yml`/`game_smoke.yml`
+  excluded by name).
+
+Measured run against the live magezero configs dir (2026-07-31):
+
+```
+[ok] /home/joshu/repos/magezero/configs/run.yml
+[ok] /home/joshu/repos/magezero/configs/run_diverse.yml
+OK: 2 config(s) clean of holdout decks (BGRoots, BWBats, HighNoonControl).
+```
+
+Wired as `tests/test_validate_run_config.py` (20 tests): the contract set is
+pinned, every holdout is tested as primary and as opponent, normalization
+variants are tested, all fail-closed branches are tested, and the tracked
+`next_run_diverse.yml` is asserted clean + carrying the #438 five at
+550×6.
+
+## 3. Breadth-vs-depth mixture prototype (item 4 — owner decides weights)
+
+### Corpora located on disk (blackwell, `tools/training/data/`, gitignored)
+
+All share the record shape
+`{system, user, response, source, attribution, kind, meta}` with response
+`{"actions": [{"pick": N}]}`:
+
+| file | size | records | shape | source |
+|---|---|---|---|---|
+| `wp3_v2_priority/train.jsonl` | 48 MB | 4,808 | 100% production (`Legal:`) | magezero_bridge (won games, priority) |
+| `wp3_v2_combat/train.jsonl` | 61 MB | — | production | magezero_bridge + combat micro |
+| `play_decisions.jsonl` | 223 MB | — | Candidate: (synthetic menus) | 17lands-replay_data |
+| `play_decisions_nontrivial.jsonl` | 141 MB | 13,671 | Candidate: | 17lands, trivial-only-menu records dropped |
+| `play_decisions_cast.jsonl` | 58 MB | — | Candidate: | 17lands, cast-only |
+| `play_decisions_bridge.jsonl` | 12 MB | 988 | 100% production (real MTGA menus) | manasight/replay ground truth |
+| `play_decisions_mixed.jsonl` | 153 MB | 14,659 | 6.74% production | bridge 988 + nontrivial 13,671 |
+| `stage0_prompts_{EOE,OTJ,TDM,WOE}.jsonl`, `stage0_turnaction_*`, `stage0v2_*` | ~0.8 GB | — | pre-WP3 Phase-0 prompt shapes | 17lands |
+
+The demo uses `wp3_v2_priority/train.jsonl` (depth) ×
+`play_decisions_mixed.jsonl` (breadth; the blunder-filtered human mix).
+
+### Prototype semantics
+
+`build_mixture_manifest.py --magezero-corpus … --human-corpus …
+--human-weight W --out manifest.json`:
+
+- Keeps ALL magezero records (depth anchor); samples human records
+  deterministically (`--seed`) so human/(human+magezero) = W; capping by
+  availability is reported, never silent.
+- **Manifest only** — no training data written without `--emit` (and `--emit`
+  refuses to overwrite, plus optional `--min-production-share` fail-closed
+  floor per the rl-pipeline-fix mixture-manifest requirement).
+- Production-shape heuristic is the repo's `Legal:` heuristic from
+  `build_bridge_dataset.py`: user contains `"Legal: (pick by number)"` and
+  not `"Candidate:"`.
+- Distinct-card coverage validated against the MTGJSON name index
+  (`~/.arenamcp/mtgjson/name_index.json`, 34,633 names + DFC-face aliases);
+  unresolvable tokens are counted and top-20 reported (drop-and-count),
+  never silently included.
+- Trivial-policy floors computed per source (same reflex families as
+  `gate_play_decisions.py` G6); records with `meta.gold_equivalent_picks`
+  (the 988 bridge records) use it, others use the single gold pick — a lower
+  bound, stated in the manifest.
+
+### Demo manifest — MEASURED, `--human-weight 0.2`, seed 20260731 (4.0 s)
+
+Mixture: **4,808 magezero + 1,202 sampled human = 6,010 records**, realized
+human share 0.2000 (not capped; 14,659 available).
+
+| metric | magezero (wp3_v2_priority/train) | human (play_decisions_mixed) | mixture |
+|---|---|---|---|
+| records | 4,808 (0 drops) | 14,659 (0 drops) | 6,010 |
+| production-shape fraction | 1.0000 | 0.0674 (988/14,659) | **0.8128** (4,885/6,010) |
+| distinct cards (vocab-validated) | 66 | 1,721 | **1,198** (union; 1,132 new vs magezero) |
+| menu size median/mean | 3 / 3.18 | 7 / 7.17 | — |
+| gold-action class histogram | pass 2,026 · cast 1,389 · play 882 · activate 511 | play_land 13,397 · cast 1,158 · pass 76 · activate 24 · other 4 | — |
+| best trivial policy | always_land_else_first **0.7633** | always_land_else_first **0.4424** | — |
+| unrecognized card tokens (distinct / occurrences) | 10 / 610 | 1,468 / 6,009 | — |
+
+Full-union ceiling (all human records, weight → 1): 1,753 distinct cards.
+Human-sampled subset alone at W=0.2 covers 1,150 of the corpus's 1,721.
+
+Notable, for the owner's weight decision:
+
+1. **Breadth is cheap**: at W=0.2 the card pool grows 66 → 1,198 (18x) while
+   production-shape fraction stays at 0.81.
+2. **The human slice is land-drop heavy**: 91.4% of its gold labels are
+   `Play Land:` picks (13,397/14,659) — the mixed corpus is main-1-window
+   data. This is the 69%-land-drop lesson shape; a taxonomy/land-drop cap
+   knob on the human slice is probably wanted before any training build.
+3. **The magezero corpus has its own reflex ceiling**: always_land_else_first
+   scores 0.7633 on it, and always_first_option scores 0.8032. Verified
+   against raw records: gold pick is menu entry 1 in 3,862/4,808 records, and
+   in 2,026 of those entry 1 is literally "Pass" (priority windows where the
+   agent passes render Pass first). Any G6-style floor on a mixture
+   containing it must use these measured numbers.
+4. Remaining unrecognized tokens are real non-cards (Clue/Spirit/Lander
+   tokens) plus XMage short-name renderings ("Malcolm", "Skrelv"); DFC face
+   aliasing, `x2`, P/T and `,attacking` suffixes are already handled
+   (unrecognized occurrences fell 1,496 → 610 on magezero after those fixes).
+
+**No weight is recommended here** — that is the owner's call, per the work
+order. The tool makes any candidate weight's numbers reproducible in ~4 s.

--- a/tools/training/wp3/build_mixture_manifest.py
+++ b/tools/training/wp3/build_mixture_manifest.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Breadth-vs-depth mixture manifest PROTOTYPE (rl-pipeline-fix.md MORNING
+PRIORITY item 4).
+
+Proposal under evaluation: low-weight blunder-filtered HUMAN data (breadth
+prior — thousands of distinct cards) under high-weight MAGEZERO self-play data
+(depth). This tool builds the MANIFEST for a candidate mixture so the owner
+can pick the weight from measured numbers. It does NOT write training data
+unless ``--emit`` is passed — the owner decision on weights comes first.
+
+Per source and for the mixture it reports:
+  - record counts (with fail-closed drop-and-count for unparseable records)
+  - production-shape fraction — the repo's ``Legal:`` menu heuristic
+    (build_bridge_dataset.py): user contains ``Legal: (pick by number)`` and
+    NOT ``Candidate:``; the Candidate: header marks synthesized 17lands menus
+  - distinct-card coverage, validated against the MTGJSON name index
+    (~/.arenamcp/mtgjson/name_index.json) — unvalidated extractions are
+    counted, never silently included
+  - gold-action class histogram (cast / play_land / pass / ...) per repo
+    reporting culture
+  - trivial-policy floor stats where computable (always_first / always_last /
+    always_pass / always_land_else_first / uniform_random_expectation),
+    the same reflex families gate_play_decisions.py floors G6 on. Records
+    whose meta carries ``gold_equivalent_picks`` use it; otherwise the gold
+    pick alone is the equivalence class (an UNDERESTIMATE of reflex accuracy
+    vs the gate's version — stated in the manifest, not hidden).
+
+Mixture semantics: ALL magezero records are kept (depth anchor); human
+records are sampled deterministically (--seed) so that
+human/(human+magezero) == --human-weight, capped at availability (capping is
+reported, never silent).
+
+Example (manifest only):
+  python tools/training/wp3/build_mixture_manifest.py \\
+      --magezero-corpus tools/training/data/wp3_v2_priority/train.jsonl \\
+      --human-corpus tools/training/data/play_decisions_mixed.jsonl \\
+      --human-weight 0.2 \\
+      --out tools/training/data/mixture_manifest_w020.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import re
+import statistics
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+DEFAULT_VOCAB = os.path.expanduser("~/.arenamcp/mtgjson/name_index.json")
+
+PRODUCTION_MENU_HEADER = "Legal: (pick by number)"  # build_bridge_dataset.py heuristic
+CANDIDATE_MARKER = "Candidate:"
+AUTOPILOT_SYSTEM_PREFIX = "You are an MTG Arena autopilot"
+
+MENU_ENTRY_RE = re.compile(r"^\s+(\d+)\.\s+(.+?)\s*$")
+# 2-space-indented entry line (hand/board): deeper indents are oracle text.
+TWO_SPACE_ENTRY_RE = re.compile(r"^  (\S.*?)\s*$")
+DISPLAY_DISAMBIG_RE = re.compile(r"\s*#\d+$")
+
+NON_CARD_ENTRY_TEXT = {"(empty)", "empty", "none"}
+
+
+# ---------------------------------------------------------------------------
+# Vocab
+# ---------------------------------------------------------------------------
+
+
+def load_vocab(path: str) -> dict:
+    """MTGJSON name index: lowercase name -> {name, type_line, ...}.
+
+    Double-faced / split names ("A // B") are additionally indexed by each
+    face, because XMage and MTGA prompts render a single face name (measured:
+    'Cecil, Dark Knight', 'Malcolm' were the top unrecognized tokens before
+    this). Face keys never overwrite an existing exact name.
+    """
+    with open(path, encoding="utf-8") as fh:
+        vocab = json.load(fh)
+    faces = {}
+    for key, info in vocab.items():
+        if " // " in key:
+            for face in key.split(" // "):
+                face = face.strip()
+                if face and face not in vocab and face not in faces:
+                    faces[face] = info
+    vocab.update(faces)
+    return vocab
+
+
+def _clean_card_token(text: str) -> str:
+    """Strip cost/flag/oracle suffixes from an entry line, keep the name part."""
+    # Cut at the first cost/flag/parenthetical/dash-oracle suffix.
+    for sep in ("  ", " {", " [", " (", " - "):
+        idx = text.find(sep)
+        if idx > 0:
+            text = text[:idx]
+    token = DISPLAY_DISAMBIG_RE.sub("", text.strip())
+    # Measured rendering artifacts (top unrecognized tokens before these):
+    token = re.sub(r"\s+x\d+$", "", token)  # "Forest x2" duplicate-count marker
+    token = re.sub(r"\s+\d+/\d+$", "", token)  # "Gene Pollinator 1/2" P/T suffix
+    token = re.sub(r",(attacking|blocking|tapped)$", "", token)  # XMage combat marker
+    return token.strip()
+
+
+def _resolve_card(token: str, vocab: dict) -> str | None:
+    """Return canonical card name, or None if not a known card."""
+    if not token or token.lower() in NON_CARD_ENTRY_TEXT:
+        return None
+    hit = vocab.get(token.lower())
+    return hit["name"] if hit else None
+
+
+# ---------------------------------------------------------------------------
+# Menu parsing + action classification
+# ---------------------------------------------------------------------------
+
+
+def parse_menu(user: str) -> list[str]:
+    """Numbered menu entry texts, in order. Empty list = no parseable menu."""
+    lines = user.splitlines()
+    start = None
+    for i, ln in enumerate(lines):
+        if PRODUCTION_MENU_HEADER in ln or ln.lstrip().startswith("Candidate: (pick by number"):
+            start = i + 1
+            break
+    if start is None:
+        return []
+    entries: list[str] = []
+    expected = 1
+    for ln in lines[start:]:
+        m = MENU_ENTRY_RE.match(ln)
+        if not m or int(m.group(1)) != expected:
+            break
+        entries.append(m.group(2))
+        expected += 1
+    return entries
+
+
+def classify_entry(text: str, vocab: dict) -> tuple[str, str | None]:
+    """(action_class, card_name_or_None) for one menu entry."""
+    t = text.strip()
+    # Strip trailing status tags like "[OK]".
+    t = re.sub(r"\s*\[[A-Za-z !?+]*\]\s*$", "", t)
+    if t == "Pass" or t.startswith(("Pass ", "Pass(", "Pass (")):
+        return "pass", None
+    if t.startswith("Play Land: "):
+        return "play_land", _resolve_card(_clean_card_token(t[len("Play Land: ") :]), vocab)
+    if t.startswith("Cast "):
+        return "cast", _resolve_card(_clean_card_token(t[len("Cast ") :]), vocab)
+    if t.startswith("Activate"):
+        rest = re.sub(r"^Activate( ability of)?\s*", "", t)
+        return "activate", _resolve_card(_clean_card_token(rest), vocab)
+    if t.startswith("{") or "}: " in t:
+        # XMage renders ability activations as the raw ability text, e.g.
+        # "{T}: Draw a card, then discard a card." (measured in wp3_v2 menus).
+        return "activate", None
+    if t.startswith(("Declare Attackers", "Attack")):
+        return "attack", None
+    if t in ("KEEP", "MULLIGAN") or t.startswith(("Keep", "Mulligan")):
+        return "mulligan_keep", None
+    if t.startswith("Play "):
+        # XMage/MageZero land plays render as "Play <name>"; MDFC/adventure
+        # plays also land here. Card resolution decides whether it is a land.
+        card = _resolve_card(_clean_card_token(t[len("Play ") :]), vocab)
+        return "play", card
+    return "other", None
+
+
+def _entry_is_land_play(action_class: str, card: str | None, vocab: dict) -> bool:
+    if action_class == "play_land":
+        return True
+    if action_class == "play" and card is not None:
+        info = vocab.get(card.lower())
+        return bool(info and "Land" in info.get("type_line", ""))
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-record extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_cards_from_user(user: str, vocab: dict, unrecognized: Counter) -> set[str]:
+    """Card names from menu entries + 2-space-indented hand/board lines.
+
+    Fail-closed accounting: tokens that do not resolve against the vocab are
+    tallied in ``unrecognized`` (and reported), never silently included or
+    silently dropped.
+    """
+    cards: set[str] = set()
+    for entry in parse_menu(user):
+        action_class, card = classify_entry(entry, vocab)
+        if card:
+            cards.add(card)
+        elif action_class in ("cast", "play", "play_land", "activate"):
+            token = re.sub(r"^(Cast |Play Land: |Play |Activate( ability of)?\s*)", "", entry)
+            unrecognized[_clean_card_token(token)] += 1
+    for ln in user.splitlines():
+        m = TWO_SPACE_ENTRY_RE.match(ln)
+        if not m:
+            continue
+        if MENU_ENTRY_RE.match(ln):
+            continue  # menu entries handled above
+        token = _clean_card_token(m.group(1))
+        card = _resolve_card(token, vocab)
+        if card:
+            cards.add(card)
+        elif token and token.lower() not in NON_CARD_ENTRY_TEXT:
+            unrecognized[token] += 1
+    return cards
+
+
+def extract_gold_pick(response: str) -> int | None:
+    try:
+        obj = json.loads(response)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if isinstance(obj, dict):
+        if isinstance(obj.get("pick"), int):
+            return obj["pick"]
+        actions = obj.get("actions")
+        if isinstance(actions, list) and actions and isinstance(actions[0], dict):
+            pick = actions[0].get("pick")
+            if isinstance(pick, int):
+                return pick
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Corpus scan
+# ---------------------------------------------------------------------------
+
+
+def scan_corpus(path: str, vocab: dict, *, keep_line_numbers: bool = False) -> dict:
+    """One streaming pass; returns stats + (optionally) usable line numbers."""
+    n_lines = 0
+    drops = Counter()
+    n_ok = 0
+    production = 0
+    candidate_shape = 0
+    neither_shape = 0
+    autopilot_system = 0
+    menu_sizes: list[int] = []
+    action_hist = Counter()
+    source_hist = Counter()
+    cards: set[str] = set()
+    unrecognized: Counter = Counter()
+    usable_lines: list[int] = []
+
+    # Trivial-policy tallies (over records with a parseable menu + pick)
+    triv_n = 0
+    hits = Counter()  # policy -> hits
+    rand_expect_sum = 0.0
+    equivalence_from_meta = 0
+
+    with open(path, encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh):
+            n_lines += 1
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                drops["bad_json"] += 1
+                continue
+            user = rec.get("user")
+            response = rec.get("response")
+            if not isinstance(user, str) or not isinstance(response, str):
+                drops["missing_user_or_response"] += 1
+                continue
+            n_ok += 1
+            if keep_line_numbers:
+                usable_lines.append(lineno)
+            source_hist[str(rec.get("source", "?"))] += 1
+
+            is_production = PRODUCTION_MENU_HEADER in user and CANDIDATE_MARKER not in user
+            if is_production:
+                production += 1
+            elif CANDIDATE_MARKER in user:
+                candidate_shape += 1
+            else:
+                neither_shape += 1
+            if str(rec.get("system", "")).startswith(AUTOPILOT_SYSTEM_PREFIX):
+                autopilot_system += 1
+
+            cards |= extract_cards_from_user(user, vocab, unrecognized)
+
+            menu = parse_menu(user)
+            pick = extract_gold_pick(response)
+            if not menu:
+                drops["no_parseable_menu"] += 1
+                continue
+            menu_sizes.append(len(menu))
+            if pick is None or not (1 <= pick <= len(menu)):
+                drops["pick_unparseable_or_out_of_range"] += 1
+                continue
+
+            classified = [classify_entry(e, vocab) for e in menu]
+            action_hist[classified[pick - 1][0]] += 1
+
+            meta = rec.get("meta") if isinstance(rec.get("meta"), dict) else {}
+            gold_set = meta.get("gold_equivalent_picks")
+            if isinstance(gold_set, list) and gold_set:
+                gold = {int(g) for g in gold_set}
+                equivalence_from_meta += 1
+            else:
+                gold = {pick}
+
+            pass_pick = next(
+                (i + 1 for i, (ac, _) in enumerate(classified) if ac == "pass"), None
+            )
+            land_pick = next(
+                (
+                    i + 1
+                    for i, (ac, card) in enumerate(classified)
+                    if _entry_is_land_play(ac, card, vocab)
+                ),
+                None,
+            )
+            triv_n += 1
+            if 1 in gold:
+                hits["always_first_option"] += 1
+            if len(menu) in gold:
+                hits["always_last_option"] += 1
+            if pass_pick is not None and pass_pick in gold:
+                hits["always_pass"] += 1
+            if (land_pick or 1) in gold:
+                hits["always_land_else_first"] += 1
+            if (pass_pick or 1) in gold:
+                hits["always_pass_else_first"] += 1
+            rand_expect_sum += len(gold) / len(menu)
+
+    trivial: dict = {"computable_n": triv_n, "gold_equivalence_from_meta_n": equivalence_from_meta}
+    if triv_n:
+        for k in (
+            "always_first_option",
+            "always_last_option",
+            "always_pass",
+            "always_pass_else_first",
+            "always_land_else_first",
+        ):
+            trivial[k] = round(hits[k] / triv_n, 4)
+        trivial["uniform_random_expectation"] = round(rand_expect_sum / triv_n, 4)
+        best = max(
+            (k for k in ("always_land_else_first", "always_pass", "always_pass_else_first")),
+            key=lambda k: trivial[k],
+        )
+        trivial["best_trivial_policy"] = best
+        trivial["best_trivial_accuracy"] = trivial[best]
+        trivial["note"] = (
+            "records without meta.gold_equivalent_picks use the single gold pick "
+            "as its own equivalence class — reflex accuracies are a lower bound "
+            "vs gate_play_decisions.reference_policies on such records"
+        )
+
+    stats = {
+        "path": path,
+        "lines": n_lines,
+        "records_usable": n_ok,
+        "drops": dict(drops),
+        "by_source": dict(source_hist),
+        "production_shape": {
+            "heuristic": f"user contains {PRODUCTION_MENU_HEADER!r} and not {CANDIDATE_MARKER!r} (build_bridge_dataset.py)",
+            "production_n": production,
+            "candidate_n": candidate_shape,
+            "neither_n": neither_shape,
+            "production_fraction": round(production / n_ok, 4) if n_ok else None,
+            "autopilot_system_prompt_n": autopilot_system,
+        },
+        "menu_size": {
+            "n": len(menu_sizes),
+            "min": min(menu_sizes) if menu_sizes else None,
+            "median": int(statistics.median(menu_sizes)) if menu_sizes else None,
+            "mean": round(statistics.fmean(menu_sizes), 2) if menu_sizes else None,
+            "max": max(menu_sizes) if menu_sizes else None,
+        },
+        "gold_action_class_histogram": dict(action_hist),
+        "card_coverage": {
+            "distinct_cards_recognized": len(cards),
+            "unrecognized_distinct_tokens": len(unrecognized),
+            "unrecognized_total_occurrences": sum(unrecognized.values()),
+            "unrecognized_top20": unrecognized.most_common(20),
+        },
+        "trivial_policies": trivial,
+    }
+    return {"stats": stats, "cards": cards, "usable_lines": usable_lines}
+
+
+# ---------------------------------------------------------------------------
+# Mixture
+# ---------------------------------------------------------------------------
+
+
+def plan_mixture(n_mz: int, n_human_avail: int, human_weight: float, seed: int) -> dict:
+    """All magezero records + enough sampled human records to hit the weight."""
+    if not (0.0 <= human_weight < 1.0):
+        raise ValueError("--human-weight must be in [0, 1)")
+    n_human_target = round(human_weight / (1.0 - human_weight) * n_mz) if human_weight else 0
+    capped = n_human_target > n_human_avail
+    n_human = min(n_human_target, n_human_avail)
+    total = n_mz + n_human
+    return {
+        "requested_human_weight": human_weight,
+        "magezero_records": n_mz,
+        "human_records_target": n_human_target,
+        "human_records_available": n_human_avail,
+        "human_records_sampled": n_human,
+        "capped_by_availability": capped,
+        "realized_human_share": round(n_human / total, 4) if total else 0.0,
+        "total_records": total,
+        "seed": seed,
+    }
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            check=True,
+        ).stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--magezero-corpus", required=True, help="MageZero (depth) corpus .jsonl")
+    ap.add_argument("--human-corpus", required=True, help="human (breadth) corpus .jsonl")
+    ap.add_argument("--human-weight", type=float, required=True, help="target human share of the mixture, e.g. 0.2")
+    ap.add_argument("--out", required=True, help="manifest JSON output path")
+    ap.add_argument("--vocab", default=DEFAULT_VOCAB, help=f"MTGJSON name index (default {DEFAULT_VOCAB})")
+    ap.add_argument("--seed", type=int, default=20260731)
+    ap.add_argument(
+        "--emit",
+        default=None,
+        metavar="PATH",
+        help="ALSO write the mixed training .jsonl to PATH. Off by default: the "
+        "owner picks the weight from the manifest BEFORE any training data is built.",
+    )
+    ap.add_argument(
+        "--min-production-share",
+        type=float,
+        default=None,
+        help="with --emit: refuse (exit 2) if the mixture's production-shape fraction is below this floor",
+    )
+    args = ap.parse_args(argv)
+
+    if not os.path.isfile(args.vocab):
+        print(f"FAIL: card-name vocab not found at {args.vocab} — coverage numbers would be unvalidated. Fail closed.")
+        return 2
+    vocab = load_vocab(args.vocab)
+
+    t0 = time.time()
+    mz = scan_corpus(args.magezero_corpus, vocab)
+    human = scan_corpus(args.human_corpus, vocab, keep_line_numbers=True)
+
+    n_mz = mz["stats"]["records_usable"]
+    n_human_avail = human["stats"]["records_usable"]
+    if n_mz == 0 or n_human_avail == 0:
+        print("FAIL: a source corpus has zero usable records — fail closed.")
+        return 2
+
+    mixture = plan_mixture(n_mz, n_human_avail, args.human_weight, args.seed)
+
+    # Deterministic sample of human usable-line indices.
+    rng = random.Random(args.seed)
+    sampled_positions = sorted(
+        rng.sample(range(n_human_avail), mixture["human_records_sampled"])
+    )
+    sampled_linenos = set(human["usable_lines"][p] for p in sampled_positions)
+
+    # Second pass over the human corpus: coverage + production share of the
+    # sampled subset (exact, not extrapolated).
+    sampled_cards: set[str] = set()
+    sampled_production = 0
+    unrec = Counter()
+    with open(args.human_corpus, encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh):
+            if lineno not in sampled_linenos:
+                continue
+            rec = json.loads(raw)
+            user = rec["user"]
+            if PRODUCTION_MENU_HEADER in user and CANDIDATE_MARKER not in user:
+                sampled_production += 1
+            sampled_cards |= extract_cards_from_user(user, vocab, unrec)
+
+    mix_total = mixture["total_records"]
+    mix_production = mz["stats"]["production_shape"]["production_n"] + sampled_production
+    mixture_stats = {
+        **mixture,
+        "distinct_cards": {
+            "magezero": len(mz["cards"]),
+            "human_full_corpus": len(human["cards"]),
+            "human_sampled_subset": len(sampled_cards),
+            "mixture_union": len(mz["cards"] | sampled_cards),
+            "mixture_new_vs_magezero": len(sampled_cards - mz["cards"]),
+            "full_union_ceiling": len(mz["cards"] | human["cards"]),
+        },
+        "production_shape_fraction": round(mix_production / mix_total, 4) if mix_total else None,
+        "production_shape_n": mix_production,
+    }
+
+    manifest = {
+        "manifest": "wp3_mixture_prototype_v1",
+        "purpose": (
+            "breadth-vs-depth mixture PROTOTYPE — owner picks --human-weight from these "
+            "numbers before any training data is built (rl-pipeline-fix.md MORNING PRIORITY item 4)"
+        ),
+        "built_ts": time.time(),
+        "git_sha": _git_sha(),
+        "elapsed_seconds": round(time.time() - t0, 2),
+        "vocab": {"path": args.vocab, "entries": len(vocab)},
+        "sources": {
+            "magezero": mz["stats"],
+            "human": human["stats"],
+        },
+        "mixture": mixture_stats,
+        "emitted": None,
+    }
+
+    if args.emit:
+        if os.path.exists(args.emit):
+            print(f"FAIL: --emit target {args.emit} already exists — refusing to overwrite.")
+            return 2
+        if (
+            args.min_production_share is not None
+            and mixture_stats["production_shape_fraction"] < args.min_production_share
+        ):
+            print(
+                f"FAIL: mixture production-shape fraction "
+                f"{mixture_stats['production_shape_fraction']} < floor {args.min_production_share} — fail closed."
+            )
+            return 2
+        lines_out: list[str] = []
+        with open(args.magezero_corpus, encoding="utf-8") as fh:
+            for raw in fh:
+                try:
+                    rec = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec.get("user"), str) and isinstance(rec.get("response"), str):
+                    lines_out.append(raw if raw.endswith("\n") else raw + "\n")
+        with open(args.human_corpus, encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh):
+                if lineno in sampled_linenos:
+                    lines_out.append(raw if raw.endswith("\n") else raw + "\n")
+        rng2 = random.Random(args.seed + 1)
+        rng2.shuffle(lines_out)
+        with open(args.emit, "w", encoding="utf-8") as fh:
+            fh.writelines(lines_out)
+        sha = hashlib.sha256("".join(lines_out).encode("utf-8")).hexdigest()
+        manifest["emitted"] = {"path": args.emit, "records": len(lines_out), "sha256": sha}
+        print(f"emitted {len(lines_out)} records -> {args.emit}")
+    else:
+        print("manifest only — no training data written (pass --emit to build the mixture file)")
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(manifest, fh, indent=2)
+        fh.write("\n")
+    print(f"manifest -> {args.out}")
+    print(
+        json.dumps(
+            {
+                "magezero_records": n_mz,
+                "human_records_available": n_human_avail,
+                "mixture": mixture_stats,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/training/wp3/next_run_diverse.yml
+++ b/tools/training/wp3/next_run_diverse.yml
@@ -1,0 +1,77 @@
+# next_run_diverse.yml — FINALIZED config for the NEXT MageZero curriculum run
+# (tracked mtgacoach-side copy; the live file is configs/run_diverse.yml in the
+#  separate magezero repo — deploy step below).
+#
+# DEPLOY (one file copy, run only between curriculum runs, NEVER mid-run):
+#   cp tools/training/wp3/next_run_diverse.yml \
+#      /home/joshu/repos/magezero/configs/run_diverse.yml
+#
+# Provenance:
+#   - Opponent set: issue #438 greedy-optimal 5 (exhaustive search over 23
+#     candidate decks, tools/training/wp3/deck_inventory.py), ADDED to the 5
+#     retained Standard-Mono baseline opponents. Pool: 83 -> 235 distinct
+#     cards (2.8x).
+#   - games_per_gen 550 / generations 6: matches the live run.yml scale the
+#     550-bump paid for (rl-pipeline-fix.md MORNING PRIORITY item 3 — start
+#     the NEXT run diverse by default, never change opponents mid-run).
+#   - PERMANENT HOLDOUT decks (unseen-deck gate slice contract): HighNoonControl,
+#     BGRoots, BWBats must NEVER appear as primary or opponent in ANY training
+#     config. Enforced by tools/training/wp3/validate_run_config.py (wired as
+#     tests/test_validate_run_config.py). Do not add them here.
+#
+# Coverage analysis (from tools/training/wp3/deck_inventory.py):
+#   UWTempo + 5 Standard-Mono:            83 distinct cards
+#   Added by the 5 diverse opponents:    152 new cards
+#   New pool:                            235 distinct cards
+#
+#   1. Oathbreaker_UR    — 46 cards, 41 new, UR storm/combo
+#   2. GBLegends         — 37 cards, 31 new, WUBRG 5c legends
+#   3. EVG_Elves         — 28 cards, 27 new, G tribal aggro
+#   4. EVG_Goblins       — 28 cards, 27 new, R tribal aggro
+#   5. Mind(MindvsMight) — 29 cards, 27 new, UR spellslinger
+#
+# Role diversity added: storm/combo, 5-colour goodstuff, tribal x2,
+# spellslinger — none of which the 5 mono opponents expose the student to.
+
+deck: UWTempo
+version: 2
+start_from_version: null   # owner call at deploy time: null = fresh bootstrap;
+                           # set to the final version of the current 550-run to
+                           # resume from its checkpoint instead.
+
+generations: 6
+games_per_gen: 550
+replay_buffer_gens: 3
+
+opponents:
+  # — retained Standard-Mono baseline opponents —
+  - deck: Standard-MonoR
+    mode: minimax
+  - deck: Standard-MonoG
+    mode: minimax
+  - deck: Standard-MonoB
+    mode: minimax
+  - deck: Standard-MonoW
+    mode: minimax
+  - deck: Standard-MonoU
+    mode: minimax
+  # — #438 diverse coverage opponents —
+  - deck: Oathbreaker_UR
+    mode: minimax
+  - deck: GBLegends
+    mode: minimax
+  - deck: EVG_Elves
+    mode: minimax
+  - deck: EVG_Goblins
+    mode: minimax
+  - deck: Mind(MindvsMight)
+    mode: minimax
+
+training:
+  analyze_dataset: true
+  generate_plots: true
+  eval_previous_model: true
+
+log_level: ACTIONS           # ALL | GAMEPLAY | ACTIONS | ERROR
+
+curriculum: configs/curriculum.yml

--- a/tools/training/wp3/validate_run_config.py
+++ b/tools/training/wp3/validate_run_config.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Fail-closed holdout-deck validator for MageZero run configs.
+
+THE CONTRACT (rl-pipeline-fix.md MORNING PRIORITY, 2026-07-30): the unseen-deck
+gate slice is only honest if its decks appear in NO training corpus, ever. The
+permanent holdout decks are:
+
+    HighNoonControl, BGRoots, BWBats
+
+This script FAILS (exit 2) if any run config lists a holdout deck as the
+primary ``deck:`` or as any ``opponents[].deck``. It fails CLOSED: a config it
+cannot read, cannot parse, or whose deck fields it cannot positively identify
+is a violation, never a skip — a typo'd config must not slip a holdout deck
+into training because the validator shrugged.
+
+Matching is normalized (case-insensitive, whitespace-stripped, optional
+``.dck`` suffix ignored) so ``highnooncontrol.dck`` cannot dodge the check.
+
+Usage:
+    validate_run_config.py <config.yml> [<config2.yml> ...]
+    validate_run_config.py --configs-dir /home/joshu/repos/magezero/configs
+
+With no arguments it validates the tracked configs in this directory
+(``next_run_diverse.yml``, ``run_baseline.yml``).
+
+Exit codes: 0 = all configs clean; 2 = violation or unreadable/ambiguous
+config (fail closed).
+
+Wired as a test in tests/test_validate_run_config.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# The permanent holdout set. Extend only by owner decision, and only ever GROW
+# it — removing a deck from here invalidates every unseen-deck gate number
+# measured while it was held out.
+HOLDOUT_DECKS = frozenset({"HighNoonControl", "BGRoots", "BWBats"})
+
+_WP3_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIGS = [
+    _WP3_DIR / "next_run_diverse.yml",
+    _WP3_DIR / "run_baseline.yml",
+]
+
+# Config filenames that are not run configs (no deck/opponents keys) and are
+# therefore out of scope when scanning a --configs-dir wholesale.
+NON_RUN_CONFIG_NAMES = frozenset({"curriculum.yml", "game.yml", "game_smoke.yml"})
+
+
+def _norm(name: object) -> str:
+    """Normalize a deck name for holdout comparison."""
+    s = str(name).strip().lower()
+    if s.endswith(".dck"):
+        s = s[: -len(".dck")]
+    return s
+
+
+_HOLDOUT_NORM = {_norm(d): d for d in HOLDOUT_DECKS}
+
+
+def validate_config(path: Path) -> list[str]:
+    """Return a list of violation strings for one config file (empty = clean).
+
+    Fail closed: any inability to positively determine the deck fields is
+    itself a violation.
+    """
+    violations: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [f"{path}: unreadable ({e}) — fail closed"]
+    try:
+        cfg = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        return [f"{path}: YAML parse error ({e}) — fail closed"]
+
+    if not isinstance(cfg, dict):
+        return [f"{path}: top level is {type(cfg).__name__}, expected mapping — fail closed"]
+
+    # Primary deck — must exist and must not be a holdout.
+    primary = cfg.get("deck")
+    if primary is None:
+        violations.append(f"{path}: missing 'deck' key — cannot prove primary is not a holdout — fail closed")
+    elif _norm(primary) in _HOLDOUT_NORM:
+        violations.append(
+            f"{path}: primary deck {primary!r} is permanent holdout "
+            f"{_HOLDOUT_NORM[_norm(primary)]!r} — holdouts must appear in NO training config"
+        )
+
+    # Opponents — the list must be well-formed and each entry checkable.
+    opponents = cfg.get("opponents")
+    if opponents is None:
+        violations.append(f"{path}: missing 'opponents' key — fail closed")
+    elif not isinstance(opponents, list) or not opponents:
+        violations.append(f"{path}: 'opponents' is not a non-empty list — fail closed")
+    else:
+        for i, opp in enumerate(opponents):
+            if not isinstance(opp, dict) or "deck" not in opp:
+                violations.append(f"{path}: opponents[{i}] has no 'deck' field — fail closed")
+                continue
+            name = opp["deck"]
+            if _norm(name) in _HOLDOUT_NORM:
+                violations.append(
+                    f"{path}: opponents[{i}] deck {name!r} is permanent holdout "
+                    f"{_HOLDOUT_NORM[_norm(name)]!r} — holdouts must appear in NO training config"
+                )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("configs", nargs="*", type=Path, help="run config YAML files to validate")
+    ap.add_argument(
+        "--configs-dir",
+        type=Path,
+        default=None,
+        help="also validate every *.yml in this directory (known non-run configs skipped by name)",
+    )
+    args = ap.parse_args(argv)
+
+    targets: list[Path] = list(args.configs)
+    if args.configs_dir is not None:
+        if not args.configs_dir.is_dir():
+            print(f"FAIL: --configs-dir {args.configs_dir} is not a directory — fail closed")
+            return 2
+        targets.extend(
+            p
+            for p in sorted(args.configs_dir.glob("*.yml"))
+            if p.name not in NON_RUN_CONFIG_NAMES and not p.name.startswith("run.yml.bak")
+        )
+    if not targets:
+        targets = list(DEFAULT_CONFIGS)
+
+    all_violations: list[str] = []
+    for path in targets:
+        vs = validate_config(path)
+        all_violations.extend(vs)
+        status = "FAIL" if vs else "ok"
+        print(f"[{status}] {path}")
+        for v in vs:
+            print(f"    {v}")
+
+    if all_violations:
+        print(f"\nFAIL: {len(all_violations)} violation(s) across {len(targets)} config(s).")
+        print("Permanent holdout decks (unseen-deck gate contract): " + ", ".join(sorted(HOLDOUT_DECKS)))
+        return 2
+    print(f"\nOK: {len(targets)} config(s) clean of holdout decks ({', '.join(sorted(HOLDOUT_DECKS))}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What (MORNING PRIORITY items 3+4 — config + prototype + validation only)

No training was run. No live-run file was touched (magezero `configs/run.yml` and `configs/run_diverse.yml` unmodified; deploy of the new config is a deliberate one-file copy, documented in the config header and PROGRESS file).

### Item 3 — diversity config for the NEXT curriculum run

`tools/training/wp3/next_run_diverse.yml` (tracked mtgacoach-side copy of the magezero `run_diverse.yml` draft, finalized):
- #438 greedy-optimal five opponents, exact `.dck` basenames verified against `deck_inventory.json`: `Oathbreaker_UR`, `GBLegends`, `EVG_Elves`, `EVG_Goblins`, `Mind(MindvsMight)` — plus the 5 retained Standard-Mono baselines. Card pool 83 -> 235 distinct (2.8x, from #438).
- `games_per_gen: 550` (draft had the pre-bump 200), `generations: 6`.
- Deploy (between runs only, never mid-run): `cp tools/training/wp3/next_run_diverse.yml /home/joshu/repos/magezero/configs/run_diverse.yml`

### Holdout contract — keeps the unseen-deck gate slice honest forever

`tools/training/wp3/validate_run_config.py` FAILS (exit 2) if any run config lists a permanent holdout deck (**HighNoonControl, BGRoots, BWBats**) as primary or opponent. Fails CLOSED on unreadable/unparseable/ambiguous configs. Normalized matching (case, whitespace, `.dck`). Wired as `tests/test_validate_run_config.py` (20 tests: contract pinned, every holdout tested both roles, all fail-closed branches, tracked config asserted clean + at 550x6 with the #438 five).

Measured against the live magezero configs dir:
```
[ok] /home/joshu/repos/magezero/configs/run.yml
[ok] /home/joshu/repos/magezero/configs/run_diverse.yml
OK: 2 config(s) clean of holdout decks (BGRoots, BWBats, HighNoonControl).
```

### Item 4 — breadth-vs-depth mixture manifest PROTOTYPE (owner picks the weight)

`tools/training/wp3/build_mixture_manifest.py --magezero-corpus ... --human-corpus ... --human-weight W --out manifest.json`
- MANIFEST ONLY — refuses to write training data without `--emit` (which also refuses overwrite and supports a `--min-production-share` fail-closed floor).
- Production-shape = the repo `Legal:` heuristic from `build_bridge_dataset.py` (`"Legal: (pick by number)"` in user, no `"Candidate:"`).
- Distinct-card coverage validated against `~/.arenamcp/mtgjson/name_index.json` (34,633 names + DFC-face aliases); unresolvable tokens counted + top-20 reported, never silently included.
- Trivial-policy floors per source (same reflex families as `gate_play_decisions.py` G6); `meta.gold_equivalent_picks` used where present (988 bridge records), single gold pick otherwise (lower bound, stated in manifest).
- 16 fixture-only unit tests.

**Human/Phase-0 corpora located on disk** (`tools/training/data/`, gitignored; all share `{system, user, response, source, attribution, kind, meta}`): `play_decisions.jsonl` (223 MB, 17lands, Candidate-shape), `play_decisions_nontrivial.jsonl` (13,671), `play_decisions_cast.jsonl`, `play_decisions_bridge.jsonl` (988, 100% production, real MTGA menus), `play_decisions_mixed.jsonl` (14,659, 6.74% production), `stage0_prompts_*` / `stage0_turnaction_*` / `stage0v2_*` (~0.8 GB, pre-WP3 prompt shapes).

## Demo manifest — MEASURED, `--human-weight 0.2`, seed 20260731, 4.0 s

`wp3_v2_priority/train.jsonl` (depth) x `play_decisions_mixed.jsonl` (breadth). Mixture: **4,808 magezero + 1,202 sampled human = 6,010 records**, realized human share 0.2000 (not capped; 14,659 available).

| metric | magezero | human (mixed) | mixture @ W=0.2 |
|---|---|---|---|
| records (drops) | 4,808 (0) | 14,659 (0) | 6,010 |
| production-shape fraction | 1.0000 | 0.0674 | **0.8128** |
| distinct cards (vocab-validated) | 66 | 1,721 | **1,198** (1,132 new vs magezero) |
| menu size median/mean | 3 / 3.18 | 7 / 7.17 | — |
| gold-action classes | pass 2,026 / cast 1,389 / play 882 / activate 511 | play_land 13,397 / cast 1,158 / pass 76 / activate 24 / other 4 | — |
| best trivial policy | always_land_else_first **0.7633** | always_land_else_first **0.4424** | — |
| unrecognized tokens (distinct / occ) | 10 / 610 | 1,468 / 6,009 | — |

Full-union ceiling (weight -> 1): 1,753 distinct cards. Manifest artifact: `tools/training/data/mixture_manifest_w020.json`.

For the weight decision (numbers, not recommendations):
1. Breadth is cheap: W=0.2 grows the card pool 66 -> 1,198 (18x) while production-shape stays 0.81.
2. The human slice is land-drop heavy: 91.4% of its gold labels are `Play Land:` picks — the 69%-land-drop lesson shape; a land-drop cap knob on the human slice is probably wanted before any training build.
3. The magezero corpus's own reflex ceiling: always_land_else_first 0.7633; always_first_option 0.8032 (verified vs raw records: pick 1 in 3,862/4,808, of which 2,026 have entry 1 = "Pass").
4. Remaining unrecognized tokens are genuine non-cards (Clue/Spirit/Lander tokens) + XMage short-name renderings; DFC faces, `x2`, P/T, `,attacking` suffixes handled (magezero unrecognized occurrences 1,496 -> 610 after fixes).

## How tested

```
pytest tests/test_validate_run_config.py tests/test_build_mixture_manifest.py tests/test_deck_inventory.py -q
56 passed
```
plus the measured demo run above and the live-configs validator run.
