### PR TITLE
wp3: unseen-deck gate slice — parameterized deck-signature guardrail, gate-shaped corpus builder, --unseen-corpus generalization

### DIFF
--- a/tests/test_unseen_deck_gate.py
+++ b/tests/test_unseen_deck_gate.py
@@ -1,0 +1,574 @@
+"""Unseen-deck gate slice wiring (MORNING PRIORITY item 1, measurement half).
+
+Proves, on fixtures, everything that must work before the real holdout logs
+(mz_unseen_HighNoonControl_vs_BGRoots.log / mz_unseen_BWBats_vs_HighNoonControl.log)
+exist:
+
+1. parse_magezero_log works when the PRIMARY deck is NOT UWTempo — deck
+   signatures derive from the .dck lists (filename inference or
+   --primary-deck), and attribution ambiguity / off-deck hands FAIL CLOSED.
+2. build_unseen_gate_corpus emits records in the strategic-gate shape that
+   run_b5_gate_eval.check_corpora accepts, with valid permuted twins.
+3. run_b5_gate_eval's --unseen-corpus generalization scoring produces the
+   seen/unseen/gap/CI section, and the flag defaults to None (absent flag =
+   unchanged behavior).
+
+The fixture log reuses the exact line grammar validated against
+mz_train_smoke.log in tests/test_parse_magezero_log.py, with players/cards
+renamed per the real BGRoots/HighNoonControl .dck lists.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+REPO = _HERE.parent
+sys.path.insert(0, str(REPO / "tools" / "training"))
+
+from parse_magezero_log import (  # noqa: E402
+    LAST_PARSE_STATS,
+    DeckSignatureError,
+    infer_decks_from_log_name,
+    parse_dck_names,
+    parse_log,
+    resolve_primary_deck,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture material: real BGRoots / HighNoonControl names from the .dck lists
+# ---------------------------------------------------------------------------
+
+BGROOTS_DCK = """4 [OTJ:266] Blooming Marsh
+4 [LCI:102] Deep-Cavern Bat
+3 [TMT:257] Forest
+4 [MKM:208] Insidious Roots
+2 [FDN:227] Llanowar Elves
+4 [BRO:264] Llanowar Wastes
+4 [MKM:105] Snarling Gorehound
+2 [TMT:255] Swamp
+4 [ONE:218] Tyvar, Jubilant Brawler
+4 [DFT:268] Wastewood Verge
+LAYOUT MAIN:(1,1)(NONE,false,50)|([OTJ:266],[OTJ:266])
+"""
+
+HIGHNOON_DCK = """4 [KTK:233] Flooded Strand
+4 [OTJ:15] High Noon
+1 [TMT:254] Island
+3 [CLU:141] Lightning Bolt
+1 [TMT:256] Mountain
+1 [TMT:253] Plains
+4 [M11:70] Preordain
+3 [H2R:3] Solitude
+4 [EMN:189] Spell Queller
+"""
+
+T = "=>[pool-3-thread-1]"
+
+# Grammar identical to the shapes pinned in tests/test_parse_magezero_log.py
+# (named-hand logList lines, logLife, playable abilities, pool, chose action),
+# only the deck is BGRoots. One game, 3 chose-action windows + 1 recovered
+# pass; "Tyvar, Jubilant Brawler" exercises comma-name segmentation.
+FIXTURE_LOG = (
+    "INFO  2026-07-31 08:00:00,000 Simulating 1 games. =>[main]\n"
+    f"INFO  2026-07-31 08:00:01,000 Player A won the die roll {T} GameImpl\n"
+    f"INFO  2026-07-31 08:00:02,000 [1:Beginning:UPKEEP]PlayerA hand: : "
+    f"Swamp,Llanowar Elves,Deep-Cavern Bat,Tyvar, Jubilant Brawler, {T} ComputerPlayer.logList \n"
+    f"INFO  2026-07-31 08:00:03,000 [1:Precombat Main:PRECOMBAT_MAIN]"
+    f"[player PlayerA:20][player PlayerB:20] {T} GameImpl.logLife\n"
+    f"INFO  2026-07-31 08:00:04,000 [1:Precombat Main:PRECOMBAT_MAIN]PlayerA "
+    f"playable abilities: [Play Swamp, Pass] {T} ComputerPlayerMCTS\n"
+    f"INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.1 count: 50] "
+    f"[Play Swamp score: 0.1 count: 200] {T} MCTSNode.bestChild\n"
+    f"INFO  2026-07-31 08:00:05,000 [1:Precombat Main:PRECOMBAT_MAIN]"
+    f"chose action:Play Swamp success ratio: 0.1 {T} ComputerPlayerMCTS\n"
+    f"INFO  2026-07-31 08:00:06,000 [2:Beginning:UPKEEP]PlayerA hand: : "
+    f"Llanowar Elves,Deep-Cavern Bat,Tyvar, Jubilant Brawler,Llanowar Wastes, {T} ComputerPlayer.logList \n"
+    f"INFO  2026-07-31 08:00:07,000 [2:Precombat Main:PRECOMBAT_MAIN]"
+    f"[player PlayerA:20][player PlayerB:19] {T} GameImpl.logLife\n"
+    f"INFO  2026-07-31 08:00:08,000 [2:Precombat Main:PRECOMBAT_MAIN]PlayerA "
+    f"playable abilities: [Cast Llanowar Elves, Play Llanowar Wastes, Pass] {T} ComputerPlayerMCTS\n"
+    f"INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.05 count: 30] "
+    f"[Cast Llanowar Elves score: 0.2 count: 400] "
+    f"[Play Llanowar Wastes score: 0.05 count: 100] {T} MCTSNode.bestChild\n"
+    f"INFO  2026-07-31 08:00:09,000 [2:Precombat Main:PRECOMBAT_MAIN]"
+    f"chose action:Cast Llanowar Elves success ratio: 0.2 {T} ComputerPlayerMCTS\n"
+    f"INFO  2026-07-31 08:00:10,000 [3:Beginning:UPKEEP]PlayerA hand: : "
+    f"Deep-Cavern Bat,Tyvar, Jubilant Brawler, {T} ComputerPlayer.logList \n"
+    f"INFO  2026-07-31 08:00:11,000 [3:Precombat Main:PRECOMBAT_MAIN]"
+    f"[player PlayerA:18][player PlayerB:17] {T} GameImpl.logLife\n"
+    f"INFO  2026-07-31 08:00:12,000 [3:Precombat Main:PRECOMBAT_MAIN]PlayerA "
+    f"playable abilities: [Cast Deep-Cavern Bat, Cast Tyvar, Jubilant Brawler, Pass] {T} ComputerPlayerMCTS\n"
+    f"INFO  PRECOMBAT_MAIN0pool= actions: [Pass score: -0.02 count: 20] "
+    f"[Cast Deep-Cavern Bat score: 0.3 count: 300] "
+    f"[Cast Tyvar, Jubilant Brawler score: 0.1 count: 150] {T} MCTSNode.bestChild\n"
+    f"INFO  2026-07-31 08:00:13,000 [3:Precombat Main:PRECOMBAT_MAIN]"
+    f"chose action:Cast Deep-Cavern Bat success ratio: 0.3 {T} ComputerPlayerMCTS\n"
+    # Recovered pass window: pool never consumed by a chose line, argmax Pass.
+    f"INFO  2026-07-31 08:00:14,000 [3:Postcombat Main:POSTCOMBAT_MAIN]PlayerA "
+    f"playable abilities: [Cast Tyvar, Jubilant Brawler, Pass] {T} ComputerPlayerMCTS\n"
+    f"INFO  POSTCOMBAT_MAIN0pool= actions: [Pass score: 0.4 count: 500] "
+    f"[Cast Tyvar, Jubilant Brawler score: 0.02 count: 40] {T} MCTSNode.bestChild\n"
+    "INFO  2026-07-31 08:00:15,000 Player A win rate: 100.00% (1/1) =>[main]\n"
+)
+
+BGROOTS_NAMES = {
+    "Blooming Marsh",
+    "Deep-Cavern Bat",
+    "Forest",
+    "Insidious Roots",
+    "Llanowar Elves",
+    "Llanowar Wastes",
+    "Snarling Gorehound",
+    "Swamp",
+    "Tyvar, Jubilant Brawler",
+    "Wastewood Verge",
+}
+
+
+@pytest.fixture()
+def decks_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "decks"
+    d.mkdir()
+    (d / "BGRoots.dck").write_text(BGROOTS_DCK, encoding="utf-8")
+    (d / "HighNoonControl.dck").write_text(HIGHNOON_DCK, encoding="utf-8")
+    return d
+
+
+@pytest.fixture()
+def fixture_log(tmp_path: Path) -> Path:
+    p = tmp_path / "mz_unseen_BGRoots_vs_HighNoonControl.log"
+    p.write_text(FIXTURE_LOG, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# 1. Deck resolution: derive-from-.dck, --primary-deck override, fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestDeckResolution:
+    def test_dck_parsing_matches_deck_list(self, decks_dir: Path):
+        assert parse_dck_names(decks_dir / "BGRoots.dck") == frozenset(BGROOTS_NAMES)
+
+    def test_filename_inference(self):
+        assert infer_decks_from_log_name("mz_unseen_HighNoonControl_vs_BGRoots.log") == (
+            "HighNoonControl",
+            "BGRoots",
+        )
+        assert infer_decks_from_log_name("/x/y/mz_unseen_BWBats_vs_HighNoonControl.log") == (
+            "BWBats",
+            "HighNoonControl",
+        )
+
+    def test_legacy_log_names_do_not_infer(self):
+        assert infer_decks_from_log_name("mz_train_smoke.log") is None
+        assert infer_decks_from_log_name("mz_train.log") is None
+
+    def test_resolve_by_inference(self, decks_dir: Path):
+        name, cards = resolve_primary_deck(
+            "mz_unseen_BGRoots_vs_HighNoonControl.log", decks_dir=decks_dir
+        )
+        assert name == "BGRoots"
+        assert cards == frozenset(BGROOTS_NAMES)
+
+    def test_explicit_primary_deck_wins_over_filename(self, decks_dir: Path):
+        name, cards = resolve_primary_deck(
+            "mz_unseen_BGRoots_vs_HighNoonControl.log",
+            primary_deck="HighNoonControl",
+            decks_dir=decks_dir,
+        )
+        assert name == "HighNoonControl"
+        assert "Lightning Bolt" in cards
+
+    def test_explicit_deck_missing_fails_closed(self, decks_dir: Path):
+        with pytest.raises(DeckSignatureError):
+            resolve_primary_deck("whatever.log", primary_deck="NoSuchDeck", decks_dir=decks_dir)
+
+    def test_inferred_deck_missing_dck_fails_closed(self, decks_dir: Path):
+        """A deck-NAMED log whose list is absent is ambiguous — never skipped."""
+        with pytest.raises(DeckSignatureError):
+            resolve_primary_deck("mz_unseen_EsperTempo_vs_BGRoots.log", decks_dir=decks_dir)
+
+    def test_no_signature_source_returns_none(self, decks_dir: Path):
+        assert resolve_primary_deck("mz_train_smoke.log", decks_dir=decks_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Parser on a non-UWTempo primary deck
+# ---------------------------------------------------------------------------
+
+
+class TestNonUWTempoParsing:
+    def test_parses_and_attributes_hands(self, fixture_log: Path, decks_dir: Path):
+        decisions, sessions = parse_log(str(fixture_log), decks_dir=decks_dir)
+        assert len(decisions) == 4  # 3 chose-action + 1 recovered pass
+        for d in decisions:
+            for card in d["hand"]:
+                assert card in BGROOTS_NAMES, f"off-deck hand card {card!r}"
+        by_turn = {(d["turn"], d["phase"]): d for d in decisions}
+        assert by_turn[(1, "PRECOMBAT_MAIN")]["hand"] == [
+            "Swamp",
+            "Llanowar Elves",
+            "Deep-Cavern Bat",
+            "Tyvar, Jubilant Brawler",
+        ]
+        assert by_turn[(1, "PRECOMBAT_MAIN")]["chosen"] == "Play Swamp"
+        assert by_turn[(2, "PRECOMBAT_MAIN")]["chosen"] == "Cast Llanowar Elves"
+        # Comma-named card survives menu segmentation via the pool vocab.
+        assert "Cast Tyvar, Jubilant Brawler" in by_turn[(3, "PRECOMBAT_MAIN")]["menu"]
+        assert by_turn[(3, "POSTCOMBAT_MAIN")]["chosen"] == "Pass"
+        assert LAST_PARSE_STATS["deck_signature_checked_rows"] == 4
+
+    def test_session_label_uses_resolved_deck_not_uwtempo(self, fixture_log: Path, decks_dir: Path):
+        decisions, sessions = parse_log(str(fixture_log), decks_dir=decks_dir)
+        assert sessions[0].label == "session0_BGRoots_vs_HighNoonControl"
+        assert all(d["session"] == "session0_BGRoots_vs_HighNoonControl" for d in decisions)
+
+    def test_off_deck_hand_fails_closed(self, tmp_path: Path, decks_dir: Path):
+        """An opponent card in the primary hand aborts the parse — the #452/#457
+        guardrail as a runtime check, parameterized by the .dck, not weakened."""
+        polluted = FIXTURE_LOG.replace(
+            "Swamp,Llanowar Elves,Deep-Cavern Bat,Tyvar, Jubilant Brawler,",
+            "Swamp,Lightning Bolt,Deep-Cavern Bat,Tyvar, Jubilant Brawler,",
+        )
+        p = tmp_path / "mz_unseen_BGRoots_vs_HighNoonControl.log"
+        p.write_text(polluted, encoding="utf-8")
+        with pytest.raises(DeckSignatureError) as exc:
+            parse_log(str(p), decks_dir=decks_dir)
+        assert "Lightning Bolt" in str(exc.value)
+
+    def test_wrong_primary_deck_designation_fails_closed(self, fixture_log: Path, decks_dir: Path):
+        """Designating the OPPONENT deck as primary must abort, not mislabel."""
+        with pytest.raises(DeckSignatureError):
+            parse_log(str(fixture_log), primary_deck="HighNoonControl", decks_dir=decks_dir)
+
+    def test_legacy_log_unchanged(self, tmp_path: Path, decks_dir: Path):
+        """No deck names in the filename + no --primary-deck = old behavior."""
+        p = tmp_path / "mz_custom.log"
+        p.write_text(FIXTURE_LOG, encoding="utf-8")
+        decisions, sessions = parse_log(str(p), decks_dir=decks_dir)
+        assert len(decisions) == 4
+        assert LAST_PARSE_STATS["deck_signature_checked_rows"] == 0
+        assert sessions[0].label.startswith("session0_UWTempo_vs_")
+
+    def test_pipeline_plumbs_primary_deck(self):
+        import inspect
+
+        from tools.training import run_wp3_pipeline as P
+
+        assert "primary_deck" in inspect.signature(P.run_pipeline).parameters
+        assert "decks_dir" in inspect.signature(P.run_pipeline).parameters
+        args = P.build_arg_parser().parse_args(["--log", "x.log"])
+        assert args.primary_deck is None
+        assert args.decks_dir is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Corpus builder: gate-shaped records + permuted twins, fail-closed rules
+# ---------------------------------------------------------------------------
+
+
+def _build(tmp_path: Path, fixture_log: Path, decks_dir: Path, *extra: str) -> Path:
+    from tools.training.wp3 import build_unseen_gate_corpus as B
+
+    out_dir = tmp_path / "out"
+    fake_train = tmp_path / "fake_train.jsonl"
+    if not fake_train.exists():
+        fake_train.write_text(json.dumps({"user": "unrelated training prompt"}) + "\n", encoding="utf-8")
+    rc = B.main(
+        [
+            "--log",
+            str(fixture_log),
+            "--decks-dir",
+            str(decks_dir),
+            "--out-dir",
+            str(out_dir),
+            "--min-records",
+            "2",
+            "--training-corpus",
+            str(fake_train),
+            *extra,
+        ]
+    )
+    assert rc == 0
+    return out_dir
+
+
+class TestUnseenCorpusBuilder:
+    def test_emits_gate_shaped_records(self, tmp_path: Path, fixture_log: Path, decks_dir: Path):
+        from tools.training import build_magezero_bridge as BRIDGE
+
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        identity = out_dir / "gate_unseen_deck_test.jsonl"
+        permuted = out_dir / "gate_unseen_deck_test_permuted.jsonl"
+        manifest = out_dir / "gate_unseen_deck_manifest.json"
+        assert identity.is_file() and permuted.is_file() and manifest.is_file()
+
+        recs = [json.loads(x) for x in identity.read_text(encoding="utf-8").splitlines()]
+        # 4 parsed decisions - 1 land drop (excluded by default) = 3
+        assert len(recs) == 3
+        for r in recs:
+            for key in ("id", "system", "user", "max_tokens", "temperature", "meta"):
+                assert key in r, f"missing top-level key {key}"
+            assert r["system"] == BRIDGE.AUTOPILOT_SYSTEM_PROMPT
+            assert "Legal: (pick by number)" in r["user"]
+            m = r["meta"]
+            assert 1 <= m["gold_pick"] <= m["menu_size"]
+            assert m["gold_pick"] in m["gold_equivalent_picks"]
+            assert m["menu_size"] == len(m["menu"])
+            assert m["deck_seen_in_train"] is False
+            assert m["is_land_drop"] is False  # excluded by default
+            for row in m["menu"]:
+                for key in ("index", "text", "action_key", "action_type", "grp_id", "instance_id", "name"):
+                    assert key in row
+        golds = {r["meta"]["menu"][r["meta"]["gold_pick"] - 1]["text"] for r in recs}
+        assert golds == {"Cast Llanowar Elves", "Cast Deep-Cavern Bat", "Pass"}
+
+    def test_permuted_twins_valid(self, tmp_path: Path, fixture_log: Path, decks_dir: Path):
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        identity = {
+            json.loads(x)["id"]: json.loads(x)
+            for x in (out_dir / "gate_unseen_deck_test.jsonl").read_text(encoding="utf-8").splitlines()
+        }
+        perms = [
+            json.loads(x)
+            for x in (out_dir / "gate_unseen_deck_test_permuted.jsonl")
+            .read_text(encoding="utf-8")
+            .splitlines()
+        ]
+        assert len(perms) == len(identity)
+        for p in perms:
+            assert p["id"].endswith("#perm")
+            twin = identity[p["id"][: -len("#perm")]]
+            assert p["meta"]["twin_id"] == twin["id"]
+            assert p["meta"]["variant"] == "permuted"
+            assert "permutation" in p["meta"]
+            # The gold ANSWER is preserved under permutation.
+            gold_perm = p["meta"]["menu"][p["meta"]["gold_pick"] - 1]["text"]
+            gold_id = twin["meta"]["menu"][twin["meta"]["gold_pick"] - 1]["text"]
+            assert gold_perm == gold_id
+            # Same options, different order (or forced identical when n small).
+            assert sorted(r["text"] for r in p["meta"]["menu"]) == sorted(
+                r["text"] for r in twin["meta"]["menu"]
+            )
+
+    def test_check_corpora_accepts_the_pair(self, tmp_path: Path, fixture_log: Path, decks_dir: Path):
+        """The exact preflight run_b5_gate_eval applies must pass."""
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        n = R.check_corpora(
+            out_dir / "gate_unseen_deck_test.jsonl",
+            out_dir / "gate_unseen_deck_test_permuted.jsonl",
+        )
+        assert n == 3
+
+    def test_manifest_carries_histograms_and_provenance(
+        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
+    ):
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        m = json.loads((out_dir / "gate_unseen_deck_manifest.json").read_text(encoding="utf-8"))
+        assert m["inputs"][0]["primary_deck"] == "BGRoots"
+        assert m["inputs"][0]["deck_signature_checked_rows"] == 4
+        assert m["composition"]["by_gold_action_type"] == {
+            "ActionType_Cast": 2,
+            "ActionType_Pass": 1,
+        }
+        assert m["drops"]["land_drop_excluded"] == 1
+        assert "MCTS teacher pick" in m["gold_label_provenance"]
+
+    def test_training_deck_as_primary_fails_closed(self, tmp_path: Path, decks_dir: Path):
+        (decks_dir / "UWTempo.dck").write_text("7 [MKM:273] Island\n", encoding="utf-8")
+        p = tmp_path / "mz_unseen_UWTempo_vs_BGRoots.log"
+        p.write_text(FIXTURE_LOG, encoding="utf-8")
+        from tools.training.wp3 import build_unseen_gate_corpus as B
+
+        with pytest.raises(SystemExit) as exc:
+            B.main(
+                ["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")]
+            )
+        assert exc.value.code == 2
+
+    def test_unresolvable_deck_fails_closed(self, tmp_path: Path, decks_dir: Path):
+        p = tmp_path / "mz_mystery.log"
+        p.write_text(FIXTURE_LOG, encoding="utf-8")
+        from tools.training.wp3 import build_unseen_gate_corpus as B
+
+        with pytest.raises(SystemExit) as exc:
+            B.main(
+                ["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")]
+            )
+        assert exc.value.code == 2
+
+    def test_training_prompt_overlap_fails_closed(
+        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
+    ):
+        """A rendered prompt found in a training corpus must abort the build."""
+        from tools.training.wp3 import build_unseen_gate_corpus as B
+
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        rec = json.loads(
+            (out_dir / "gate_unseen_deck_test.jsonl").read_text(encoding="utf-8").splitlines()[0]
+        )
+        leaky_train = tmp_path / "leaky_train.jsonl"
+        leaky_train.write_text(json.dumps({"user": rec["user"]}) + "\n", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            B.main(
+                [
+                    "--log",
+                    str(fixture_log),
+                    "--decks-dir",
+                    str(decks_dir),
+                    "--out-dir",
+                    str(tmp_path / "out2"),
+                    "--min-records",
+                    "2",
+                    "--training-corpus",
+                    str(leaky_train),
+                ]
+            )
+        assert exc.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. run_b5_gate_eval generalization wiring
+# ---------------------------------------------------------------------------
+
+
+class TestGeneralizationWiring:
+    def test_flag_defaults_to_none(self):
+        """Absent flag = the option contributes nothing (additive guarantee)."""
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        args = R.build_parser().parse_args([])
+        assert args.unseen_corpus is None
+        assert args.unseen_permuted_corpus is None
+
+    def test_bootstrap_gap_degenerate_cases(self):
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        # Candidate perfect on seen, zero on unseen; baseline perfect on both.
+        seen = [(1, 1)] * 40
+        unseen = [(0, 1)] * 40
+        raw_ci, adj_ci = R._bootstrap_generalization(seen, unseen, bootstraps=200)
+        assert raw_ci == [1.0, 1.0]
+        assert adj_ci == [1.0, 1.0]
+
+    def test_bootstrap_gap_zero_when_identical(self):
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        pairs = [(1, 0), (0, 1), (1, 1), (0, 0)] * 10
+        raw_ci, adj_ci = R._bootstrap_generalization(pairs, list(pairs), bootstraps=500)
+        assert raw_ci[0] <= 0.0 <= raw_ci[1]
+        assert adj_ci[0] <= 0.0 <= adj_ci[1]
+
+    def test_compute_generalization_end_to_end(
+        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
+    ):
+        """Score the builder's real output through the same scorer the gate
+        uses (gate_play_decisions.evaluate) via compute_generalization."""
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        corpus = out_dir / "gate_unseen_deck_test.jsonl"
+        perm_corpus = out_dir / "gate_unseen_deck_test_permuted.jsonl"
+        recs = [json.loads(x) for x in corpus.read_text(encoding="utf-8").splitlines()]
+        perm_recs = [json.loads(x) for x in perm_corpus.read_text(encoding="utf-8").splitlines()]
+
+        cand, base = "cand-label", "base-label"
+
+        def wrong_pick(meta: dict) -> int:
+            for i in range(1, meta["menu_size"] + 1):
+                if i not in meta["gold_equivalent_picks"]:
+                    return i
+            raise AssertionError("no wrong pick exists")
+
+        def write_resp(path: Path, rows: list[tuple[str, str, int]]) -> Path:
+            with open(path, "w", encoding="utf-8") as f:
+                for pid, backend, pick in rows:
+                    f.write(
+                        json.dumps(
+                            {
+                                "prompt_id": pid,
+                                "backend": backend,
+                                "response": json.dumps({"actions": [{"pick": pick}]}),
+                            }
+                        )
+                        + "\n"
+                    )
+            return path
+
+        # Seen slice: candidate and baseline both answer gold (acc 1.0 each).
+        seen_cand = write_resp(
+            tmp_path / "seen_cand.jsonl", [(r["id"], cand, r["meta"]["gold_pick"]) for r in recs]
+        )
+        seen_base = write_resp(
+            tmp_path / "seen_base.jsonl", [(r["id"], base, r["meta"]["gold_pick"]) for r in recs]
+        )
+        # Unseen slice: candidate always wrong (acc 0.0), baseline gold (1.0).
+        unseen_cand = write_resp(
+            tmp_path / "unseen_cand.jsonl", [(r["id"], cand, wrong_pick(r["meta"])) for r in recs]
+        )
+        unseen_base = write_resp(
+            tmp_path / "unseen_base.jsonl", [(r["id"], base, r["meta"]["gold_pick"]) for r in recs]
+        )
+        unseen_perm = write_resp(
+            tmp_path / "unseen_perm.jsonl",
+            [(r["id"], cand, r["meta"]["gold_pick"]) for r in perm_recs],
+        )
+
+        g = R.compute_generalization(
+            seen_corpus_path=corpus,
+            seen_cand_resp=seen_cand,
+            seen_base_resp=seen_base,
+            unseen_corpus_path=corpus,
+            unseen_cand_resp=unseen_cand,
+            unseen_base_resp=unseen_base,
+            unseen_perm_corpus_path=perm_corpus,
+            unseen_perm_resp=unseen_perm,
+            cand_label=cand,
+            base_label=base,
+            bootstraps=200,
+        )
+        assert g["seen"]["candidate_overall"] == 1.0
+        assert g["unseen"]["candidate_overall"] == 0.0
+        assert g["seen"]["baseline_overall"] == 1.0
+        assert g["unseen"]["baseline_overall"] == 1.0
+        assert g["gap_candidate_seen_minus_unseen"] == 1.0
+        assert g["gap_bootstrap_95ci"] == [1.0, 1.0]
+        assert g["baseline_adjusted_gap"] == 1.0
+        assert g["baseline_adjusted_gap_95ci"] == [1.0, 1.0]
+        # Permuted arm answered its permuted gold: permutation gap = 0 - 1.
+        assert g["unseen"]["candidate_permuted_overall"] == 1.0
+        assert g["unseen"]["permutation_gap_candidate"] == -1.0
+
+    def test_compute_generalization_fails_closed_on_mismatched_responses(
+        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
+    ):
+        from tools.training.wp3 import run_b5_gate_eval as R
+
+        out_dir = _build(tmp_path, fixture_log, decks_dir)
+        corpus = out_dir / "gate_unseen_deck_test.jsonl"
+        perm_corpus = out_dir / "gate_unseen_deck_test_permuted.jsonl"
+        empty = tmp_path / "empty.jsonl"
+        empty.write_text("", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            R.compute_generalization(
+                seen_corpus_path=corpus,
+                seen_cand_resp=empty,
+                seen_base_resp=empty,
+                unseen_corpus_path=corpus,
+                unseen_cand_resp=empty,
+                unseen_base_resp=empty,
+                unseen_perm_corpus_path=perm_corpus,
+                unseen_perm_resp=empty,
+                cand_label="c",
+                base_label="b",
+                bootstraps=50,
+            )
+        assert exc.value.code == 2

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -58,6 +58,127 @@ RE_NAMED_HAND = re.compile(r"\[(\d+):([^:\]]+):(\w+)\](\w+) hand: : (.*?)\s*(?:=
 # player's name-attributed hand lines may reach a training row.
 PRIMARY_PLAYER = "PlayerA"
 
+# ── Primary-deck resolution + hand deck-signature guardrail ─────────────
+#
+# The #452/#457-family guardrail ("the primary player must not 'hold' cards
+# outside the primary player's deck") was previously pinned to UWTempo in
+# tests only. It is now a runtime, fail-closed check parameterized by the
+# actual .dck list, so logs whose primary deck is NOT UWTempo (e.g. the
+# permanent-holdout unseen-deck logs mz_unseen_<Primary>_vs_<Opponent>.log)
+# get the SAME protection instead of silently none.
+#
+# Resolution order (never guess):
+#   1. an explicit primary_deck argument (CLI --primary-deck) — the named
+#      .dck MUST exist, else DeckSignatureError;
+#   2. filename inference from the `..._<Primary>_vs_<Opponent>.log`
+#      convention — an inferred deck whose .dck is missing is AMBIGUOUS and
+#      raises rather than being skipped (a deck-named log with no list to
+#      check against must not build unchecked);
+#   3. neither → None: legacy logs (mz_train_smoke.log) keep their existing
+#      behavior (test-level UWTempo guardrail, no runtime check).
+
+DEFAULT_DECKS_DIR = "/home/joshu/repos/magezero/xmage/decks"
+
+# `..._<Primary>_vs_<Opponent>.log` — deck names as used in .dck filenames
+# (letters/digits plus the separators that appear in the deck directory).
+RE_LOG_DECK_NAMES = re.compile(r"_([A-Za-z0-9][A-Za-z0-9 .()-]*)_vs_([A-Za-z0-9][A-Za-z0-9 .()-]*)\.log$")
+
+# One .dck card line: `4 [LCI:63] Malcolm, Alluring Scoundrel` (optionally
+# `SB:`-prefixed for sideboard lines). LAYOUT lines are skipped by the caller.
+RE_DCK_CARD = re.compile(r"^\s*(?:SB:\s*)?(\d+)\s+\[[^\]]+\]\s+(.+?)\s*$")
+
+
+class DeckSignatureError(ValueError):
+    """Primary-deck attribution is ambiguous or the hand signature is broken."""
+
+
+def parse_dck_names(path: str | Path) -> frozenset[str]:
+    """Distinct card names in an XMage .dck file (main + sideboard lines)."""
+    names: set[str] = set()
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("LAYOUT"):
+                continue
+            m = RE_DCK_CARD.match(line)
+            if m:
+                names.add(m.group(2))
+    if not names:
+        raise DeckSignatureError(f"no card lines parsed from deck list: {path}")
+    return frozenset(names)
+
+
+def infer_decks_from_log_name(log_name: str) -> tuple[str, str] | None:
+    """(primary, opponent) deck names from `..._<Primary>_vs_<Opponent>.log`."""
+    m = RE_LOG_DECK_NAMES.search(os.path.basename(log_name))
+    return (m.group(1), m.group(2)) if m else None
+
+
+def resolve_primary_deck(
+    log_path: str | Path,
+    primary_deck: str | None = None,
+    decks_dir: str | Path | None = None,
+) -> tuple[str, frozenset[str]] | None:
+    """Resolve (deck_name, card_name_set) for the primary player, or None.
+
+    Fail-closed: an explicit or filename-inferred deck whose .dck cannot be
+    loaded raises DeckSignatureError instead of degrading to "no check".
+    Returns None only when there is NO signature source at all (legacy logs
+    whose filename carries no `_vs_` deck names and no --primary-deck given).
+    """
+    d = Path(decks_dir) if decks_dir is not None else Path(DEFAULT_DECKS_DIR)
+    if primary_deck:
+        name = primary_deck.removesuffix(".dck")
+        dck = d / f"{name}.dck"
+        if not dck.is_file():
+            raise DeckSignatureError(
+                f"--primary-deck {name!r} has no deck list at {dck} — refusing to "
+                "attribute hands against an unknown deck (fail closed)"
+            )
+        return name, parse_dck_names(dck)
+    inferred = infer_decks_from_log_name(str(log_path))
+    if inferred is None:
+        return None
+    name = inferred[0]
+    dck = d / f"{name}.dck"
+    if not dck.is_file():
+        raise DeckSignatureError(
+            f"log name {os.path.basename(str(log_path))!r} names primary deck {name!r} "
+            f"but no deck list exists at {dck} — pass --primary-deck/--decks-dir "
+            "(fail closed: a deck-named log must not parse unchecked)"
+        )
+    return name, parse_dck_names(dck)
+
+
+def verify_hand_signature(decisions: list[dict], deck_name: str, deck_names: frozenset[str]) -> int:
+    """Every emitted hand card must be in the primary deck — else raise.
+
+    This is the runtime form of tests' TestHandDeckSignature: a hand card
+    outside the primary player's deck list means hand attribution broke
+    (#452 family: positional pollution, swapped players, score suffixes).
+    The whole parse is rejected with a class histogram — never a silent drop.
+    Returns the number of rows checked.
+    """
+    from collections import Counter
+
+    offenders: Counter[str] = Counter()
+    rows_hit = 0
+    for d in decisions:
+        bad = [c for c in d.get("hand", []) if c not in deck_names]
+        if bad:
+            rows_hit += 1
+            offenders.update(bad)
+    if offenders:
+        hist = dict(offenders.most_common(15))
+        raise DeckSignatureError(
+            f"hand deck-signature check FAILED against {deck_name}.dck: "
+            f"{sum(offenders.values())} off-deck hand entries in {rows_hit} rows "
+            f"(of {len(decisions)}). Offender histogram (top 15): {hist}. "
+            "Either the primary-deck attribution is wrong (pass --primary-deck) "
+            "or hand attribution regressed — refusing to emit."
+        )
+    return len(decisions)
+
 # The emitter tag at end of line disambiguates the two battlefield-block
 # grammars (#430). `ComputerPlayerMCTS.printBattlefieldScore` blocks are
 #   [PlayerX] header -> Hand -> Permanents (SELF) -> Permanents (OPPONENT)
@@ -87,6 +208,7 @@ LAST_PARSE_STATS: dict[str, int] = {
     "ambiguous_unconsumed": 0,
     "hand_named_attributed": 0,
     "hand_dropped_unattributed": 0,
+    "deck_signature_checked_rows": 0,
 }
 
 
@@ -342,11 +464,15 @@ def parse_permanents(text: str) -> list[dict[str, Any]]:
 
 
 class SessionInfo:
-    def __init__(self, seq: int, start_ts: str, opponent: str, n_games: int):
+    def __init__(self, seq: int, start_ts: str, opponent: str, n_games: int, *, primary: str = "UWTempo"):
         self.seq = seq
         self.start_ts = start_ts
         self.opponent = opponent
         self.n_games = n_games
+        # Primary (MCTS) deck name for the session label. "UWTempo" is the
+        # legacy default (every smoke/curriculum log to date); unseen-deck
+        # logs carry their resolved deck name instead.
+        self.primary = primary
         self.win_rate: float | None = None
         self.n_wins: int | None = None
         self.n_total: int | None = None
@@ -365,10 +491,16 @@ class SessionInfo:
 
     @property
     def label(self) -> str:
-        return f"session{self.seq}_UWTempo_vs_{self.opponent}"
+        return f"session{self.seq}_{self.primary}_vs_{self.opponent}"
 
 
-def detect_sessions(lines: list[str], is_smoke_log: bool = False) -> list[SessionInfo]:
+def detect_sessions(
+    lines: list[str],
+    is_smoke_log: bool = False,
+    *,
+    primary: str = "UWTempo",
+    opponent_name: str | None = None,
+) -> list[SessionInfo]:
     opponents = list(SMOKE_OPPONENTS_GEN0)
     sessions: list[SessionInfo] = []
     seq = 0
@@ -379,8 +511,13 @@ def detect_sessions(lines: list[str], is_smoke_log: bool = False) -> list[Sessio
         if sm:
             ts = _extract_ts(line, "unknown")
             n_games = int(sm.group(1))
-            opponent = opponents[opp_idx % len(opponents)] if is_smoke_log else f"session{seq}"
-            sess = SessionInfo(seq, ts, opponent, n_games)
+            if is_smoke_log:
+                opponent = opponents[opp_idx % len(opponents)]
+            elif opponent_name:
+                opponent = opponent_name
+            else:
+                opponent = f"session{seq}"
+            sess = SessionInfo(seq, ts, opponent, n_games, primary=primary)
             sessions.append(sess)
             seq += 1
             opp_idx += 1
@@ -405,14 +542,28 @@ def _extract_ts(line: str, default: str) -> str:
 # ── Main parser ─────────────────────────────────────────────────────────
 
 
-def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
+def parse_log(
+    log_path: str,
+    *,
+    primary_deck: str | None = None,
+    decks_dir: str | Path | None = None,
+) -> tuple[list[dict], list[SessionInfo]]:
     log_name = os.path.basename(log_path)
     is_smoke = "smoke" in log_name
+
+    # Primary-deck resolution (fail-closed; see resolve_primary_deck). None
+    # means "no signature source" — legacy behavior, no runtime check.
+    resolved = resolve_primary_deck(log_path, primary_deck=primary_deck, decks_dir=decks_dir)
+    inferred = infer_decks_from_log_name(log_name)
+    primary_label = resolved[0] if resolved else "UWTempo"
+    opponent_label = inferred[1] if inferred else None
 
     with open(log_path, encoding="utf-8", errors="replace") as f:
         all_lines = f.readlines()
 
-    sessions = detect_sessions(all_lines, is_smoke_log=is_smoke)
+    sessions = detect_sessions(
+        all_lines, is_smoke_log=is_smoke, primary=primary_label, opponent_name=opponent_label
+    )
 
     # Per-thread state
     threads: dict[str, _ThreadState] = {}
@@ -590,6 +741,13 @@ def parse_log(log_path: str) -> tuple[list[dict], list[SessionInfo]]:
 
     # Enrich with sessions using per-thread game counts
     _enrich_sessions(decisions, sessions)
+
+    # Runtime deck-signature guardrail (raises DeckSignatureError on any
+    # off-deck hand card; see verify_hand_signature).
+    if resolved is not None:
+        stats["deck_signature_checked_rows"] = verify_hand_signature(decisions, resolved[0], resolved[1])
+    else:
+        stats["deck_signature_checked_rows"] = 0
 
     LAST_PARSE_STATS.update(stats)
 
@@ -895,6 +1053,18 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--out", required=True, help="Output JSONL path")
     parser.add_argument("--report", action="store_true", help="Print reconciliation report")
+    parser.add_argument(
+        "--primary-deck",
+        default=None,
+        help="Primary (MCTS) deck name, e.g. HighNoonControl. Overrides filename "
+        "inference; the .dck must exist under --decks-dir (fail closed). "
+        "Enables the runtime hand deck-signature guardrail.",
+    )
+    parser.add_argument(
+        "--decks-dir",
+        default=None,
+        help=f"XMage deck directory (default: {DEFAULT_DECKS_DIR})",
+    )
     return parser
 
 
@@ -907,7 +1077,9 @@ def main():
 
     for log_path in args.logs:
         log_name = os.path.basename(log_path)
-        decisions, sessions = parse_log(log_path)
+        decisions, sessions = parse_log(
+            log_path, primary_deck=args.primary_deck, decks_dir=args.decks_dir
+        )
         all_decisions.extend(decisions)
 
         wr_lines = []
@@ -959,6 +1131,11 @@ def _print_report(
     print("\n  Hand attribution (name-attributed ComputerPlayer.logList only):")
     print(f"    Rows with named hand:        {n_named}")
     print(f"    Rows DROPPED (no named hand line for the row's turn): {n_dropped}")
+    n_sig = LAST_PARSE_STATS.get("deck_signature_checked_rows", 0)
+    if n_sig:
+        print(f"    Deck-signature guardrail:    PASSED on {n_sig} rows (0 off-deck hand cards)")
+    else:
+        print("    Deck-signature guardrail:    NOT RUN (no primary deck resolved; legacy log)")
     # Reconciliation against the pre-switch positional source (diagnostic;
     # `:N` evaluator score suffixes are stripped before comparing so only
     # CONTENT differences count, not format pollution).

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -92,17 +92,30 @@ def _git_sha() -> str:
 # ---------------------------------------------------------------------------
 
 
-def stage_parse(log_paths: list[Path]) -> list[dict]:
-    """Parse log files, returning combined decisions list."""
+def stage_parse(
+    log_paths: list[Path],
+    primary_deck: str | None = None,
+    decks_dir: str | None = None,
+) -> list[dict]:
+    """Parse log files, returning combined decisions list.
+
+    ``primary_deck``/``decks_dir`` feed the parser's fail-closed deck-signature
+    guardrail (parse_magezero_log.resolve_primary_deck): with neither set,
+    behavior on legacy logs (no ``_<Primary>_vs_<Opponent>`` filename) is
+    unchanged; deck-named logs are checked against their .dck automatically.
+    A DeckSignatureError aborts the pipeline — never builds an unchecked corpus.
+    """
     all_decisions: list[dict] = []
     per_log_counts: dict[str, int] = {}
 
     for lp in log_paths:
         print(f"  Parsing {lp} ...", end=" ", flush=True)
-        decisions, sessions = PARSER.parse_log(str(lp))
+        decisions, sessions = PARSER.parse_log(str(lp), primary_deck=primary_deck, decks_dir=decks_dir)
         all_decisions.extend(decisions)
         per_log_counts[str(lp)] = len(decisions)
-        print(f"{len(decisions)} decisions, {len(sessions)} sessions")
+        checked = PARSER.LAST_PARSE_STATS.get("deck_signature_checked_rows", 0)
+        sig = f", deck-signature OK on {checked} rows" if checked else ""
+        print(f"{len(decisions)} decisions, {len(sessions)} sessions{sig}")
 
     return all_decisions
 
@@ -664,6 +677,8 @@ def run_pipeline(
     seed: int = 7,
     balance: str | None = None,
     include_combat: bool = False,
+    primary_deck: str | None = None,
+    decks_dir: str | None = None,
 ) -> dict[str, Any]:
     """Run the full WP-3 pipeline.
 
@@ -674,7 +689,7 @@ def run_pipeline(
 
     # ── Stage 1: Parse ────────────────────────────────────────────────────
     print("Stage 1/5 — Parse logs")
-    raw_decisions = stage_parse(log_paths)
+    raw_decisions = stage_parse(log_paths, primary_deck=primary_deck, decks_dir=decks_dir)
     raw_count = len(raw_decisions)
 
     # Save intermediate: decisions
@@ -880,6 +895,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "via magezero_combat_micro and render them into the same splits. "
         "OFF by default: without this flag the pipeline output is unchanged.",
     )
+    parser.add_argument(
+        "--primary-deck",
+        default=None,
+        help="Primary (MCTS) deck name for the parser's fail-closed hand "
+        "deck-signature guardrail (e.g. HighNoonControl). Default: inferred "
+        "from a _<Primary>_vs_<Opponent>.log filename; legacy logs run "
+        "unchecked exactly as before.",
+    )
+    parser.add_argument(
+        "--decks-dir",
+        default=None,
+        help="XMage deck directory holding the .dck lists "
+        "(default: parse_magezero_log.DEFAULT_DECKS_DIR)",
+    )
     return parser
 
 
@@ -955,7 +984,12 @@ def main(argv: list[str] | None = None) -> int:
             seed=args.seed,
             balance=args.balance,
             include_combat=args.include_combat,
+            primary_deck=args.primary_deck,
+            decks_dir=args.decks_dir,
         )
+    except PARSER.DeckSignatureError as e:
+        print(f"\nPipeline aborted (fail closed): {e}", file=sys.stderr)
+        return 43
     except SystemExit as e:
         if e.code == 42:
             print("\nPipeline aborted: pass rate tripwire or leak scan failed.", file=sys.stderr)

--- a/tools/training/wp3/PROGRESS-wp3-unseen-gate-slice.md
+++ b/tools/training/wp3/PROGRESS-wp3-unseen-gate-slice.md
@@ -1,0 +1,134 @@
+# PROGRESS: wp3-unseen-gate-slice
+
+Branch: `wp3-unseen-gate-slice`. MORNING PRIORITY item 1, measurement half:
+everything that CONSUMES the unseen-deck holdout logs
+(`mz_unseen_HighNoonControl_vs_BGRoots.log`, `mz_unseen_BWBats_vs_HighNoonControl.log`)
+once the curriculum boundary fires. The logs did not exist while this was
+built; every claim below is fixture- or smoke-log-measured, and that limit is
+stated in the PR.
+
+## 1. Parser generalization (parse_magezero_log.py, run_wp3_pipeline.py)
+
+UWTempo / deck-signature assumptions found:
+
+1. `SessionInfo.label` hardcoded `session{n}_UWTempo_vs_{opp}` — every log's
+   sessions were labeled UWTempo regardless of the deck actually played.
+2. `SMOKE_OPPONENTS_GEN0` rotation applied only when "smoke" in filename;
+   any other log got opponent `session{n}` (no deck identity at all).
+3. The #452/#457 hand deck-signature guardrail existed ONLY as tests
+   (`tests/test_parse_magezero_log.py::TestHandDeckSignature`, hardcoded
+   17-name `UWTEMPO_DECK` frozenset). No runtime check, and none possible
+   for any non-UWTempo primary.
+4. `PRIMARY_PLAYER = "PlayerA"` / `actor="PlayerA"` / `Player A win rate`
+   — the MCTS player is assumed to be PlayerA (mz harness naming). Left in
+   place, but now runtime-VERIFIED whenever a deck resolves: if PlayerA's
+   hands don't match the designated primary deck, the parse aborts.
+5. Build-time tooling pins (unchanged, out of scope for this slice):
+   `wp3/deck_inventory.py PRIMARY_DECK`, `wp3/resolve_cards.py DECK_FILES`,
+   `taxonomy/build_taxonomy.py`; `magezero_card_map.json` covers only the 85
+   training-deck names (unseen decks absent — no dependency here because the
+   bridge renders name-only prompts).
+
+Changes (parameterize, do NOT weaken):
+
+- `resolve_primary_deck()`: explicit `--primary-deck` wins; else filename
+  inference from `..._<Primary>_vs_<Opponent>.log`; a named deck whose .dck
+  is missing raises `DeckSignatureError` (ambiguity fails closed, never
+  "skip the check"); no source at all -> `None` = legacy behavior.
+- `verify_hand_signature()`: runtime version of the test guardrail — ANY
+  off-deck hand card aborts the whole parse with an offender histogram.
+  Runs whenever a deck resolves. Signatures derive from the .dck lists
+  (`parse_dck_names`, main + SB lines).
+- Session labels use the resolved deck name; opponent from filename when
+  available. `--primary-deck` / `--decks-dir` plumbed through
+  `parse_magezero_log.py` CLI and `run_wp3_pipeline.py` (DeckSignatureError
+  -> pipeline exit 43, fail closed).
+
+**Measured legacy parity (real 210MB `mz_train_smoke.log`):** old (master)
+parser vs new parser on the same file: **21,557 decisions each,
+byte-identical rows** (underscore fields stripped, JSON-compared), identical
+stats (`recovered_pass 11,820; ambiguous_unconsumed 6,423;
+hand_named_attributed 21,557; hand_dropped_unattributed 52`), identical
+session labels. `deck_signature_checked_rows = 0` (no signature source —
+legacy path taken, as designed).
+Note: the committed intermediate `data/wp3/decisions.jsonl` has 21,609 rows —
+it was built at 48a47ac, BEFORE #457 dropped the 52 unattributable-hand rows
+(21,609 - 52 = 21,557). Stale intermediate, not a regression; today's master
+parser reproduces 21,557.
+
+`MZ_SMOKE_LOG=... pytest tests/test_parse_magezero_log.py::TestHandDeckSignature`:
+3 passed in 14.4s with the new parser (pinned UWTempo guardrail intact).
+
+## 2. Corpus builder (`tools/training/wp3/build_unseen_gate_corpus.py`)
+
+MZ logs -> gate-shaped eval prompts, record shape matched to
+`gate_strategic_decisions_test.jsonl` (verified against real records: top
+keys `{id, system, user, max_tokens, temperature, meta}`; meta carries every
+field `gate_play_decisions.evaluate` reads — menu rows with
+index/text/action_key/action_type/grp_id/instance_id/name, gold_pick,
+gold_equivalent_picks, menu_size, is_land_drop, gold_action_type,
+format_bucket, request_type, deck_seen_in_train=False, pass_pick,
+first_land_pick, split, variant, twin_id). Prompts rendered by the SAME
+production path as the training corpus (`build_magezero_bridge.build_game_state`
+-> `gate_play_decisions.build_user_message`); permuted twins via
+`gate_play_decisions.permute_decision`, ids `#perm`-suffixed —
+`run_b5_gate_eval.check_corpora` accepts the pair (test-proven).
+
+Fail-closed: unresolvable primary deck; primary deck in the known TRAINING
+set (UWTempo, Standard-Mono*); off-deck hand (parser guardrail); rendered
+prompt found in a training corpus (sha256 exclusion); "score:"/"count:" leak
+markers; < --min-records. Land drops excluded by default (matches the seen
+strategic gate's `exclude_land_drops: true`); duplicate-prompt policy copied
+from the seen gate (same-gold collapse, conflicting-gold group drop).
+Manifest carries per-log sha256, primary deck + name count, drop ledger,
+class histograms, and honest provenance notes (teacher-pick labels;
+name-only prompts).
+
+**Fixture build (BGRoots primary, real .dck names, grammar cut from the
+validated smoke-log shapes):** 4 parsed decisions -> 3 records
+(1 land_drop_excluded), composition `{ActionType_Cast: 2, ActionType_Pass: 1}`,
+3 valid permuted twins (gold answer preserved, order moved), rendered prompt
+eyeballed against the raw fixture log (turn/life/hand/menu/gold all match).
+
+## 3. Gate runner wiring (`run_b5_gate_eval.py --unseen-corpus`)
+
+Additive only — absent flag, every new code path is behind
+`if unseen_corpus is not None` and the summary json gains no key
+(`build_parser().parse_args([])` -> None, test-pinned). With the flag:
+preflight `check_corpora`, three extra arms (candidate identity, candidate
+permuted, baseline identity) on the unseen slice, and a `generalization`
+summary section scored by `gate_play_decisions.evaluate` (one scorer for
+both slices): seen/unseen candidate+baseline accuracies (Wilson CIs), raw
+gap with independent-resample bootstrap CI, **baseline-adjusted gap**
+(cand-base paired per prompt within each slice, difficulty cancels) with
+paired-bootstrap CI, and an advisory unseen permutation gap. Reporting only;
+exit code untouched.
+
+**Fixture-measured generalization section** (candidate scripted gold-on-seen
+/ wrong-on-unseen, baseline gold-on-both, B=200): seen 1.0, unseen 0.0,
+gap 1.0 CI [1.0, 1.0], baseline-adjusted 1.0 CI [1.0, 1.0], permutation gap
+-1.0 — all exact per construction. Empty-response mismatch dies exit 2.
+
+## 4. Tests
+
+`tests/test_unseen_deck_gate.py`: **26 passed** (deck resolution incl. 3
+fail-closed cases; non-UWTempo parsing with correct hand attribution +
+comma-name menus; off-deck hand and wrong-primary-designation abort; legacy
+logs unchanged; builder shape/twins/manifest/check_corpora; 3 builder
+fail-closed cases; generalization bootstrap + end-to-end + fail-closed).
+Related suites: `test_parse_magezero_log.py test_run_wp3_pipeline.py
+test_magezero_filters.py test_magezero_bridge_leaks.py
+test_magezero_combat_micro.py test_gate_play_decisions.py
+test_unseen_deck_gate.py` -> **229 passed, 7 skipped** (env-gated skips,
+pre-existing).
+
+## Not done / blocked
+
+- END-TO-END on the real unseen logs: impossible until the curriculum
+  boundary writes them. First real run:
+  `build_unseen_gate_corpus.py --log /home/joshu/mz_unseen_*.log` then
+  `run_b5_gate_eval.py ... --unseen-corpus tools/training/data/gate_unseen_deck_test.jsonl`.
+- PlayerA==primary-deck ordering in the unseen logs is unverified; if the
+  harness seats decks differently, the signature check aborts loudly —
+  rerun with `--primary-deck <actual>`.
+- No ruff in the venvs on blackwell; py_compile + pytest only.

--- a/tools/training/wp3/build_unseen_gate_corpus.py
+++ b/tools/training/wp3/build_unseen_gate_corpus.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""UNSEEN-DECK gate slice builder: MageZero logs -> gate-shaped eval prompts.
+
+Purpose (rl-pipeline-fix.md MORNING PRIORITY item 1)
+----------------------------------------------------
+Turn MageZero MCTS games played with PERMANENT-HOLDOUT decks (HighNoonControl,
+BGRoots, BWBats — never in any training corpus) into an eval corpus with the
+SAME record shape as the strategic gate corpus
+(``tools/training/data/gate_strategic_decisions_test.jsonl``, built by
+``tools.training.gate_play_decisions``), so ``run_b5_gate_eval.py
+--unseen-corpus`` can score any candidate+baseline pair on it and report the
+seen-vs-unseen generalization gap.
+
+Shape contract (verified against the real seen corpus)
+------------------------------------------------------
+Top-level: ``{id, system, user, max_tokens, temperature, meta}`` where
+``system`` is the imported production ``AUTOPILOT_SYSTEM_PROMPT`` and ``user``
+is rendered by the SAME production prompt builder the training corpus uses
+(``gate_play_decisions.build_user_message`` via
+``build_magezero_bridge.build_game_state``) — never re-implemented.
+``meta`` carries every field ``gate_play_decisions.evaluate`` reads:
+``menu`` (rows with index/text/action_key/action_type/grp_id/instance_id/
+name), ``gold_pick``, ``gold_equivalent_picks``, ``menu_size``,
+``is_land_drop``, ``gold_action_type``, ``format_bucket``, ``request_type``,
+``deck_seen_in_train`` (False — permanent holdout), ``pass_pick``,
+``first_land_pick``, ``split``, ``variant``, ``twin_id``.
+The permuted twin file mirrors the seen gate's convention: ids get the
+``#perm`` suffix, twins are produced by ``gate_play_decisions.permute_decision``
+(the shuffle is forced to move the gold pick when possible).
+
+Honest differences from the seen corpus, recorded in the manifest:
+  * the gold label is the MCTS TEACHER's pick, not a human pick;
+  * card facts are name-only (no grp_ids / oracle text / card_facts_audit) —
+    identical to the WP-3 training records, so seen-vs-unseen is NOT
+    prompt-fidelity-matched to the replay-derived seen gate; the
+    generalization gap section in run_b5_gate_eval reports both slices'
+    provenance for exactly this reason;
+  * ``is_own_turn`` mirrors the bridge's known limitation (active player is
+    always the local seat in the reconstructed state).
+
+Fail-closed rules
+-----------------
+  * every input log MUST resolve a primary deck (filename inference or
+    --primary-deck); the parser's hand deck-signature guardrail runs and any
+    off-deck hand card aborts (parse_magezero_log.DeckSignatureError);
+  * a primary deck that is a KNOWN TRAINING DECK aborts — this corpus is
+    definitionally unseen;
+  * any rendered prompt whose sha256 appears in a training corpus aborts;
+  * "score:"/"count:" (MCTS leak markers) in any prompt abort;
+  * fewer than --min-records surviving records abort.
+
+Usage
+-----
+    /home/joshu/venv-train/bin/python3 tools/training/wp3/build_unseen_gate_corpus.py \\
+        --log /home/joshu/mz_unseen_HighNoonControl_vs_BGRoots.log \\
+        --log /home/joshu/mz_unseen_BWBats_vs_HighNoonControl.log \\
+        --out-dir tools/training/data
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+SRC = REPO / "src"
+for p in (str(SRC), str(REPO)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# Order matters: build_magezero_bridge registers a minimal `arenamcp` package
+# (no PySide6 cascade) and loads the production AUTOPILOT_SYSTEM_PROMPT;
+# gate_play_decisions then finds arenamcp.action_planner already in
+# sys.modules exactly as run_wp3_pipeline does.
+from tools.training import build_magezero_bridge as BRIDGE  # noqa: E402
+from tools.training import gate_play_decisions as G  # noqa: E402
+from tools.training import parse_magezero_log as PARSER  # noqa: E402
+
+STEM_DEFAULT = "gate_unseen_deck"
+DEFAULT_OUT_DIR = REPO / "tools" / "training" / "data"
+
+# Decks that HAVE appeared in a training corpus (smoke + gen curricula).
+# A gate slice built from one of these is not "unseen" — hard abort.
+TRAINING_DECKS = frozenset(
+    {
+        "UWTempo",
+        "Standard-MonoR",
+        "Standard-MonoG",
+        "Standard-MonoB",
+        "Standard-MonoW",
+        "Standard-MonoU",
+    }
+)
+
+# Entry text -> MTGA-style action type, mirroring how XMage phrases its
+# priority menus (measured on wp3/decisions.jsonl: Play/Cast/Pass/ability
+# text cover >99.7% of entries; "true"/"false" rows are binary decisions the
+# builder excludes wholesale).
+def classify_action_type(text: str) -> str:
+    t = text.strip()
+    if t == "Pass":
+        return "ActionType_Pass"
+    if t.startswith("Play "):
+        return "ActionType_Play"
+    if t.startswith("Cast "):
+        return "ActionType_Cast"
+    if ":" in t:
+        # Ability grammar: "{T}: Draw a card...", "{W/P}, {T}: ...",
+        # "Sacrifice {this}: ..." — cost, colon, effect.
+        return "ActionType_Activate"
+    return "ActionType_Other"
+
+
+def entry_name(text: str, action_type: str) -> str | None:
+    if action_type == "ActionType_Play":
+        return text[len("Play ") :].strip() or None
+    if action_type == "ActionType_Cast":
+        return text[len("Cast ") :].strip() or None
+    return None
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.strip().encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def git_sha() -> str:
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=REPO, capture_output=True, text=True, timeout=10
+        )
+        return r.stdout.strip()
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def die(msg: str) -> None:
+    print(f"FAIL-CLOSED: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_training_prompt_hashes(paths: list[Path]) -> tuple[set[str], list[str]]:
+    """sha256 of every `user` prompt in the given training JSONL files."""
+    hashes: set[str] = set()
+    used: list[str] = []
+    for p in paths:
+        if not p.is_file():
+            continue
+        used.append(str(p))
+        with open(p, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                u = rec.get("user")
+                if u:
+                    hashes.add(sha256_text(u))
+    return hashes, used
+
+
+def default_training_corpora() -> list[Path]:
+    out: list[Path] = []
+    data = REPO / "tools" / "training" / "data"
+    for d in sorted(data.glob("wp3*")):
+        for name in ("train.jsonl", "val.jsonl", "test.jsonl"):
+            p = d / name
+            if p.is_file():
+                out.append(p)
+    return out
+
+
+def build_decision(row: dict, drops: Counter) -> dict | None:
+    """MageZero decisions-JSONL row -> gate decision dict, or None (counted)."""
+    kind = row.get("decision_kind", "priority")
+    if kind != "priority":
+        drops[f"dk_{kind}"] += 1
+        return None
+    menu_texts = [str(m) for m in row.get("menu", [])]
+    if len(menu_texts) < 2:
+        drops["menu_too_small"] += 1
+        return None
+    chosen = row.get("chosen", "")
+    if not chosen:
+        drops["chosen_empty"] += 1
+        return None
+    if chosen not in menu_texts:
+        drops["chosen_not_in_menu"] += 1
+        return None
+
+    rows = []
+    for i, text in enumerate(menu_texts):
+        atype = classify_action_type(text)
+        rows.append(
+            {
+                "index": i + 1,
+                "text": text,
+                # No grp_ids exist for MageZero data: the TEXT is the action
+                # identity, which also implements the seen gate's text-equality
+                # equivalence rule (identical lines are the same choice).
+                "action_key": text,
+                "action_type": atype,
+                "grp_id": None,
+                "instance_id": None,
+                "name": entry_name(text, atype),
+            }
+        )
+    gold_pick = menu_texts.index(chosen) + 1
+    gold_row = rows[gold_pick - 1]
+    equivalents = sorted(r["index"] for r in rows if r["text"] == gold_row["text"])
+
+    return {
+        "game_state": BRIDGE.build_game_state(row),
+        "menu": rows,
+        "gold_pick": gold_pick,
+        "gold_action_key": gold_row["action_key"],
+        "gold_action_type": gold_row["action_type"],
+        "gold_equivalent_picks": equivalents,
+        "menu_size": len(rows),
+        "is_land_drop": gold_row["action_type"] == "ActionType_Play",
+        "has_land_option": any(r["action_type"] == "ActionType_Play" for r in rows),
+        "pass_pick": next((r["index"] for r in rows if r["action_type"] == "ActionType_Pass"), None),
+        "first_land_pick": next((r["index"] for r in rows if r["action_type"] == "ActionType_Play"), None),
+        "menu_key_spell": sorted({r["action_key"] for r in rows}),
+        "n_meaningful_options": sum(1 for r in rows if r["action_type"] != "ActionType_Pass"),
+        "trigger": G.TRIGGER,
+        "request_type": "ActionsAvailable",
+        "decision_kind": "priority_action",
+        "phase": row.get("phase"),
+        "step": "",
+        # Bridge limitation carried over honestly: the reconstructed state
+        # always makes the local seat active (build_magezero_bridge).
+        "is_own_turn": True,
+        "turn_number": row.get("turn"),
+        "decision_uid": None,
+        "format": "MageZero_unseen",
+        "format_bucket": "constructed",
+        # Permanent holdout by construction; evaluate() reads this field.
+        "deck_seen_in_train": False,
+        "outcome": row.get("outcome", "unknown"),
+        "source": {
+            "replay_file": row.get("_log") or row.get("game_id", "").split(":")[0],
+            "game_id": row.get("game_id"),
+            "session": row.get("session"),
+            "turn": row.get("turn"),
+        },
+    }
+
+
+def render_record(decision: dict, record_id: str, variant: str, twin_id: str) -> dict:
+    menu_texts = [r["text"] for r in decision["menu"]]
+    user = G.build_user_message(decision["game_state"], menu_texts, decision.get("trigger", G.TRIGGER))
+    if user.count("Legal: (pick by number)") != 1:
+        raise RuntimeError("production formatter degraded — refusing a non-production-shaped record")
+    meta = {k: v for k, v in decision.items() if k != "game_state" and not k.startswith("_")}
+    meta["split"] = "test"
+    meta["variant"] = variant
+    meta["twin_id"] = twin_id
+    return {
+        "id": record_id,
+        "system": BRIDGE.AUTOPILOT_SYSTEM_PROMPT,
+        "user": user,
+        "max_tokens": 400,
+        "temperature": 0.0,
+        "meta": meta,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--log", action="append", dest="logs", required=True, type=Path)
+    ap.add_argument(
+        "--primary-deck",
+        default=None,
+        help="primary (MCTS) deck name; default per-log filename inference "
+        "(_<Primary>_vs_<Opponent>.log). With multiple logs, prefer inference.",
+    )
+    ap.add_argument("--decks-dir", default=None, help="XMage deck dir (.dck lists)")
+    ap.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    ap.add_argument("--stem", default=STEM_DEFAULT)
+    ap.add_argument("--seed", type=int, default=20260731)
+    ap.add_argument(
+        "--include-land-drops",
+        action="store_true",
+        help="keep land-drop-gold decisions. Default EXCLUDED, matching the "
+        "seen strategic gate corpus (exclude_land_drops: true in its manifest).",
+    )
+    ap.add_argument(
+        "--training-corpus",
+        action="append",
+        type=Path,
+        default=None,
+        help="training JSONL(s) whose prompts must not appear here "
+        "(default: every wp3*/train,val,test .jsonl under tools/training/data)",
+    )
+    ap.add_argument("--min-records", type=int, default=30)
+    args = ap.parse_args(argv)
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    identity_path = out_dir / f"{args.stem}_test.jsonl"
+    permuted_path = out_dir / f"{args.stem}_test_permuted.jsonl"
+    manifest_path = out_dir / f"{args.stem}_manifest.json"
+
+    if args.primary_deck and len(args.logs) > 1:
+        die(
+            "--primary-deck with multiple --log files would assert ONE deck for "
+            "all of them; rely on per-log filename inference instead, or run "
+            "one build per log"
+        )
+
+    # ---- parse (deck resolution + signature guardrail inside) ------------
+    inputs: list[dict] = []
+    all_rows: list[dict] = []
+    for lp in args.logs:
+        if not lp.is_file():
+            die(f"log not found: {lp}")
+        try:
+            resolved = PARSER.resolve_primary_deck(
+                lp, primary_deck=args.primary_deck, decks_dir=args.decks_dir
+            )
+        except PARSER.DeckSignatureError as e:
+            die(str(e))
+        if resolved is None:
+            die(
+                f"cannot resolve a primary deck for {lp.name} — an unseen-deck "
+                "gate corpus with unknown deck attribution is meaningless. "
+                "Name the log _<Primary>_vs_<Opponent>.log or pass --primary-deck."
+            )
+        deck_name, deck_cards = resolved
+        if deck_name in TRAINING_DECKS:
+            die(
+                f"primary deck {deck_name!r} ({lp.name}) is a TRAINING deck — "
+                "this slice must contain only permanent-holdout decks"
+            )
+        try:
+            rows, sessions = PARSER.parse_log(
+                str(lp), primary_deck=args.primary_deck, decks_dir=args.decks_dir
+            )
+        except PARSER.DeckSignatureError as e:
+            die(str(e))
+        checked = PARSER.LAST_PARSE_STATS.get("deck_signature_checked_rows", 0)
+        print(
+            f"[unseen-gate] {lp.name}: {len(rows)} decisions, primary={deck_name} "
+            f"({len(deck_cards)} names), signature OK on {checked} rows"
+        )
+        inputs.append(
+            {
+                "log": str(lp),
+                "log_sha256": sha256_file(lp),
+                "primary_deck": deck_name,
+                "deck_distinct_names": len(deck_cards),
+                "decisions_parsed": len(rows),
+                "deck_signature_checked_rows": checked,
+                "sessions": len(sessions),
+            }
+        )
+        all_rows.extend(rows)
+
+    # ---- decisions -> gate decisions ------------------------------------
+    drops: Counter = Counter()
+    decisions: list[dict] = []
+    for row in all_rows:
+        d = build_decision(row, drops)
+        if d is None:
+            continue
+        if d["is_land_drop"] and not args.include_land_drops:
+            drops["land_drop_excluded"] += 1
+            continue
+        decisions.append(d)
+
+    # ---- render + dedupe (seen-gate policy: identical prompt+gold collapse,
+    # identical prompt+different gold drops the whole group) ---------------
+    rendered: list[tuple[dict, dict]] = []  # (decision, identity record)
+    seen_prompt_gold: dict[str, str] = {}
+    ambiguous_prompts: set[str] = set()
+    for i, d in enumerate(decisions):
+        rec_id = f"uz-{Path(inputs[0]['log']).stem if len(inputs) == 1 else args.stem}-{i:05d}"
+        rec = render_record(d, rec_id, "identity", rec_id)
+        u = rec["user"]
+        gold_text = d["menu"][d["gold_pick"] - 1]["text"]
+        if u in seen_prompt_gold:
+            if seen_prompt_gold[u] == gold_text:
+                drops["duplicate_prompt_collapsed"] += 1
+            else:
+                # This row AND every previously-kept row with this prompt are
+                # unanswerable — drop the whole group, counted per row below.
+                ambiguous_prompts.add(u)
+                drops["ambiguous_duplicate_prompt_dropped"] += 1
+            continue
+        seen_prompt_gold[u] = gold_text
+        rendered.append((d, rec))
+    if ambiguous_prompts:
+        kept: list[tuple[dict, dict]] = []
+        for d, rec in rendered:
+            if rec["user"] in ambiguous_prompts:
+                drops["ambiguous_duplicate_prompt_dropped"] += 1
+            else:
+                kept.append((d, rec))
+        rendered = kept
+
+    if len(rendered) < args.min_records:
+        die(
+            f"only {len(rendered)} records survived (< --min-records {args.min_records}); "
+            f"drop ledger: {dict(drops)}"
+        )
+
+    # ---- leak checks -----------------------------------------------------
+    corpora = args.training_corpus if args.training_corpus else default_training_corpora()
+    train_hashes, train_files = load_training_prompt_hashes(corpora)
+    leaks = 0
+    for _, rec in rendered:
+        for text in (rec["user"], rec["system"]):
+            if "score:" in text or "count:" in text:
+                die(f"MCTS leak marker in prompt {rec['id']}")
+        if sha256_text(rec["user"]) in train_hashes:
+            leaks += 1
+    if leaks:
+        die(
+            f"{leaks} rendered prompts appear in training corpora ({train_files}) — "
+            "either the decks are not holdouts or a corpus leaked"
+        )
+
+    # ---- permuted twins --------------------------------------------------
+    identity_records: list[dict] = []
+    permuted_records: list[dict] = []
+    for d, rec in rendered:
+        identity_records.append(rec)
+        twin = G.permute_decision(d, seed_key=f"{args.seed}:{rec['id']}")
+        # `permutation` rides along in meta via the twin dict itself.
+        prec = render_record(twin, f"{rec['id']}#perm", "permuted", rec["id"])
+        permuted_records.append(prec)
+
+    # ---- write -----------------------------------------------------------
+    def write_jsonl(path: Path, records: list[dict]) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            for r in records:
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    write_jsonl(identity_path, identity_records)
+    write_jsonl(permuted_path, permuted_records)
+
+    metas = [r["meta"] for r in identity_records]
+    sizes = sorted(m["menu_size"] for m in metas)
+    n = len(metas)
+    composition = {
+        "n": n,
+        "by_gold_action_type": dict(Counter(m["gold_action_type"] for m in metas)),
+        "by_phase": dict(Counter(m.get("phase") or "unknown" for m in metas)),
+        "by_outcome": dict(Counter(m.get("outcome", "unknown") for m in metas)),
+        "pass_gold_share": round(
+            sum(1 for m in metas if m["gold_action_type"] == "ActionType_Pass") / n, 4
+        ),
+        "land_gold_share": round(sum(1 for m in metas if m["is_land_drop"]) / n, 4),
+        "menu_size": {
+            "min": sizes[0],
+            "median": sizes[len(sizes) // 2],
+            "max": sizes[-1],
+            "mean": round(sum(sizes) / n, 2),
+        },
+    }
+    manifest = {
+        "corpus": args.stem,
+        "built_ts": time.time(),
+        "git_sha": git_sha(),
+        "seed": args.seed,
+        "builder": "tools/training/wp3/build_unseen_gate_corpus.py",
+        "inputs": inputs,
+        "gold_label_provenance": "MCTS teacher pick (production search settings), NOT a human pick",
+        "filters": {
+            "decision_kind": "priority only",
+            "exclude_land_drops": not args.include_land_drops,
+            "duplicate_prompts": "identical prompt+gold collapsed; identical prompt+different gold dropped",
+        },
+        "drops": dict(drops),
+        "composition": composition,
+        "training_prompt_exclusion": {
+            "files": train_files,
+            "hashes": len(train_hashes),
+            "overlaps": 0,
+        },
+        "honest_notes": [
+            "prompts are name-only (no oracle text/grp_ids), matching the WP-3 "
+            "training records rather than the replay-derived seen gate — the "
+            "seen-vs-unseen comparison is provenance-annotated, not fidelity-matched",
+            "is_own_turn is always True (bridge state-reconstruction limitation)",
+            "deck_seen_in_train is False by construction (permanent holdout decks)",
+        ],
+        "files": {
+            "identity": {"path": str(identity_path), "records": len(identity_records),
+                         "sha256": sha256_file(identity_path)},
+            "permuted": {"path": str(permuted_path), "records": len(permuted_records),
+                         "sha256": sha256_file(permuted_path)},
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print(f"[unseen-gate] wrote {len(identity_records)} identity + {len(permuted_records)} permuted records")
+    print(f"[unseen-gate] composition: {json.dumps(composition['by_gold_action_type'])}")
+    print(f"[unseen-gate] drops: {json.dumps(dict(drops))}")
+    print(f"[unseen-gate] manifest: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/training/wp3/run_b5_gate_eval.py
+++ b/tools/training/wp3/run_b5_gate_eval.py
@@ -367,6 +367,151 @@ def assert_arm_complete(responses: Path, label: str, expected_n: int) -> None:
 
 
 # --------------------------------------------------------------------------
+# Generalization (seen vs unseen-deck slice) — only runs with --unseen-corpus
+# --------------------------------------------------------------------------
+
+
+def _bootstrap_generalization(
+    seen_pairs: list[tuple[int, int]],
+    unseen_pairs: list[tuple[int, int]],
+    bootstraps: int,
+    seed: int = 20260731,
+) -> tuple[list[float], list[float]]:
+    """95% bootstrap CIs on the seen-minus-unseen accuracy gap.
+
+    Each pair is (candidate_correct, baseline_correct) for ONE prompt. The two
+    slices are DIFFERENT prompt populations, so the raw gap resamples them
+    independently; the baseline-adjusted gap — (cand-base on seen) minus
+    (cand-base on unseen) — preserves the per-prompt candidate/baseline
+    pairing inside each slice so shared prompt difficulty cancels. That is
+    the paired estimator: read it, not the raw gap, when deciding whether the
+    candidate generalizes worse than its own base model.
+    """
+    import random
+
+    rng = random.Random(seed)
+    ns, nu = len(seen_pairs), len(unseen_pairs)
+
+    def acc(pairs: list[tuple[int, int]], idx: int) -> float:
+        return sum(p[idx] for p in pairs) / len(pairs)
+
+    raw: list[float] = []
+    adj: list[float] = []
+    for _ in range(bootstraps):
+        s = [seen_pairs[rng.randrange(ns)] for _ in range(ns)]
+        u = [unseen_pairs[rng.randrange(nu)] for _ in range(nu)]
+        raw.append(acc(s, 0) - acc(u, 0))
+        adj.append((acc(s, 0) - acc(s, 1)) - (acc(u, 0) - acc(u, 1)))
+
+    def ci(values: list[float]) -> list[float]:
+        v = sorted(values)
+        lo = v[int(0.025 * len(v))]
+        hi = v[min(len(v) - 1, int(0.975 * len(v)))]
+        return [round(lo, 4), round(hi, 4)]
+
+    return ci(raw), ci(adj)
+
+
+def compute_generalization(
+    seen_corpus_path: Path,
+    seen_cand_resp: Path,
+    seen_base_resp: Path,
+    unseen_corpus_path: Path,
+    unseen_cand_resp: Path,
+    unseen_base_resp: Path,
+    unseen_perm_corpus_path: Path,
+    unseen_perm_resp: Path,
+    cand_label: str,
+    base_label: str,
+    bootstraps: int,
+) -> dict:
+    """Score candidate+baseline on both slices; return the summary section.
+
+    Scoring reuses gate_play_decisions.evaluate VERBATIM (same pick
+    extraction, same gold-equivalence rules) so the seen and unseen numbers
+    are produced by one scorer, not two implementations.
+    """
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    from tools.training import gate_play_decisions as G
+
+    seen_corpus = list(G._read_jsonl(seen_corpus_path))
+    unseen_corpus = list(G._read_jsonl(unseen_corpus_path))
+    perm_corpus = list(G._read_jsonl(unseen_perm_corpus_path))
+
+    cand_seen = G.evaluate(seen_corpus, seen_cand_resp, cand_label)
+    base_seen = G.evaluate(seen_corpus, seen_base_resp, base_label)
+    cand_unseen = G.evaluate(unseen_corpus, unseen_cand_resp, cand_label)
+    base_unseen = G.evaluate(unseen_corpus, unseen_base_resp, base_label)
+    cand_unseen_perm = G.evaluate(perm_corpus, unseen_perm_resp, cand_label)
+
+    def pairs(cand: dict, base: dict) -> list[tuple[int, int]]:
+        out = []
+        for pid, c in cand.get("per_id", {}).items():
+            b = base.get("per_id", {}).get(pid)
+            if b is not None:
+                out.append((1 if c["correct"] else 0, 1 if b["correct"] else 0))
+        return out
+
+    seen_pairs = pairs(cand_seen, base_seen)
+    unseen_pairs = pairs(cand_unseen, base_unseen)
+    if not seen_pairs or not unseen_pairs:
+        die(
+            f"generalization scoring produced empty pair sets "
+            f"(seen={len(seen_pairs)}, unseen={len(unseen_pairs)}) — response "
+            "files do not match the corpora; refusing to report a gap"
+        )
+
+    raw_ci, adj_ci = _bootstrap_generalization(seen_pairs, unseen_pairs, bootstraps)
+    c_seen = cand_seen["overall"]["accuracy"]
+    c_unseen = cand_unseen["overall"]["accuracy"]
+    b_seen = base_seen["overall"]["accuracy"]
+    b_unseen = base_unseen["overall"]["accuracy"]
+    perm_acc = cand_unseen_perm["overall"]["accuracy"]
+
+    return {
+        "seen": {
+            "corpus": str(seen_corpus_path),
+            "n_paired": len(seen_pairs),
+            "candidate_overall": c_seen,
+            "candidate_95ci": cand_seen["overall"]["accuracy_95ci"],
+            "baseline_overall": b_seen,
+            "provenance": "real MTGA replay menus, human picks",
+        },
+        "unseen": {
+            "corpus": str(unseen_corpus_path),
+            "n_paired": len(unseen_pairs),
+            "candidate_overall": c_unseen,
+            "candidate_95ci": cand_unseen["overall"]["accuracy_95ci"],
+            "baseline_overall": b_unseen,
+            "candidate_permuted_overall": perm_acc,
+            "permutation_gap_candidate": (
+                round(c_unseen - perm_acc, 4) if c_unseen is not None and perm_acc is not None else None
+            ),
+            "provenance": "MageZero MCTS teacher picks on permanent-holdout decks "
+            "(name-only prompts, same shape as WP-3 training records)",
+        },
+        "gap_candidate_seen_minus_unseen": (
+            round(c_seen - c_unseen, 4) if c_seen is not None and c_unseen is not None else None
+        ),
+        "gap_bootstrap_95ci": raw_ci,
+        "baseline_adjusted_gap": (
+            round((c_seen - b_seen) - (c_unseen - b_unseen), 4)
+            if None not in (c_seen, b_seen, c_unseen, b_unseen)
+            else None
+        ),
+        "baseline_adjusted_gap_95ci": adj_ci,
+        "bootstraps": bootstraps,
+        "notes": [
+            "reporting only — NOT a pre-registered leg; never affects the exit code",
+            "the two slices differ in prompt provenance AND label provenance; "
+            "read the baseline-adjusted gap (difficulty cancels via the shared "
+            "base model), not the raw gap alone",
+        ],
+    }
+
+
+# --------------------------------------------------------------------------
 # Main
 # --------------------------------------------------------------------------
 
@@ -431,6 +576,25 @@ def build_parser() -> argparse.ArgumentParser:
         "loudly (never silently) and the exit code ignores L3",
     )
     p.add_argument(
+        "--unseen-corpus",
+        type=Path,
+        default=None,
+        help="OPTIONAL unseen-deck gate slice (built by tools/training/wp3/"
+        "build_unseen_gate_corpus.py from permanent-holdout-deck MageZero "
+        "logs). When given, candidate AND baseline are also scored on it and "
+        "the summary json gains a 'generalization' section: seen score, "
+        "unseen score, gap, and paired-bootstrap CIs on the gap. Reporting "
+        "only — never a pre-registered leg, never changes the exit code. "
+        "Without this flag, behavior is identical to before the option existed.",
+    )
+    p.add_argument(
+        "--unseen-permuted-corpus",
+        type=Path,
+        default=None,
+        help="permuted twin of --unseen-corpus "
+        "(default: <unseen-corpus stem>_permuted.jsonl next to it)",
+    )
+    p.add_argument(
         "--dry-run",
         action="store_true",
         help="CPU-only preflight: resolve adapter, validate corpora/CLIs, "
@@ -451,7 +615,15 @@ def main(argv: list[str] | None = None) -> int:
     combat_corpus = args.combat_corpus or (data / "combat_gate_test.jsonl")
     combat_permuted = args.combat_permuted_corpus or (data / "combat_gate_test_permuted.jsonl")
 
+    unseen_corpus = args.unseen_corpus
+    unseen_permuted = args.unseen_permuted_corpus
+    if unseen_corpus is not None and unseen_permuted is None:
+        unseen_permuted = unseen_corpus.with_name(unseen_corpus.stem + "_permuted" + unseen_corpus.suffix)
+
     out = {
+        "unseen_cand": data / f"gate_{args.run_id}_unseen_candidate_test.jsonl",
+        "unseen_cand_perm": data / f"gate_{args.run_id}_unseen_candidate_test_permuted.jsonl",
+        "unseen_base": data / f"gate_{args.run_id}_unseen_baseline_test.jsonl",
         "combat_cand": data / f"gate_{args.run_id}_combat_candidate_test.jsonl",
         "combat_cand_perm": data / f"gate_{args.run_id}_combat_candidate_test_permuted.jsonl",
         "combat_base": data / f"gate_{args.run_id}_combat_baseline_test.jsonl",
@@ -479,6 +651,10 @@ def main(argv: list[str] | None = None) -> int:
         check_cli_importable(sys.executable, "tools.training.gate_combat_decisions")
         combat_n = check_corpora(combat_corpus, combat_permuted, perm_suffix="-perm", require_menu_size=False)
         log(f"combat gate corpus: {combat_n} records ({combat_corpus.name})")
+    unseen_n = 0
+    if unseen_corpus is not None:
+        unseen_n = check_corpora(unseen_corpus, unseen_permuted)
+        log(f"unseen-deck gate corpus: {unseen_n} records ({unseen_corpus.name})")
     r = subprocess.run(
         [args.serve_python, "-c", "import vllm; print(vllm.__version__)"],
         capture_output=True,
@@ -546,6 +722,14 @@ def main(argv: list[str] | None = None) -> int:
             assert_arm_complete(out["combat_cand"], cand_label, combat_n)
             assert_arm_complete(out["combat_cand_perm"], cand_label, combat_n)
             assert_arm_complete(out["combat_base"], base_label, combat_n)
+
+        if unseen_corpus is not None:
+            run_arm(args, unseen_corpus, out["unseen_cand"], LORA_NAME)
+            run_arm(args, unseen_permuted, out["unseen_cand_perm"], LORA_NAME)
+            run_arm(args, unseen_corpus, out["unseen_base"], args.base_model)
+            assert_arm_complete(out["unseen_cand"], cand_label, unseen_n)
+            assert_arm_complete(out["unseen_cand_perm"], cand_label, unseen_n)
+            assert_arm_complete(out["unseen_base"], base_label, unseen_n)
 
         tripwire_scores = {}
         if not args.skip_tripwires:
@@ -679,6 +863,23 @@ def main(argv: list[str] | None = None) -> int:
             "combat_report": str(out["combat_report"]),
         }
 
+    # ---- generalization: seen vs unseen-deck slice (CPU, optional) -------
+    generalization = None
+    if unseen_corpus is not None:
+        generalization = compute_generalization(
+            seen_corpus_path=corpus,
+            seen_cand_resp=out["cand_test"],
+            seen_base_resp=out["base_test"],
+            unseen_corpus_path=unseen_corpus,
+            unseen_cand_resp=out["unseen_cand"],
+            unseen_base_resp=out["unseen_base"],
+            unseen_perm_corpus_path=unseen_permuted,
+            unseen_perm_resp=out["unseen_cand_perm"],
+            cand_label=cand_label,
+            base_label=base_label,
+            bootstraps=args.bootstraps,
+        )
+
     summary = {
         "run_id": args.run_id,
         "adapter": str(adapter),
@@ -712,6 +913,8 @@ def main(argv: list[str] | None = None) -> int:
         "gate_report": str(out["report"]),
         "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
     }
+    if generalization is not None:
+        summary["generalization"] = generalization
     out["summary"].write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
 
     log("=" * 72)
@@ -739,6 +942,16 @@ def main(argv: list[str] | None = None) -> int:
         f"same-base (12B) comparison: base overall {base_overall}, "
         f"paired delta CI {report.get('paired_bootstrap')}"
     )
+    if generalization is not None:
+        log(
+            "generalization (ADVISORY, not a leg): "
+            f"seen {generalization['seen']['candidate_overall']} vs "
+            f"unseen {generalization['unseen']['candidate_overall']} — "
+            f"gap {generalization['gap_candidate_seen_minus_unseen']} "
+            f"CI {generalization['gap_bootstrap_95ci']}, "
+            f"baseline-adjusted {generalization['baseline_adjusted_gap']} "
+            f"CI {generalization['baseline_adjusted_gap_95ci']}"
+        )
     log(f"full G1-G7 gate verdict: {report.get('verdict')} (exit {gate_rc})")
     log(f"summary: {out['summary']}")
     log("=" * 72)


### PR DESCRIPTION
UNSEEN-DECK gate slice: everything that consumes the holdout logs (MORNING PRIORITY item 1, measurement half).

**Stated plainly: the slice has NOT run end-to-end.** The holdout logs (`mz_unseen_HighNoonControl_vs_BGRoots.log`, `mz_unseen_BWBats_vs_HighNoonControl.log`) do not exist until the curriculum boundary fires. What is proven here is the wiring, on fixtures, plus byte-identical legacy behavior on the real smoke log. All numbers below are measured.

## 1. Parser generalization (UWTempo assumptions found and parameterized)

Assumptions found: (a) `SessionInfo.label` hardcoded UWTempo; (b) `SMOKE_OPPONENTS_GEN0`-only opponent naming; (c) the #452/#457 hand deck-signature guardrail existed only as tests pinned to a 17-name `UWTEMPO_DECK` frozenset — no runtime check possible for any other deck; (d) `PRIMARY_PLAYER="PlayerA"` (kept — mz harness naming — but now runtime-verified via the signature check); (e) build-tool pins (`deck_inventory.py`, `resolve_cards.py`, taxonomy; `magezero_card_map.json` covers only the 85 training names) — noted, out of scope.

Now: signatures derive from the .dck lists (`/home/joshu/repos/magezero/xmage/decks/<name>.dck`, main+SB lines) via filename inference (`..._<Primary>_vs_<Opponent>.log`) or `--primary-deck`. Fail-closed: a named deck with no .dck raises; any off-deck hand card aborts the parse with an offender histogram (the guardrail is parameterized, not weakened — the pinned UWTempo tests still pass, incl. the full-smoke-log one: 3 passed in 14.4s).

**Legacy parity, measured on the real 210MB `mz_train_smoke.log`:** old (master) vs new parser — **21,557 decisions each, byte-identical rows**, identical stats (`recovered_pass 11,820 / ambiguous 6,423 / named 21,557 / dropped 52`), identical session labels. (The committed `data/wp3/decisions.jsonl` intermediate has 21,609 rows because it was built at 48a47ac, before #457 dropped those 52 rows — stale intermediate, not a regression.)

## 2. `wp3/build_unseen_gate_corpus.py`

MZ logs -> records shaped exactly like `gate_strategic_decisions_test.jsonl` (shape verified against real records; produced by the same production prompt path the training bridge uses, permuted `#perm` twins via `gate_play_decisions.permute_decision`). `run_b5_gate_eval.check_corpora` accepts the output pair (test-proven). Fail-closed: unresolvable primary deck, training deck as primary (UWTempo/Standard-Mono*), prompt-sha overlap with training corpora, leak markers, `--min-records`. Land drops excluded by default to match the seen gate; manifest carries drop ledger + class histograms + teacher-pick/name-only provenance notes.

Fixture build (BGRoots primary, real .dck names): 4 decisions -> 3 records (1 `land_drop_excluded`), composition `{Cast: 2, Pass: 1}`, twins valid, rendered prompt eyeballed against the raw fixture lines.

## 3. `run_b5_gate_eval.py --unseen-corpus` (additive)

Absent flag = behavior identical to today (all new paths behind `if unseen_corpus is not None`; no new summary key; default-None test-pinned). With the flag: candidate+baseline (+candidate-permuted) run on the unseen slice, and the summary json gains `generalization`: seen/unseen accuracies with Wilson CIs, raw gap + bootstrap CI, **baseline-adjusted gap** (per-prompt cand/base pairing preserved inside each slice, so difficulty cancels) + paired-bootstrap CI, advisory permutation gap. Scored by `gate_play_decisions.evaluate` for both slices — one scorer, not two. Reporting only; exit code untouched.

Fixture-measured section (scripted responses, B=200): seen 1.0 / unseen 0.0, gap 1.0 CI [1.0, 1.0], adjusted 1.0 CI [1.0, 1.0], permutation gap -1.0 — exact per construction; empty-response mismatch dies exit 2.

## 4. Tests

`tests/test_unseen_deck_gate.py`: **26 passed** — non-UWTempo attribution (incl. comma-named cards), ambiguity/off-deck/wrong-designation all fail closed, builder shape+twins+manifest, 3 builder fail-closed cases, generalization end-to-end. Related suites (`test_parse_magezero_log`, `test_run_wp3_pipeline`, `test_magezero_filters`, `test_magezero_bridge_leaks`, `test_magezero_combat_micro`, `test_gate_play_decisions`, this file): **229 passed, 7 skipped** (pre-existing env-gated skips).

## First real run, once the logs land

```
/home/joshu/venv-train/bin/python3 tools/training/wp3/build_unseen_gate_corpus.py \
  --log /home/joshu/mz_unseen_HighNoonControl_vs_BGRoots.log \
  --log /home/joshu/mz_unseen_BWBats_vs_HighNoonControl.log
/home/joshu/venv-train/bin/python3 tools/training/wp3/run_b5_gate_eval.py --gpu 0 \
  --unseen-corpus tools/training/data/gate_unseen_deck_test.jsonl ...
```

Known risks recorded in the PROGRESS file: PlayerA==primary ordering in the unseen logs is unverified (the signature check aborts loudly if wrong — rerun with `--primary-deck`); unseen prompts are name-only like the training records, so read the baseline-adjusted gap, not the raw gap alone; no ruff on blackwell (py_compile + pytest only).
