### PR TITLE
WP-3: oracle-text coverage — 0.0% -> 98.7% measured, fail-closed pipeline floor

### DIFF
--- a/tests/test_build_mixture_manifest.py
+++ b/tests/test_build_mixture_manifest.py
@@ -24,7 +24,10 @@ VOCAB = {
     "plains": {"name": "Plains", "type_line": "Basic Land — Plains"},
     "seachrome coast": {"name": "Seachrome Coast", "type_line": "Land"},
     "no more lies": {"name": "No More Lies", "type_line": "Instant"},
-    "skrelv, defector mite": {"name": "Skrelv, Defector Mite", "type_line": "Legendary Creature — Phyrexian Mite"},
+    "skrelv, defector mite": {
+        "name": "Skrelv, Defector Mite",
+        "type_line": "Legendary Creature — Phyrexian Mite",
+    },
     "veteran survivor": {"name": "Veteran Survivor", "type_line": "Creature — Human Survivor"},
 }
 
@@ -189,8 +192,20 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
 
 def test_scan_corpus_fixture(tmp_path):
     recs = [
-        {"system": "You are an MTG Arena autopilot. ...", "user": MZ_USER, "response": '{"actions": [{"pick": 1}]}', "source": "magezero_bridge", "meta": {}},
-        {"system": "You are an MTG Arena autopilot. ...", "user": CANDIDATE_USER, "response": '{"actions": [{"pick": 2}]}', "source": "17lands-replay_data", "meta": {}},
+        {
+            "system": "You are an MTG Arena autopilot. ...",
+            "user": MZ_USER,
+            "response": '{"actions": [{"pick": 1}]}',
+            "source": "magezero_bridge",
+            "meta": {},
+        },
+        {
+            "system": "You are an MTG Arena autopilot. ...",
+            "user": CANDIDATE_USER,
+            "response": '{"actions": [{"pick": 2}]}',
+            "source": "17lands-replay_data",
+            "meta": {},
+        },
         {"system": "x", "user": "no menu at all", "response": '{"actions": [{"pick": 1}]}', "source": "junk"},
     ]
     p = tmp_path / "corpus.jsonl"

--- a/tests/test_magezero_card_map.py
+++ b/tests/test_magezero_card_map.py
@@ -86,9 +86,7 @@ class TestCardMapCompleteness:
         the local-bulk enricher explicitly recorded as having no local source
         (oracle_source == "none_local") — those are counted, not guessed."""
         missing = [
-            k
-            for k, v in card_map.items()
-            if not v.get("found") and v.get("oracle_source") != "none_local"
+            k for k, v in card_map.items() if not v.get("found") and v.get("oracle_source") != "none_local"
         ]
         assert not missing, f"{len(missing)} cards not found on Scryfall: {missing}"
 
@@ -102,7 +100,9 @@ class TestCardMapCompleteness:
         fuzzy = [
             k
             for k, v in card_map.items()
-            if v.get("found") and not v.get("exact") and not str(v.get("oracle_source", "")).startswith("local_bulk:")
+            if v.get("found")
+            and not v.get("exact")
+            and not str(v.get("oracle_source", "")).startswith("local_bulk:")
         ]
         assert len(fuzzy) <= 2, f"Expected ≤2 fuzzy matches, got {len(fuzzy)}: {fuzzy}"
 

--- a/tests/test_magezero_card_map.py
+++ b/tests/test_magezero_card_map.py
@@ -82,14 +82,44 @@ class TestCardMapCompleteness:
         assert not bad, f"Entries without scryfall name: {bad}"
 
     def test_all_names_found(self, card_map):
-        """Every card was found (exact or fuzzy) on Scryfall."""
-        missing = [k for k, v in card_map.items() if not v.get("found")]
+        """Every card was found (exact or fuzzy) on Scryfall, except entries
+        the local-bulk enricher explicitly recorded as having no local source
+        (oracle_source == "none_local") — those are counted, not guessed."""
+        missing = [
+            k
+            for k, v in card_map.items()
+            if not v.get("found") and v.get("oracle_source") != "none_local"
+        ]
         assert not missing, f"{len(missing)} cards not found on Scryfall: {missing}"
 
     def test_exact_count(self, card_map):
-        """At most 2 entries may be fuzzy (the layout-only refs)."""
-        fuzzy = [k for k, v in card_map.items() if v.get("found") and not v.get("exact")]
+        """At most 2 non-enricher entries may be fuzzy (the layout-only refs).
+
+        Entries added by enrich_card_map.py (tokens, DFC faces — tagged with
+        an oracle_source) are name-normalized by construction ("Map Token" ->
+        token "Map") and are exempt from the exactness invariant.
+        """
+        fuzzy = [
+            k
+            for k, v in card_map.items()
+            if v.get("found") and not v.get("exact") and not str(v.get("oracle_source", "")).startswith("local_bulk:")
+        ]
         assert len(fuzzy) <= 2, f"Expected ≤2 fuzzy matches, got {len(fuzzy)}: {fuzzy}"
+
+    def test_oracle_text_enrichment(self, card_map):
+        """The map carries oracle text for the training decks: every found
+        entry either has an oracle_text field or is explicitly marked
+        none_local. Guards against re-running resolve_cards.py without the
+        enrichment step (which would silently strip oracle coverage)."""
+        unenriched = [
+            k
+            for k, v in card_map.items()
+            if v.get("found") and "oracle_text" not in v and v.get("oracle_source") != "none_local"
+        ]
+        assert not unenriched, (
+            f"{len(unenriched)} found entries lack oracle_text (run "
+            f"tools/training/wp3/enrich_card_map.py): {unenriched[:10]}"
+        )
 
     def test_at_least_83_entries(self, card_map):
         """At least 83 entries in the map (the number of deck card names)."""

--- a/tests/test_oracle_coverage.py
+++ b/tests/test_oracle_coverage.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for oracle-text coverage: parser noise strips, oracle attachment in
+the MZ bridge, the [NO TARGETS] sanitizer, the audit module, and the
+pipeline's fail-closed --min-oracle-coverage floor."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+for p in (str(REPO), str(REPO / "src")):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from tools.training import build_magezero_bridge as BRIDGE  # noqa: E402
+from tools.training import oracle_coverage as ORACLE  # noqa: E402
+from tools.training import parse_magezero_log as PARSER  # noqa: E402
+from tools.training import run_wp3_pipeline as PIPE  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Parser log-noise strips
+# ---------------------------------------------------------------------------
+
+
+class TestParserSuffixStrips:
+    def test_hand_score_suffix_stripped(self):
+        """GameStateEvaluator2 hand entries carry ':<score>' — log noise."""
+        got = PARSER.parse_card_list("Adarkar Wastes:5; Negate:5; Skrelv, Defector Mite:5")
+        assert got == ["Adarkar Wastes", "Negate", "Skrelv, Defector Mite"]
+
+    def test_hand_without_suffix_unchanged(self):
+        got = PARSER.parse_card_list("Island; Kitsa, Otterball Elite")
+        assert got == ["Island", "Kitsa, Otterball Elite"]
+
+    def test_permanents_attacking_extracted(self):
+        got = PARSER.parse_permanents(
+            "Kitsa, Otterball Elite,tapped,attacking; Island,tapped; Skrelv, Defector Mite"
+        )
+        assert got[0]["name"] == "Kitsa, Otterball Elite"
+        assert got[0]["tapped"] is True
+        assert got[0]["attacking"] is True
+        assert got[1] == {"name": "Island", "tapped": True}
+        assert got[2] == {"name": "Skrelv, Defector Mite", "tapped": False}
+
+    def test_permanents_blocking_extracted(self):
+        got = PARSER.parse_permanents("Malcolm, Alluring Scoundrel,blocking")
+        assert got[0]["name"] == "Malcolm, Alluring Scoundrel"
+        assert got[0]["blocking"] is True
+        assert not got[0]["tapped"]
+
+
+# ---------------------------------------------------------------------------
+# Bridge oracle attachment
+# ---------------------------------------------------------------------------
+
+
+def _row(**over):
+    row = {
+        "game_id": "t:g:1",
+        "turn": 4,
+        "phase": "PRECOMBAT_MAIN",
+        "outcome": "won",
+        "actor": "PlayerA",
+        "session": "s",
+        "decision_kind": "priority",
+        "hand": ["Lightning Strike", "Island"],
+        "battlefield_self": [{"name": "Floodfarm Verge", "tapped": False}],
+        "battlefield_opp": [{"name": "Burnout Bashtronaut", "tapped": False}],
+        "menu": ["Cast Lightning Strike", "Pass"],
+        "chosen": "Cast Lightning Strike",
+        "mcts_counts": {},
+    }
+    row.update(over)
+    return row
+
+
+class TestBridgeOracleAttachment:
+    def test_hand_oracle_in_prompt(self):
+        rec, reason = BRIDGE.build_record(_row())
+        assert reason == ""
+        assert "Lightning Strike deals 3 damage to any target." in rec["user"]
+
+    def test_board_oracle_in_prompt(self):
+        rec, _ = BRIDGE.build_record(_row())
+        # Non-basic land oracle text renders (#461 behavior)
+        assert "Activate only if you control a Plains or an Island" in rec["user"]
+
+    def test_basic_land_oracle_suppressed(self):
+        rec, _ = BRIDGE.build_record(_row())
+        # Basic Island: reminder-only oracle must NOT render as text
+        assert "Add {U}.)" not in rec["user"].replace("Activate only if you control a Plains or an Island.", "")
+
+    def test_no_targets_tag_stripped_and_counted(self):
+        BRIDGE.ORACLE_STATS.clear()
+        rec, _ = BRIDGE.build_record(_row())
+        # Burnout Bashtronaut is untyped (MZ carries no type lines), so the
+        # formatter cannot see opponent creatures and would emit a false
+        # [NO TARGETS] on the removal spell. The sanitizer must remove it.
+        assert "[NO TARGETS]" not in rec["user"]
+        assert BRIDGE.ORACLE_STATS["no_targets_stripped"] >= 1
+
+    def test_removal_tag_kept(self):
+        # [RM:...] derives from the card's own oracle text — a true card fact.
+        rec, _ = BRIDGE.build_record(_row())
+        assert "[RM:<=3T]" in rec["user"]
+
+    def test_opp_never_marked_attacking(self):
+        """An is_attacking-marked opp card makes the formatter run block
+        analysis on fabricated 0/0 stats — must never happen from MZ data."""
+        row = _row(
+            battlefield_opp=[{"name": "Burnout Bashtronaut", "tapped": True, "attacking": True}],
+            phase="COMBAT_DECLARE_BLOCKERS",
+        )
+        gs = BRIDGE.build_game_state(row)
+        opp = [c for c in gs["battlefield"] if c["owner_seat_id"] == BRIDGE.OPP_SEAT]
+        assert all(not c.get("is_attacking") for c in opp)
+
+    def test_local_attacking_marked(self):
+        row = _row(battlefield_self=[{"name": "Skrelv, Defector Mite", "tapped": True, "attacking": True}])
+        gs = BRIDGE.build_game_state(row)
+        me = [c for c in gs["battlefield"] if c["owner_seat_id"] == BRIDGE.LOCAL_SEAT]
+        assert me[0]["is_attacking"] is True
+
+    def test_unresolved_name_renders_bare_and_counted(self):
+        BRIDGE.ORACLE_STATS.clear()
+        row = _row(hand=["Totally Invented Cardname", "Island"])
+        rec, reason = BRIDGE.build_record(row)
+        assert reason == ""
+        assert "Totally Invented Cardname" in rec["user"]
+        assert BRIDGE.ORACLE_STATS["oracle_unresolved"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Audit module
+# ---------------------------------------------------------------------------
+
+
+def _lookup(name):
+    table = {
+        "shockbolt": "Shockbolt deals 3 damage to any target.",
+        "vanilla bear": "",
+        "wind drake": "Flying",
+        "verge land": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains.",
+    }
+    return table.get(name.lower())
+
+
+class TestAuditClassification:
+    def test_covered(self):
+        prompt = ORACLE.normalize("HAND:\n  Shockbolt {R} [S,OK]\n    Shockbolt deals 3 damage to any target.")
+        assert ORACLE.classify_mention("Shockbolt", prompt, _lookup) == "covered"
+
+    def test_uncovered(self):
+        prompt = ORACLE.normalize("HAND:\n  Shockbolt {R} [S,OK]")
+        assert ORACLE.classify_mention("Shockbolt", prompt, _lookup) == "uncovered"
+
+    def test_unresolved(self):
+        assert ORACLE.classify_mention("Unknown Card", "x", _lookup) == "unresolved"
+
+    def test_no_text(self):
+        assert ORACLE.classify_mention("Vanilla Bear", "x", _lookup) == "no_text"
+
+    def test_keyword_only(self):
+        assert ORACLE.classify_mention("Wind Drake", "x", _lookup) == "keyword_only"
+
+    def test_symbol_dialects_match(self):
+        """MTGA {oT} dialect vs Scryfall {T} must not break matching."""
+        prompt = ORACLE.normalize(
+            "  Verge Land  [S,LAND]\n    {oT}: Add {oW}.\n{oT}: Add {oU}. Activate only if you control a Plains."
+        )
+        assert ORACLE.classify_mention("Verge Land", prompt, _lookup) == "covered"
+
+
+class TestAuditPromptParsing:
+    PROMPT = (
+        "TRIGGER: t\n\n=== GAME ===\n"
+        "Legal: (pick by number)\n"
+        "  1. Cast Shockbolt\n"
+        "  2. Play Verge Land\n"
+        "  3. Pass\n"
+        "T3 YOUR | Main1 | Pri:You\n"
+        "Life: You=20 Opp=20\n"
+        "\nYOUR BOARD:\n"
+        "  Vanilla Bear\n"
+        "OPP BOARD:\n"
+        "  Wind Drake [FLY]\n"
+        "Atk: None (T/SS)\n"
+        "\nHAND:\n"
+        "  Shockbolt {R} [S,OK]\n"
+        "    Shockbolt deals 3 damage to any target.\n"
+        "  Verge Land  [S,LAND]\n"
+        "\nRespond with ONLY a JSON action plan matching the schema.\n"
+    )
+
+    def test_contexts_and_classes(self):
+        stats = ORACLE.new_stats()
+        ORACLE.audit_prompt(self.PROMPT, _lookup, stats)
+        assert stats["hand"]["covered"] == 1        # Shockbolt
+        assert stats["hand"]["uncovered"] == 1      # Verge Land (no text attached)
+        assert stats["your_board"]["no_text"] == 1  # Vanilla Bear
+        assert stats["opp_board"]["keyword_only"] == 1  # Wind Drake
+        # menu: Shockbolt covered (text present in prompt), Verge Land uncovered
+        assert stats["menu"]["covered"] == 1
+        assert stats["menu"]["uncovered"] == 1
+
+    def test_summary_coverage(self):
+        stats = ORACLE.new_stats()
+        ORACLE.audit_prompt(self.PROMPT, _lookup, stats)
+        summary = ORACLE.summarize(stats)
+        # covered=2 (hand+menu Shockbolt), uncovered=2 -> 0.5
+        assert summary["overall_coverage"] == 0.5
+
+    def test_block_menu_two_names(self):
+        names = ORACLE._menu_entry_names(
+            "Block Ojer Axonil, Deepest Might with Malcolm, Alluring Scoundrel", {}
+        )
+        assert names == ["Ojer Axonil, Deepest Might", "Malcolm, Alluring Scoundrel"]
+
+    def test_ability_text_menu_entry_is_not_a_gap(self):
+        from collections import Counter
+
+        unparsed = Counter()
+        assert ORACLE._menu_entry_names("{T}: Draw a card, then discard a card.", unparsed) == []
+        assert not unparsed
+
+
+# ---------------------------------------------------------------------------
+# Pipeline floor (fail closed)
+# ---------------------------------------------------------------------------
+
+
+def _fake_rendered(user: str):
+    return {"train": [{"user": user, "system": "s", "response": "r", "meta": {}}]}
+
+
+class TestPipelineFloor:
+    BARE = (
+        "Legal: (pick by number)\n  1. Cast Lightning Strike\n  2. Pass\n"
+        "HAND:\n  Lightning Strike  [S,OK]\n"
+    )
+    COVERED = (
+        "Legal: (pick by number)\n  1. Cast Lightning Strike\n  2. Pass\n"
+        "HAND:\n  Lightning Strike  [S,OK]\n"
+        "    Lightning Strike deals 3 damage to any target.\n"
+    )
+
+    def test_floor_off_by_default(self):
+        summary = PIPE.stage_oracle_coverage(_fake_rendered(self.BARE), None)
+        assert summary["overall_coverage"] == 0.0
+
+    def test_floor_trips_below(self):
+        with pytest.raises(SystemExit) as exc:
+            PIPE.stage_oracle_coverage(_fake_rendered(self.BARE), 0.9)
+        assert exc.value.code == 43
+
+    def test_floor_passes_above(self):
+        summary = PIPE.stage_oracle_coverage(_fake_rendered(self.COVERED), 0.9)
+        assert summary["overall_coverage"] == 1.0
+
+    def test_floor_trips_on_no_mentions(self):
+        """No measurable mentions with a floor set is a failure, not a pass."""
+        with pytest.raises(SystemExit) as exc:
+            PIPE.stage_oracle_coverage(_fake_rendered("Legal: (pick by number)\n  1. Pass\n"), 0.5)
+        assert exc.value.code == 43

--- a/tests/test_oracle_coverage.py
+++ b/tests/test_oracle_coverage.py
@@ -18,7 +18,6 @@ from tools.training import oracle_coverage as ORACLE  # noqa: E402
 from tools.training import parse_magezero_log as PARSER  # noqa: E402
 from tools.training import run_wp3_pipeline as PIPE  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Parser log-noise strips
 # ---------------------------------------------------------------------------
@@ -90,7 +89,9 @@ class TestBridgeOracleAttachment:
     def test_basic_land_oracle_suppressed(self):
         rec, _ = BRIDGE.build_record(_row())
         # Basic Island: reminder-only oracle must NOT render as text
-        assert "Add {U}.)" not in rec["user"].replace("Activate only if you control a Plains or an Island.", "")
+        assert "Add {U}.)" not in rec["user"].replace(
+            "Activate only if you control a Plains or an Island.", ""
+        )
 
     def test_no_targets_tag_stripped_and_counted(self):
         BRIDGE.ORACLE_STATS.clear()
@@ -149,7 +150,9 @@ def _lookup(name):
 
 class TestAuditClassification:
     def test_covered(self):
-        prompt = ORACLE.normalize("HAND:\n  Shockbolt {R} [S,OK]\n    Shockbolt deals 3 damage to any target.")
+        prompt = ORACLE.normalize(
+            "HAND:\n  Shockbolt {R} [S,OK]\n    Shockbolt deals 3 damage to any target."
+        )
         assert ORACLE.classify_mention("Shockbolt", prompt, _lookup) == "covered"
 
     def test_uncovered(self):
@@ -197,8 +200,8 @@ class TestAuditPromptParsing:
     def test_contexts_and_classes(self):
         stats = ORACLE.new_stats()
         ORACLE.audit_prompt(self.PROMPT, _lookup, stats)
-        assert stats["hand"]["covered"] == 1        # Shockbolt
-        assert stats["hand"]["uncovered"] == 1      # Verge Land (no text attached)
+        assert stats["hand"]["covered"] == 1  # Shockbolt
+        assert stats["hand"]["uncovered"] == 1  # Verge Land (no text attached)
         assert stats["your_board"]["no_text"] == 1  # Vanilla Bear
         assert stats["opp_board"]["keyword_only"] == 1  # Wind Drake
         # menu: Shockbolt covered (text present in prompt), Verge Land uncovered
@@ -237,8 +240,7 @@ def _fake_rendered(user: str):
 
 class TestPipelineFloor:
     BARE = (
-        "Legal: (pick by number)\n  1. Cast Lightning Strike\n  2. Pass\n"
-        "HAND:\n  Lightning Strike  [S,OK]\n"
+        "Legal: (pick by number)\n  1. Cast Lightning Strike\n  2. Pass\nHAND:\n  Lightning Strike  [S,OK]\n"
     )
     COVERED = (
         "Legal: (pick by number)\n  1. Cast Lightning Strike\n  2. Pass\n"

--- a/tests/test_unseen_deck_gate.py
+++ b/tests/test_unseen_deck_gate.py
@@ -170,9 +170,7 @@ class TestDeckResolution:
         assert infer_decks_from_log_name("mz_train.log") is None
 
     def test_resolve_by_inference(self, decks_dir: Path):
-        name, cards = resolve_primary_deck(
-            "mz_unseen_BGRoots_vs_HighNoonControl.log", decks_dir=decks_dir
-        )
+        name, cards = resolve_primary_deck("mz_unseen_BGRoots_vs_HighNoonControl.log", decks_dir=decks_dir)
         assert name == "BGRoots"
         assert cards == frozenset(BGROOTS_NAMES)
 
@@ -389,9 +387,7 @@ class TestUnseenCorpusBuilder:
         from tools.training.wp3 import build_unseen_gate_corpus as B
 
         with pytest.raises(SystemExit) as exc:
-            B.main(
-                ["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")]
-            )
+            B.main(["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")])
         assert exc.value.code == 2
 
     def test_unresolvable_deck_fails_closed(self, tmp_path: Path, decks_dir: Path):
@@ -400,14 +396,10 @@ class TestUnseenCorpusBuilder:
         from tools.training.wp3 import build_unseen_gate_corpus as B
 
         with pytest.raises(SystemExit) as exc:
-            B.main(
-                ["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")]
-            )
+            B.main(["--log", str(p), "--decks-dir", str(decks_dir), "--out-dir", str(tmp_path / "o")])
         assert exc.value.code == 2
 
-    def test_training_prompt_overlap_fails_closed(
-        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
-    ):
+    def test_training_prompt_overlap_fails_closed(self, tmp_path: Path, fixture_log: Path, decks_dir: Path):
         """A rendered prompt found in a training corpus must abort the build."""
         from tools.training.wp3 import build_unseen_gate_corpus as B
 
@@ -467,9 +459,7 @@ class TestGeneralizationWiring:
         assert raw_ci[0] <= 0.0 <= raw_ci[1]
         assert adj_ci[0] <= 0.0 <= adj_ci[1]
 
-    def test_compute_generalization_end_to_end(
-        self, tmp_path: Path, fixture_log: Path, decks_dir: Path
-    ):
+    def test_compute_generalization_end_to_end(self, tmp_path: Path, fixture_log: Path, decks_dir: Path):
         """Score the builder's real output through the same scorer the gate
         uses (gate_play_decisions.evaluate) via compute_generalization."""
         from tools.training.wp3 import run_b5_gate_eval as R

--- a/tests/test_validate_run_config.py
+++ b/tests/test_validate_run_config.py
@@ -47,7 +47,7 @@ def _write(tmp_path: Path, text: str, name: str = "cfg.yml") -> Path:
 def test_holdout_set_is_exactly_the_three_pinned_decks():
     # Growing this set is an owner decision; shrinking it invalidates every
     # unseen-deck gate number measured while the deck was held out.
-    assert V.HOLDOUT_DECKS == {"HighNoonControl", "BGRoots", "BWBats"}
+    assert {"HighNoonControl", "BGRoots", "BWBats"} == V.HOLDOUT_DECKS
 
 
 def test_clean_config_passes(tmp_path):

--- a/tools/training/build_magezero_bridge.py
+++ b/tools/training/build_magezero_bridge.py
@@ -179,6 +179,91 @@ _LAND_SUFFIXES = (
 _LAND_NAME_CONTAINS = ("Cavern of", "Field of", "Urza's", "Mishra's", "Corrupted", "Darksteel")
 
 
+# ---------------------------------------------------------------------------
+# Oracle text lookup (magezero_card_map.json, enriched from the LOCAL
+# Scryfall bulk by tools/training/wp3/enrich_card_map.py)
+# ---------------------------------------------------------------------------
+#
+# The transfer medium for card generalization is TEXT: a bare card name in a
+# prompt teaches name->action; oracle text teaches role->action. Every card
+# dict below therefore carries the card's real oracle text when a LOCAL
+# source has it. Names with no local source are counted in ORACLE_STATS
+# ("unresolved") and rendered bare — never fabricated.
+#
+# Deliberately NOT attached, and why:
+#   type_line / power / toughness — typing MZ cards as creatures makes the
+#     production formatter print P/T (0/0 when absent — fabricated stats) and
+#     run the combat solver, whose "Computed optimal ..." lines are computed
+#     from those stats and are fail-closed-rejected by the combat adapter.
+#     Keyword flags (FLY/DTH/...) derive from the attached oracle text alone.
+
+_CARD_MAP_PATH = REPO / "tools" / "training" / "magezero_card_map.json"
+
+# Mention-level accounting, reset per build by main(); keys:
+#   oracle_attached / oracle_no_text / oracle_unresolved / no_targets_stripped
+ORACLE_STATS: Counter = Counter()
+
+
+def _load_card_oracle() -> dict[str, str]:
+    """name(lower) -> oracle_text for every locally-resolved map entry.
+
+    An entry WITHOUT an ``oracle_text`` key is unresolved (no local source),
+    distinct from a resolved card whose oracle text is genuinely empty
+    (vanilla creature) — the two are counted separately.
+    """
+    try:
+        with open(_CARD_MAP_PATH, encoding="utf-8") as f:
+            card_map = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    idx: dict[str, str] = {}
+    for name, entry in card_map.items():
+        if "oracle_text" not in entry:
+            continue
+        idx[name.lower()] = entry["oracle_text"]
+        canon = entry.get("scryfall") or ""
+        if canon:
+            idx.setdefault(canon.lower(), entry["oracle_text"])
+        if " // " in canon:
+            for face in canon.split(" // "):
+                idx.setdefault(face.lower(), entry["oracle_text"])
+    return idx
+
+
+_ORACLE_BY_NAME: dict[str, str] = _load_card_oracle()
+
+
+def _lookup_oracle(name: str) -> str:
+    """Oracle text for *name*, with mention-level accounting."""
+    got = _ORACLE_BY_NAME.get(name.lower())
+    if got is None:
+        ORACLE_STATS["oracle_unresolved"] += 1
+        return ""
+    if got:
+        ORACLE_STATS["oracle_attached"] += 1
+    else:
+        ORACLE_STATS["oracle_no_text"] += 1
+    return got
+
+
+def sanitize_user(user: str) -> str:
+    """Remove the ``[NO TARGETS]`` tag from a rendered MZ prompt, counted.
+
+    The tag is computed by the production formatter from the opponent's TYPED
+    board (opp_creatures etc.). MZ boards are untyped, so the input to that
+    computation is systematically missing and the tag comes out false for any
+    removal spell whenever the opponent has creatures — while the gold answer
+    (MageZero) frequently casts exactly that spell. A derived claim whose
+    inputs are known-absent is dropped and counted, per fail-closed rules.
+    The [RM:...] tags are kept: they derive from the card's own oracle text.
+    """
+    n = user.count(" [NO TARGETS]")
+    if n:
+        ORACLE_STATS["no_targets_stripped"] += n
+        user = user.replace(" [NO TARGETS]", "")
+    return user
+
+
 def _resolve_type_line(name: str) -> str:
     """Return a type_line for a card given only its name.
 
@@ -216,20 +301,48 @@ LOCAL_SEAT = 1
 OPP_SEAT = 2
 
 
-def _build_card(name: str, seat: int, tapped: bool, instance_id: int) -> dict:
-    """One battlefield card entry from MageZero data."""
+def _build_card(
+    name: str,
+    seat: int,
+    tapped: bool,
+    instance_id: int,
+    turn: int = -1,
+    attacking: bool = False,
+    blocking: bool = False,
+) -> dict:
+    """One battlefield card entry from MageZero data.
+
+    ``turn_entered_battlefield`` is set to the CURRENT turn: the entry turn is
+    not recoverable from MZ logs, and with untyped cards the field's only
+    prompt-visible effect is the planner formatter's recent-ETB gate on
+    rendering oracle text (long-resident cards render flags only). Current
+    turn makes the attached oracle text actually reach the prompt; no SS flag
+    or summoning-sickness inference can fire because those need a creature
+    type line, which MZ cards never carry.
+
+    ``attacking``/``blocking`` markers are honoured for the LOCAL seat only,
+    exactly like magezero_combat_micro.build_combat_record: an
+    is_attacking-marked OPPONENT card makes the production formatter run its
+    block analysis on fabricated 0/0 stats ("No blocks -> take 0 dmg").
+    """
     tl = _resolve_type_line(name)
-    return {
+    card = {
         "instance_id": instance_id,
         "name": name,
         "type_line": tl,
-        "oracle_text": "",
+        "oracle_text": _lookup_oracle(name),
         "mana_cost": "",
         "owner_seat_id": seat,
         "controller_seat_id": seat,
         "is_tapped": tapped,
-        "turn_entered_battlefield": -1,
+        "turn_entered_battlefield": turn,
     }
+    if seat == LOCAL_SEAT:
+        if attacking:
+            card["is_attacking"] = True
+        if blocking:
+            card["is_blocking"] = True
+    return card
 
 
 def _build_hand_card(name: str) -> dict:
@@ -241,7 +354,7 @@ def _build_hand_card(name: str) -> dict:
         "type_line": tl,
         "mana_cost": "",
         "cmc": 0.0,
-        "oracle_text": "",
+        "oracle_text": _lookup_oracle(name),
     }
 
 
@@ -252,13 +365,32 @@ def build_game_state(row: dict) -> dict:
     →_format_game_context) expects: players, turn, battlefield, hand, stack,
     graveyard, legal_actions.
     """
+    turn_num = row.get("turn", 0)
     battlefield: list[dict] = []
     next_id = 1
     for card in row.get("battlefield_self", []):
-        battlefield.append(_build_card(card["name"], LOCAL_SEAT, card.get("tapped", False), next_id))
+        battlefield.append(
+            _build_card(
+                card["name"],
+                LOCAL_SEAT,
+                card.get("tapped", False),
+                next_id,
+                turn=turn_num,
+                attacking=bool(card.get("attacking")),
+                blocking=bool(card.get("blocking")),
+            )
+        )
         next_id += 1
     for card in row.get("battlefield_opp", []):
-        battlefield.append(_build_card(card["name"], OPP_SEAT, card.get("tapped", False), 1000 + next_id))
+        battlefield.append(
+            _build_card(
+                card["name"],
+                OPP_SEAT,
+                card.get("tapped", False),
+                1000 + next_id,
+                turn=turn_num,
+            )
+        )
         next_id += 1
 
     hand = [_build_hand_card(n) for n in row.get("hand", [])]
@@ -354,7 +486,7 @@ def build_record(row: dict) -> tuple[dict | None, str]:
 
     # Build user message via production formatter (build_user_message calls
     # ActionPlanner._build_action_prompt → CoachEngine._format_game_context).
-    user = G.build_user_message(game_state, menu)
+    user = sanitize_user(G.build_user_message(game_state, menu))
 
     # R1: the guard that killed prior runs — assert every record.
     if user.count("Legal: (pick by number)") != 1:

--- a/tools/training/magezero_card_map.json
+++ b/tools/training/magezero_card_map.json
@@ -3,6 +3,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{T}: Add {W} or {U}. This land deals 1 damage to you.",
     "scryfall": "Adarkar Wastes",
     "type_line": "Land"
   },
@@ -10,41 +12,63 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Vigilance\nAdeline's power is equal to the number of creatures you control.\nWhenever you attack, for each opponent, create a 1/1 white Human creature token that's tapped and attacking that player or a planeswalker they control.",
+    "power": "*",
     "scryfall": "Adeline, Resplendent Cathar",
-    "type_line": "Legendary Creature \u2014 Human Knight"
+    "toughness": "4",
+    "type_line": "Legendary Creature — Human Knight"
   },
   "Aloe Alchemist": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Trample\nWhen this card becomes plotted, target creature gets +3/+2 and gains trample until end of turn.\nPlot {1}{G} (You may pay {1}{G} and exile this card from your hand. Cast it as a sorcery on a later turn without paying its mana cost. Plot only as a sorcery.)",
+    "power": "3",
     "scryfall": "Aloe Alchemist",
-    "type_line": "Creature \u2014 Plant Warlock"
+    "toughness": "2",
+    "type_line": "Creature — Plant Warlock"
   },
   "Ascendant Packleader": {
     "exact": true,
     "found": true,
     "mana_cost": "{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This creature enters with a +1/+1 counter on it if you control a permanent with mana value 4 or greater.\nWhenever you cast a spell with mana value 4 or greater, put a +1/+1 counter on this creature.",
+    "power": "2",
     "scryfall": "Ascendant Packleader",
-    "type_line": "Creature \u2014 Wolf"
+    "toughness": "1",
+    "type_line": "Creature — Wolf"
   },
   "Axebane Ferox": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{G}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Deathtouch, haste\nWard—Collect evidence 4. (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player exiles cards with total mana value 4 or greater from their graveyard.)",
+    "power": "4",
     "scryfall": "Axebane Ferox",
-    "type_line": "Creature \u2014 Beast"
+    "toughness": "4",
+    "type_line": "Creature — Beast"
   },
   "Bloodletter of Aclazotz": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{B}{B}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying\nIf an opponent would lose life during your turn, they lose twice that much life instead. (Damage causes loss of life.)",
+    "power": "2",
     "scryfall": "Bloodletter of Aclazotz",
-    "type_line": "Creature \u2014 Vampire Demon"
+    "toughness": "4",
+    "type_line": "Creature — Vampire Demon"
   },
   "Blue Sun's Twilight": {
     "exact": true,
     "found": true,
     "mana_cost": "{X}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Gain control of target creature with mana value X or less. If X is 5 or more, create a token that's a copy of that creature.",
     "scryfall": "Blue Sun's Twilight",
     "type_line": "Sorcery"
   },
@@ -52,6 +76,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Return target creature or Vehicle to its owner's hand.",
     "scryfall": "Bounce Off",
     "type_line": "Instant"
   },
@@ -59,20 +85,30 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Whenever this creature enters or transforms into Brutal Cathar, exile target creature an opponent controls until this creature leaves the battlefield.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.) // First strike\nWard—Pay 3 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
+    "power": "2",
     "scryfall": "Brutal Cathar // Moonrage Brute",
-    "type_line": "Creature \u2014 Human Soldier Werewolf // Creature \u2014 Werewolf"
+    "toughness": "2",
+    "type_line": "Creature — Human Soldier Werewolf // Creature — Werewolf"
   },
   "Burnout Bashtronaut": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Menace\nStart your engines! (If you have no speed, it starts at 1. It increases once on each of your turns when an opponent loses life. Max speed is 4.)\n{2}: This creature gets +1/+0 until end of turn.\nMax speed — This creature has double strike.",
+    "power": "1",
     "scryfall": "Burnout Bashtronaut",
-    "type_line": "Creature \u2014 Goblin Warrior"
+    "toughness": "1",
+    "type_line": "Creature — Goblin Warrior"
   },
   "Burst Lightning": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Kicker {4} (You may pay an additional {4} as you cast this spell.)\nBurst Lightning deals 2 damage to any target. If this spell was kicked, it deals 4 damage instead.",
     "scryfall": "Burst Lightning",
     "type_line": "Instant"
   },
@@ -80,34 +116,70 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Deathtouch\nDarkness — Whenever Cecil deals damage, you lose that much life. Then if your life total is less than or equal to half your starting life total, untap Cecil and transform it. // Lifelink\nProtect — Whenever Cecil attacks, other attacking creatures gain indestructible until end of turn.",
+    "power": "2",
     "scryfall": "Cecil, Dark Knight // Cecil, Redeemed Paladin",
-    "type_line": "Legendary Creature \u2014 Human Knight // Legendary Creature \u2014 Human Knight"
+    "toughness": "3",
+    "type_line": "Legendary Creature — Human Knight // Legendary Creature — Human Knight"
+  },
+  "Cecil, Redeemed Paladin": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:face",
+    "oracle_text": "Deathtouch\nDarkness — Whenever Cecil deals damage, you lose that much life. Then if your life total is less than or equal to half your starting life total, untap Cecil and transform it. // Lifelink\nProtect — Whenever Cecil attacks, other attacking creatures gain indestructible until end of turn.",
+    "power": "2",
+    "scryfall": "Cecil, Dark Knight // Cecil, Redeemed Paladin",
+    "toughness": "3",
+    "type_line": "Legendary Creature — Human Knight // Legendary Creature — Human Knight"
   },
   "Cenote Scout": {
     "exact": true,
     "found": true,
     "mana_cost": "{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "When this creature enters, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on this creature, then put the card back or put it into your graveyard.)",
+    "power": "1",
     "scryfall": "Cenote Scout",
-    "type_line": "Creature \u2014 Merfolk Scout"
+    "toughness": "1",
+    "type_line": "Creature — Merfolk Scout"
   },
   "Chrome Host Seedshark": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying\nWhenever you cast a noncreature spell, incubate X, where X is that spell's mana value. (Create an Incubator token with X +1/+1 counters on it and \"{2}: Transform this token.\" It transforms into a 0/0 Phyrexian artifact creature.)",
+    "power": "2",
     "scryfall": "Chrome Host Seedshark",
-    "type_line": "Creature \u2014 Phyrexian Shark"
+    "toughness": "4",
+    "type_line": "Creature — Phyrexian Shark"
+  },
+  "Clue Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "{2}, Sacrifice this token: Draw a card.",
+    "scryfall": "Clue",
+    "type_line": "Token Artifact — Clue"
   },
   "Combat Research": {
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Enchant creature\nEnchanted creature has \"Whenever this creature deals combat damage to a player, draw a card.\"\nAs long as enchanted creature is legendary, it gets +1/+1 and has ward {1}. (Whenever enchanted creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
     "scryfall": "Combat Research",
-    "type_line": "Enchantment \u2014 Aura"
+    "type_line": "Enchantment — Aura"
   },
   "Consider": {
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Surveil 1. (Look at the top card of your library. You may put it into your graveyard.)\nDraw a card.",
     "scryfall": "Consider",
     "type_line": "Instant"
   },
@@ -115,20 +187,41 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Each other Human you control gets +1/+0 and has ward {1}. (Whenever it becomes the target of a spell or ability an opponent controls, counter it unless that player pays {1}.)",
+    "power": "2",
     "scryfall": "Coppercoat Vanguard",
-    "type_line": "Creature \u2014 Human Soldier"
+    "toughness": "2",
+    "type_line": "Creature — Human Soldier"
   },
   "Deep-Cavern Bat": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying, lifelink\nWhen this creature enters, look at target opponent's hand. You may exile a nonland card from it until this creature leaves the battlefield.",
+    "power": "1",
     "scryfall": "Deep-Cavern Bat",
-    "type_line": "Creature \u2014 Bat"
+    "toughness": "1",
+    "type_line": "Creature — Bat"
+  },
+  "Demon Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "Flying",
+    "power": "*",
+    "scryfall": "Demon",
+    "toughness": "*",
+    "type_line": "Token Creature — Demon"
   },
   "Destroy Evil": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Choose one —\n• Destroy target creature with toughness 4 or greater.\n• Destroy target enchantment.",
     "scryfall": "Destroy Evil",
     "type_line": "Instant"
   },
@@ -136,6 +229,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Counter target spell. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
     "scryfall": "Dissipate",
     "type_line": "Instant"
   },
@@ -143,6 +238,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {W}.\nChannel — {2}{W}, Discard this card: It deals 4 damage to target attacking or blocking creature. This ability costs {1} less to activate for each legendary creature you control.",
     "scryfall": "Eiganjo, Seat of the Empire",
     "type_line": "Legendary Land"
   },
@@ -150,13 +247,19 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Haste\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\nValiant — Whenever this creature becomes the target of a spell or ability you control for the first time each turn, exile the top card of your library. Until end of turn, you may play that card.",
+    "power": "2",
     "scryfall": "Emberheart Challenger",
-    "type_line": "Creature \u2014 Mouse Warrior"
+    "toughness": "2",
+    "type_line": "Creature — Mouse Warrior"
   },
   "Essence Scatter": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Counter target creature spell.",
     "scryfall": "Essence Scatter",
     "type_line": "Instant"
   },
@@ -164,20 +267,30 @@
     "exact": true,
     "found": true,
     "mana_cost": "{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This creature enters with an oil counter on it.\nThis creature gets +1/+1 for each oil counter on it.\nWhenever another creature you control enters, if that creature has greater power or toughness than this creature, put an oil counter on this creature.",
+    "power": "0",
     "scryfall": "Evolving Adaptive",
-    "type_line": "Creature \u2014 Phyrexian Warrior"
+    "toughness": "0",
+    "type_line": "Creature — Phyrexian Warrior"
   },
   "Extraction Specialist": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Lifelink\nWhen this creature enters, return target creature card with mana value 2 or less from your graveyard to the battlefield. That creature can't attack or block for as long as you control this creature.",
+    "power": "3",
     "scryfall": "Extraction Specialist",
-    "type_line": "Creature \u2014 Human Rogue"
+    "toughness": "2",
+    "type_line": "Creature — Human Rogue"
   },
   "Fading Hope": {
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Return target creature to its owner's hand. If its mana value was 3 or less, scry 1. (Look at the top card of your library. You may put that card on the bottom.)",
     "scryfall": "Fading Hope",
     "type_line": "Instant"
   },
@@ -185,6 +298,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {W}.\n{T}: Add {U}. Activate only if you control a Plains or an Island.",
     "scryfall": "Floodfarm Verge",
     "type_line": "Land"
   },
@@ -192,13 +307,19 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This creature gets +1/+1 for each Forest you control.\nDisguise {4}{G}\nWhen this creature is turned face up, search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle.",
+    "power": "0",
     "scryfall": "Flourishing Bloom-Kin",
-    "type_line": "Creature \u2014 Plant Elemental"
+    "toughness": "0",
+    "type_line": "Creature — Plant Elemental"
   },
   "Flow of Knowledge": {
     "exact": true,
     "found": true,
     "mana_cost": "{4}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Draw a card for each Island you control, then discard two cards.",
     "scryfall": "Flow of Knowledge",
     "type_line": "Instant"
   },
@@ -206,20 +327,28 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {G}.)",
     "scryfall": "Forest",
-    "type_line": "Basic Land \u2014 Forest"
+    "type_line": "Basic Land — Forest"
   },
   "Forsaken Miner": {
     "exact": true,
     "found": true,
     "mana_cost": "{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This creature can't block.\nWhenever you commit a crime, you may pay {B}. If you do, return this card from your graveyard to the battlefield. (Targeting opponents, anything they control, and/or cards in their graveyards is a crime.)",
+    "power": "2",
     "scryfall": "Forsaken Miner",
-    "type_line": "Creature \u2014 Skeleton Rogue"
+    "toughness": "2",
+    "type_line": "Creature — Skeleton Rogue"
   },
   "Full Bore": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Target creature you control gets +3/+2 until end of turn. If that creature was cast for its warp cost, it also gains trample and haste until end of turn.",
     "scryfall": "Full Bore",
     "type_line": "Instant"
   },
@@ -227,13 +356,19 @@
     "exact": true,
     "found": true,
     "mana_cost": "{B}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Kicker {B} (You may pay an additional {B} as you cast this spell.)\nWhen this creature enters, if it was kicked, target player sacrifices a creature of their choice.",
+    "power": "2",
     "scryfall": "Gatekeeper of Malakir",
-    "type_line": "Creature \u2014 Vampire Warrior"
+    "toughness": "2",
+    "type_line": "Creature — Vampire Warrior"
   },
   "Get Lost": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Destroy target creature, enchantment, or planeswalker. Its controller creates two Map tokens. (They're artifacts with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")",
     "scryfall": "Get Lost",
     "type_line": "Instant"
   },
@@ -241,6 +376,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Target creature you control deals damage equal to its power to target creature or planeswalker you don't control.",
     "scryfall": "Hard-Hitting Question",
     "type_line": "Sorcery"
   },
@@ -248,76 +385,136 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying\nHaughty Djinn's power is equal to the number of instant and sorcery cards in your graveyard.\nInstant and sorcery spells you cast cost {1} less to cast.",
+    "power": "*",
     "scryfall": "Haughty Djinn",
-    "type_line": "Creature \u2014 Djinn"
+    "toughness": "4",
+    "type_line": "Creature — Djinn"
   },
   "Hired Claw": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Whenever you attack with one or more Lizards, this creature deals 1 damage to target opponent.\n{1}{R}: Put a +1/+1 counter on this creature. Activate only if an opponent lost life this turn and only once each turn.",
+    "power": "1",
     "scryfall": "Hired Claw",
-    "type_line": "Creature \u2014 Lizard Mercenary"
+    "toughness": "2",
+    "type_line": "Creature — Lizard Mercenary"
   },
   "Hopeful Initiate": {
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Training (Whenever this creature attacks with another creature with greater power, put a +1/+1 counter on this creature.)\n{2}{W}, Remove two +1/+1 counters from among creatures you control: Destroy target artifact or enchantment.",
+    "power": "1",
     "scryfall": "Hopeful Initiate",
-    "type_line": "Creature \u2014 Human Warlock"
+    "toughness": "2",
+    "type_line": "Creature — Human Warlock"
   },
   "Hullbreaker Horror": {
     "exact": true,
     "found": true,
     "mana_cost": "{5}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flash\nThis spell can't be countered.\nWhenever you cast a spell, choose up to one —\n• Return target spell you don't control to its owner's hand.\n• Return target nonland permanent to its owner's hand.",
+    "power": "7",
     "scryfall": "Hullbreaker Horror",
-    "type_line": "Creature \u2014 Kraken Horror"
+    "toughness": "8",
+    "type_line": "Creature — Kraken Horror"
+  },
+  "Human Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "",
+    "power": "1",
+    "scryfall": "Human",
+    "toughness": "1",
+    "type_line": "Token Creature — Human"
   },
   "Impulse": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Look at the top four cards of your library. Put one of them into your hand and the rest on the bottom of your library in any order.",
     "scryfall": "Impulse",
     "type_line": "Instant"
+  },
+  "Incubator Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "{2}: Transform this artifact.",
+    "power": "0",
+    "scryfall": "Incubator // Phyrexian",
+    "toughness": "0",
+    "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian"
   },
   "Iridescent Vinelasher": {
     "exact": true,
     "found": true,
     "mana_cost": "{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Offspring {2} (You may pay an additional {2} as you cast this spell. If you do, when this creature enters, create a 1/1 token copy of it.)\nLandfall — Whenever a land you control enters, this creature deals 1 damage to target opponent.",
+    "power": "1",
     "scryfall": "Iridescent Vinelasher",
-    "type_line": "Creature \u2014 Lizard Assassin"
+    "toughness": "2",
+    "type_line": "Creature — Lizard Assassin"
   },
   "Island": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {U}.)",
     "scryfall": "Island",
-    "type_line": "Basic Land \u2014 Island"
+    "type_line": "Basic Land — Island"
   },
   "Kellan, Planar Trailblazer": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{1}{R}: If Kellan is a Scout, it becomes a Human Faerie Detective and gains \"Whenever Kellan deals combat damage to a player, exile the top card of your library. You may play that card this turn.\"\n{2}{R}: If Kellan is a Detective, it becomes a 3/2 Human Faerie Rogue and gains double strike.",
+    "power": "2",
     "scryfall": "Kellan, Planar Trailblazer",
-    "type_line": "Legendary Creature \u2014 Human Faerie Scout"
+    "toughness": "1",
+    "type_line": "Legendary Creature — Human Faerie Scout"
   },
   "Kitsa, Otterball Elite": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Vigilance\nProwess (Whenever you cast a noncreature spell, this creature gets +1/+1 until end of turn.)\n{T}: Draw a card, then discard a card.\n{2}, {T}: Copy target instant or sorcery spell you control. You may choose new targets for the copy. Activate only if Kitsa's power is 3 or greater.",
+    "power": "1",
     "scryfall": "Kitsa, Otterball Elite",
-    "type_line": "Legendary Creature \u2014 Otter Wizard"
+    "toughness": "3",
+    "type_line": "Legendary Creature — Otter Wizard"
   },
   "Knight-Errant of Eos": {
     "exact": true,
     "found": true,
     "mana_cost": "{4}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Convoke\nWhen this creature enters, look at the top six cards of your library. You may reveal up to two creature cards with mana value X or less from among them, where X is the number of creatures that convoked this creature. Put the revealed cards into your hand, then shuffle.",
+    "power": "4",
     "scryfall": "Knight-Errant of Eos",
-    "type_line": "Creature \u2014 Human Knight"
+    "toughness": "4",
+    "type_line": "Creature — Human Knight"
   },
   "Lightning Strike": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Lightning Strike deals 3 damage to any target.",
     "scryfall": "Lightning Strike",
     "type_line": "Instant"
   },
@@ -325,20 +522,37 @@
     "exact": false,
     "found": true,
     "mana_cost": "{1}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Whenever equipped creature deals combat damage, put a charge counter on Lost Jitte.\nRemove a charge counter from Lost Jitte: Choose one —\n• Untap target land.\n• Target creature can't block this turn.\n• Put a +1/+1 counter on equipped creature.\nEquip {1}",
     "scryfall": "Lost Jitte",
-    "type_line": "Legendary Artifact \u2014 Equipment"
+    "type_line": "Legendary Artifact — Equipment"
   },
   "Malcolm, Alluring Scoundrel": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flash\nFlying\nWhenever Malcolm deals combat damage to a player, put a chorus counter on it. Draw a card, then discard a card. If there are four or more chorus counters on Malcolm, you may cast the discarded card without paying its mana cost.",
+    "power": "2",
     "scryfall": "Malcolm, Alluring Scoundrel",
-    "type_line": "Legendary Creature \u2014 Siren Pirate"
+    "toughness": "1",
+    "type_line": "Legendary Creature — Siren Pirate"
+  },
+  "Map Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "{1}, {T}, Sacrifice this artifact: Target creature you control explores. Activate only as a sorcery. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on that creature, then put the card back or put it into your graveyard.)",
+    "scryfall": "Map",
+    "type_line": "Token Artifact — Map"
   },
   "Memory Deluge": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Look at the top X cards of your library, where X is the amount of mana spent to cast this spell. Put two of them into your hand and the rest on the bottom of your library in a random order.\nFlashback {5}{U}{U} (You may cast this card from your graveyard for its flashback cost. Then exile it.)",
     "scryfall": "Memory Deluge",
     "type_line": "Instant"
   },
@@ -346,34 +560,55 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {W} or {U}.)\nThis land enters tapped.\nWhen this land enters, surveil 1. (Look at the top card of your library. You may put it into your graveyard.)",
     "scryfall": "Meticulous Archive",
-    "type_line": "Land \u2014 Plains Island"
+    "type_line": "Land — Plains Island"
   },
   "Mirrex": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{T}: Add one mana of any color. Activate only if this land entered this turn.\n{3}, {T}: Create a 1/1 colorless Phyrexian Mite artifact creature token with toxic 1 and \"This token can't block.\" (Players dealt combat damage by it also get a poison counter.)",
     "scryfall": "Mirrex",
-    "type_line": "Land \u2014 Sphere"
+    "type_line": "Land — Sphere"
   },
   "Mishra's Foundry": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{2}: This land becomes a 2/2 Assembly-Worker artifact creature until end of turn. It's still a land.\n{1}, {T}: Target attacking Assembly-Worker gets +2/+2 until end of turn.",
     "scryfall": "Mishra's Foundry",
     "type_line": "Land"
+  },
+  "Moonrage Brute": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:face",
+    "oracle_text": "Whenever this creature enters or transforms into Brutal Cathar, exile target creature an opponent controls until this creature leaves the battlefield.\nDaybound (If a player casts no spells during their own turn, it becomes night next turn.) // First strike\nWard—Pay 3 life.\nNightbound (If a player casts at least two spells during their own turn, it becomes day next turn.)",
+    "power": "2",
+    "scryfall": "Brutal Cathar // Moonrage Brute",
+    "toughness": "2",
+    "type_line": "Creature — Human Soldier Werewolf // Creature — Werewolf"
   },
   "Mountain": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {R}.)",
     "scryfall": "Mountain",
-    "type_line": "Basic Land \u2014 Mountain"
+    "type_line": "Basic Land — Mountain"
   },
   "Negate": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Counter target noncreature spell.",
     "scryfall": "Negate",
     "type_line": "Instant"
   },
@@ -381,6 +616,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "{W}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Counter target spell unless its controller pays {3}. If that spell is countered this way, exile it instead of putting it into its owner's graveyard.",
     "scryfall": "No More Lies",
     "type_line": "Instant"
   },
@@ -388,34 +625,72 @@
     "exact": true,
     "found": true,
     "mana_cost": "{3}{R}{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying, haste\nWhen this creature enters, it deals 1 damage to target creature an opponent controls.\nWarp {2}{R} (You may cast this card from your hand for its warp cost. Exile this creature at the beginning of the next end step, then you may cast it from exile on a later turn.)",
+    "power": "4",
     "scryfall": "Nova Hellkite",
-    "type_line": "Creature \u2014 Dragon"
+    "toughness": "5",
+    "type_line": "Creature — Dragon"
   },
   "Novice Inspector": {
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "When this creature enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "power": "1",
     "scryfall": "Novice Inspector",
-    "type_line": "Creature \u2014 Human Detective"
+    "toughness": "2",
+    "type_line": "Creature — Human Detective"
   },
   "Ojer Axonil, Deepest Might": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Trample\nIf a red source you control would deal an amount of noncombat damage less than Ojer Axonil's power to an opponent, that source deals damage equal to Ojer Axonil's power instead.\nWhen Ojer Axonil dies, return it to the battlefield tapped and transformed under its owner's control. // (Transforms from Ojer Axonil, Deepest Might.)\n{T}: Add {R}.\n{2}{R}, {T}: Transform this land. Activate only if red sources you controlled dealt 4 or more noncombat damage this turn and only as a sorcery.",
+    "power": "4",
     "scryfall": "Ojer Axonil, Deepest Might // Temple of Power",
-    "type_line": "Legendary Creature \u2014 God // Land"
+    "toughness": "4",
+    "type_line": "Legendary Creature — God // Land"
+  },
+  "Phyrexian Mite Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nThis creature can't block.",
+    "power": "1",
+    "scryfall": "Phyrexian Mite",
+    "toughness": "1",
+    "type_line": "Token Artifact Creature — Phyrexian Mite"
+  },
+  "Phyrexian Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "{2}: Transform this artifact.",
+    "power": "0",
+    "scryfall": "Incubator // Phyrexian",
+    "toughness": "0",
+    "type_line": "Token Artifact — Incubator // Token Artifact Creature — Phyrexian"
   },
   "Plains": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {W}.)",
     "scryfall": "Plains",
-    "type_line": "Basic Land \u2014 Plains"
+    "type_line": "Basic Land — Plains"
   },
   "Plaza of Heroes": {
     "exact": false,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{T}: Add one mana of any color. Spend this mana only to cast a legendary spell.\n{T}: Add one mana of any color among legendary permanents you control.\n{3}, {T}, Exile this land: Target legendary creature gains hexproof and indestructible until end of turn.",
     "scryfall": "Plaza of Heroes",
     "type_line": "Land"
   },
@@ -423,34 +698,61 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Reach\n{6}{W/P}: Transform Polukranos Reborn. Activate only as a sorcery. ({W/P} can be paid with either {W} or 2 life.) // Reach, lifelink\nWhenever Polukranos or another nontoken Hydra you control dies, create a 3/3 green and white Phyrexian Hydra creature token with reach and a 3/3 green and white Phyrexian Hydra creature token with lifelink.",
+    "power": "4",
     "scryfall": "Polukranos Reborn // Polukranos, Engine of Ruin",
-    "type_line": "Legendary Creature \u2014 Hydra // Legendary Creature \u2014 Phyrexian Hydra"
+    "toughness": "5",
+    "type_line": "Legendary Creature — Hydra // Legendary Creature — Phyrexian Hydra"
   },
   "Quirion Beastcaller": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Whenever you cast a creature spell, put a +1/+1 counter on this creature.\nWhen this creature dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on this creature.",
+    "power": "2",
     "scryfall": "Quirion Beastcaller",
-    "type_line": "Creature \u2014 Dryad Warrior"
+    "toughness": "2",
+    "type_line": "Creature — Dryad Warrior"
   },
   "Razorkin Needlehead": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This creature has first strike during your turn.\nWhenever an opponent draws a card, this creature deals 1 damage to them.",
+    "power": "2",
     "scryfall": "Razorkin Needlehead",
-    "type_line": "Creature \u2014 Human Assassin"
+    "toughness": "2",
+    "type_line": "Creature — Human Assassin"
   },
   "Recruitment Officer": {
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{3}{W}: Look at the top four cards of your library. You may reveal a creature card with mana value 3 or less from among them and put it into your hand. Put the rest on the bottom of your library in a random order.",
+    "power": "2",
     "scryfall": "Recruitment Officer",
-    "type_line": "Creature \u2014 Human Soldier"
+    "toughness": "1",
+    "type_line": "Creature — Human Soldier"
+  },
+  "Ritual Chamber": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "{2}{B} // {3}{B}{B}",
+    "oracle_source": "local_bulk:face",
+    "oracle_text": "At the beginning of your end step, draw a card. If you control a Demon, each opponent loses 2 life and you gain 2 life. Otherwise, you lose 2 life.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.) // When you unlock this door, create a 6/6 black Demon creature token with flying.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
+    "scryfall": "Unholy Annex // Ritual Chamber",
+    "type_line": "Enchantment — Room // Enchantment — Room"
   },
   "Rockface Village": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{T}: Add {R}. Spend this mana only to cast a creature spell.\n{R}, {T}: Target Lizard, Mouse, Otter, or Raccoon you control gets +1/+0 and gains haste until end of turn. Activate only as a sorcery.",
     "scryfall": "Rockface Village",
     "type_line": "Land"
   },
@@ -458,6 +760,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This land enters tapped unless you control two or fewer other lands.\n{T}: Add {W} or {U}.",
     "scryfall": "Seachrome Coast",
     "type_line": "Land"
   },
@@ -465,34 +769,48 @@
     "exact": true,
     "found": true,
     "mana_cost": "{2}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Vigilance\nWhenever this creature enters or attacks, create a Map token. (It's an artifact with \"{1}, {T}, Sacrifice this token: Target creature you control explores. Activate only as a sorcery.\")",
+    "power": "3",
     "scryfall": "Sentinel of the Nameless City",
-    "type_line": "Creature \u2014 Merfolk Warrior Scout"
+    "toughness": "4",
+    "type_line": "Creature — Merfolk Warrior Scout"
   },
   "Shardmage's Rescue": {
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flash\nEnchant creature you control\nAs long as this Aura entered this turn, enchanted creature has hexproof.\nEnchanted creature gets +1/+1.",
     "scryfall": "Shardmage's Rescue",
-    "type_line": "Enchantment \u2014 Aura"
+    "type_line": "Enchantment — Aura"
   },
   "Sharp-Eyed Rookie": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{G}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Vigilance\nWhenever a creature you control enters, if its power is greater than this creature's power or its toughness is greater than this creature's toughness, put a +1/+1 counter on this creature and investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice this token: Draw a card.\")",
+    "power": "2",
     "scryfall": "Sharp-Eyed Rookie",
-    "type_line": "Creature \u2014 Human Detective"
+    "toughness": "2",
+    "type_line": "Creature — Human Detective"
   },
   "Sheltered by Ghosts": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Enchant creature you control\nWhen this Aura enters, exile target nonland permanent an opponent controls until this Aura leaves the battlefield.\nEnchanted creature gets +1/+0 and has lifelink and ward {2}.",
     "scryfall": "Sheltered by Ghosts",
-    "type_line": "Enchantment \u2014 Aura"
+    "type_line": "Enchantment — Aura"
   },
   "Shock": {
     "exact": true,
     "found": true,
     "mana_cost": "{R}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Shock deals 2 damage to any target.",
     "scryfall": "Shock",
     "type_line": "Instant"
   },
@@ -500,6 +818,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "{1}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Destroy target non-outlaw creature. (Assassins, Mercenaries, Pirates, Rogues, and Warlocks are outlaws. Everyone else is fair game.)",
     "scryfall": "Shoot the Sheriff",
     "type_line": "Instant"
   },
@@ -507,20 +827,30 @@
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Toxic 1 (Players dealt combat damage by this creature also get a poison counter.)\nSkrelv can't block.\n{W/P}, {T}: Choose a color. Another target creature you control gains toxic 1 and hexproof from that color until end of turn. It can't be blocked by creatures of that color this turn. ({W/P} can be paid with either {W} or 2 life.)",
+    "power": "1",
     "scryfall": "Skrelv, Defector Mite",
-    "type_line": "Legendary Artifact Creature \u2014 Phyrexian Mite"
+    "toughness": "1",
+    "type_line": "Legendary Artifact Creature — Phyrexian Mite"
   },
   "Sleep-Cursed Faerie": {
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Flying, ward {2}\nThis creature enters tapped with three stun counters on it. (If it would become untapped, remove a stun counter from it instead.)\n{1}{U}: Untap this creature.",
+    "power": "3",
     "scryfall": "Sleep-Cursed Faerie",
-    "type_line": "Creature \u2014 Faerie Wizard"
+    "toughness": "3",
+    "type_line": "Creature — Faerie Wizard"
   },
   "Soul Partition": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Exile target nonland permanent. For as long as that card remains exiled, its owner may play it. A spell cast by an opponent this way costs {2} more to cast.",
     "scryfall": "Soul Partition",
     "type_line": "Instant"
   },
@@ -528,6 +858,8 @@
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "{T}: Add {C}.\n{4}: This land becomes a 3/3 creature with vigilance and all creature types. It's still a land.",
     "scryfall": "Soulstone Sanctuary",
     "type_line": "Land"
   },
@@ -535,34 +867,68 @@
     "exact": true,
     "found": true,
     "mana_cost": "{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Counter target noncreature spell unless its controller pays {2}.",
     "scryfall": "Spell Pierce",
     "type_line": "Instant"
+  },
+  "Spirit Token": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:token",
+    "oracle_text": "Flying",
+    "power": "1",
+    "scryfall": "Spirit",
+    "toughness": "1",
+    "type_line": "Token Creature — Spirit"
   },
   "Swamp": {
     "exact": true,
     "found": true,
     "mana_cost": "",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "({T}: Add {B}.)",
     "scryfall": "Swamp",
-    "type_line": "Basic Land \u2014 Swamp"
+    "type_line": "Basic Land — Swamp"
   },
   "Teferi, Temporal Pilgrim": {
     "exact": true,
     "found": true,
     "mana_cost": "{3}{U}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Whenever you draw a card, put a loyalty counter on Teferi.\n0: Draw a card.\n−2: Create a 2/2 blue Spirit creature token with vigilance and \"Whenever you draw a card, put a +1/+1 counter on this token.\"\n−12: Target opponent chooses a permanent they control and returns it to its owner's hand. Then they shuffle each nonland permanent they control into its owner's library.",
     "scryfall": "Teferi, Temporal Pilgrim",
-    "type_line": "Legendary Planeswalker \u2014 Teferi"
+    "type_line": "Legendary Planeswalker — Teferi"
+  },
+  "Temple of Power": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "",
+    "oracle_source": "local_bulk:face",
+    "oracle_text": "Trample\nIf a red source you control would deal an amount of noncombat damage less than Ojer Axonil's power to an opponent, that source deals damage equal to Ojer Axonil's power instead.\nWhen Ojer Axonil dies, return it to the battlefield tapped and transformed under its owner's control. // (Transforms from Ojer Axonil, Deepest Might.)\n{T}: Add {R}.\n{2}{R}, {T}: Transform this land. Activate only if red sources you controlled dealt 4 or more noncombat damage this turn and only as a sorcery.",
+    "power": "4",
+    "scryfall": "Ojer Axonil, Deepest Might // Temple of Power",
+    "toughness": "4",
+    "type_line": "Legendary Creature — God // Land"
   },
   "Thalia, Guardian of Thraben": {
     "exact": true,
     "found": true,
     "mana_cost": "{1}{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "First strike\nNoncreature spells cost {1} more to cast.",
+    "power": "2",
     "scryfall": "Thalia, Guardian of Thraben",
-    "type_line": "Legendary Creature \u2014 Human Soldier"
+    "toughness": "1",
+    "type_line": "Legendary Creature — Human Soldier"
   },
   "Thirst for Discovery": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Draw three cards. Then discard two cards unless you discard a basic land card.",
     "scryfall": "Thirst for Discovery",
     "type_line": "Instant"
   },
@@ -570,28 +936,51 @@
     "exact": true,
     "found": true,
     "mana_cost": "{6}{U}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "This spell costs {1} less to cast for each instant and sorcery card in your graveyard.\nWard {2} (Whenever this creature becomes the target of a spell or ability an opponent controls, counter it unless that player pays {2}.)",
+    "power": "5",
     "scryfall": "Tolarian Terror",
-    "type_line": "Creature \u2014 Serpent"
+    "toughness": "5",
+    "type_line": "Creature — Serpent"
+  },
+  "Unholy Annex": {
+    "exact": false,
+    "found": true,
+    "mana_cost": "{2}{B} // {3}{B}{B}",
+    "oracle_source": "local_bulk:face",
+    "oracle_text": "At the beginning of your end step, draw a card. If you control a Demon, each opponent loses 2 life and you gain 2 life. Otherwise, you lose 2 life.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.) // When you unlock this door, create a 6/6 black Demon creature token with flying.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
+    "scryfall": "Unholy Annex // Ritual Chamber",
+    "type_line": "Enchantment — Room // Enchantment — Room"
   },
   "Unholy Annex // Ritual Chamber": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{B} // {3}{B}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "At the beginning of your end step, draw a card. If you control a Demon, each opponent loses 2 life and you gain 2 life. Otherwise, you lose 2 life.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.) // When you unlock this door, create a 6/6 black Demon creature token with flying.\n(You may cast either half. That door unlocks on the battlefield. As a sorcery, you may pay the mana cost of a locked door to unlock it.)",
     "scryfall": "Unholy Annex // Ritual Chamber",
-    "type_line": "Enchantment \u2014 Room // Enchantment \u2014 Room"
+    "type_line": "Enchantment — Room // Enchantment — Room"
   },
   "Unstoppable Slasher": {
     "exact": true,
     "found": true,
     "mana_cost": "{2}{B}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "Deathtouch\nWhenever this creature deals combat damage to a player, they lose half their life, rounded up.\nWhen this creature dies, if it had no counters on it, return it to the battlefield tapped under its owner's control with two stun counters on it.",
+    "power": "2",
     "scryfall": "Unstoppable Slasher",
-    "type_line": "Creature \u2014 Zombie Assassin"
+    "toughness": "3",
+    "type_line": "Creature — Zombie Assassin"
   },
   "Warden of the Inner Sky": {
     "exact": true,
     "found": true,
     "mana_cost": "{W}",
+    "oracle_source": "local_bulk:canonical",
+    "oracle_text": "As long as this creature has three or more counters on it, it has flying and vigilance.\nTap three untapped artifacts and/or creatures you control: Put a +1/+1 counter on this creature. Scry 1. Activate only as a sorcery.",
+    "power": "1",
     "scryfall": "Warden of the Inner Sky",
-    "type_line": "Creature \u2014 Human Soldier"
+    "toughness": "2",
+    "type_line": "Creature — Human Soldier"
   }
 }

--- a/tools/training/magezero_combat_micro.py
+++ b/tools/training/magezero_combat_micro.py
@@ -502,8 +502,13 @@ def _context_ok(
 
 
 def _board_entry(p: dict) -> dict:
+    """parse_permanents now extracts ,attacking/,blocking into flags itself;
+    the suffix strip is kept as a fail-safe for rows parsed by older code."""
     name, marker = _strip_combat_suffix(p["name"])
     out = {"name": name, "tapped": bool(p.get("tapped", False))}
+    for key in ("attacking", "blocking"):
+        if p.get(key):
+            out[key] = True
     if marker:
         out[marker] = True
     return out
@@ -943,7 +948,7 @@ def build_combat_record(row: dict) -> tuple[dict | None, str]:
         # Blocking happens on the opponent's turn.
         game_state["turn"]["active_player"] = BRIDGE.OPP_SEAT
 
-    user = G.build_user_message(game_state, menu, trigger=trigger)
+    user = BRIDGE.sanitize_user(G.build_user_message(game_state, menu, trigger=trigger))
     if "Computed optimal" in user:
         # A solver line would be combat math computed from fabricated card
         # stats, and can restate the gold answer. Fail closed.

--- a/tools/training/oracle_coverage.py
+++ b/tools/training/oracle_coverage.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from collections import Counter
 from pathlib import Path
 

--- a/tools/training/oracle_coverage.py
+++ b/tools/training/oracle_coverage.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Oracle-text coverage audit for rendered training/gate prompts.
+
+The transfer medium for card generalization is TEXT: a bare card name in a
+prompt teaches name->action; oracle text teaches role->action (#461 fixed
+lands; this audits everything). This module measures, per rendered prompt,
+which card-name mentions carry that card's oracle text in the SAME prompt,
+split by context:
+
+  menu        — numbered "Legal:"/"Candidate:" entries (production menus are
+                bare names by design; reported, not "fixed")
+  hand        — HAND: section
+  your_board  — YOUR BOARD: section
+  opp_board   — OPP BOARD: section
+  attacking   — ATTACKING YOU: section (combat-gate shape)
+
+Classification per (record, context, distinct name) mention:
+
+  covered       oracle text resolves locally AND its normalized prefix appears
+                in the prompt
+  uncovered     oracle text resolves locally but does NOT appear in the prompt
+  keyword_only  oracle text is only evergreen keywords — the production
+                formatter deliberately renders these as flags, not text
+  no_text       the card genuinely has no oracle text (vanilla creature,
+                basic land reminder-only)
+  unresolved    no LOCAL oracle source for this name (counted, never guessed)
+
+FAIL CLOSED: lines that cannot be parsed are counted per context
+(``unparsed_lines``), never silently skipped; headline coverage counts
+``unresolved`` in the denominator.
+
+Lookup sources (local only, no network):
+  1. tools/training/magezero_card_map.json (enriched with oracle_text)
+  2. optional Scryfall bulk cache (~/.arenamcp/cache/scryfall/
+     default_cards.json) via ``build_lookup(use_bulk=True)`` — needed for
+     gate corpora built from real Arena replays.
+
+CLI
+---
+    python3 tools/training/oracle_coverage.py FILE.jsonl [...] [--bulk] [--json OUT]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MAP_PATH = REPO / "tools" / "training" / "magezero_card_map.json"
+BULK_PATH = Path.home() / ".arenamcp" / "cache" / "scryfall" / "default_cards.json"
+
+CONTEXTS = ("menu", "hand", "your_board", "opp_board", "attacking")
+
+# Mirrors the keyword-only suppression set in coach.py _format_board_card.
+_KEYWORD_WORDS = {
+    "flying", "reach", "haste", "vigilance", "trample", "first", "strike",
+    "double", "deathtouch", "lifelink", "menace", "ward", "hexproof",
+    "indestructible", "defender",
+}
+
+_MIN_MATCH_CHARS = 12
+_PREFIX_CHARS = 30
+
+
+# ---------------------------------------------------------------------------
+# Normalization + matching
+# ---------------------------------------------------------------------------
+
+_RE_BRACES = re.compile(r"\{[^}]*\}")
+_RE_REMINDER = re.compile(r"\([^)]*\)")
+_RE_TAGS = re.compile(r"<[^>]+>")
+_RE_NONALNUM = re.compile(r"[^a-z0-9 ]+")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip mana symbols / reminder text / markup, collapse to
+    alphanumeric words. Same function is applied to prompts and oracle text so
+    Scryfall-vs-MTGA symbol dialects ({T} vs {oT}) cannot cause a mismatch."""
+    t = text.lower()
+    t = _RE_TAGS.sub(" ", t)
+    t = _RE_BRACES.sub(" ", t)
+    t = _RE_REMINDER.sub(" ", t)
+    t = _RE_NONALNUM.sub(" ", t)
+    return " ".join(t.split())
+
+
+def is_keyword_only(oracle_norm: str) -> bool:
+    words = [w for w in oracle_norm.split() if w]
+    return bool(words) and all(w in _KEYWORD_WORDS for w in words)
+
+
+def classify_mention(name: str, prompt_norm: str, lookup) -> str:
+    """Classify one card-name mention against the normalized prompt."""
+    oracle = lookup(name)
+    if oracle is None:
+        return "unresolved"
+    oracle_norm = normalize(oracle)
+    if not oracle_norm:
+        return "no_text"
+    if is_keyword_only(oracle_norm):
+        return "keyword_only"
+    if len(oracle_norm) < _MIN_MATCH_CHARS:
+        # Too short to match reliably; treat presence of the full normalized
+        # text as the criterion.
+        return "covered" if oracle_norm in prompt_norm else "uncovered"
+    if oracle_norm[:_PREFIX_CHARS] in prompt_norm:
+        return "covered"
+    # DFC / multi-part oracle: any face's prefix counts.
+    for part in oracle.split(" // "):
+        pn = normalize(part)
+        if len(pn) >= _MIN_MATCH_CHARS and pn[:_PREFIX_CHARS] in prompt_norm:
+            return "covered"
+    return "uncovered"
+
+
+# ---------------------------------------------------------------------------
+# Lookup construction
+# ---------------------------------------------------------------------------
+
+
+def _oracle_from_bulk_card(card: dict) -> str:
+    text = card.get("oracle_text")
+    if text:
+        return text
+    faces = card.get("card_faces") or []
+    return " // ".join(f.get("oracle_text") or "" for f in faces).strip(" /")
+
+
+def build_lookup(map_path: Path = MAP_PATH, use_bulk: bool = False, bulk_path: Path = BULK_PATH):
+    """Return ``lookup(name) -> str | None`` (None = no local source).
+
+    The card map is authoritative for MageZero/XMage names; the optional bulk
+    index covers arbitrary Arena card names in real-replay gate corpora.
+    """
+    by_name: dict[str, str] = {}
+    try:
+        card_map = json.loads(Path(map_path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        card_map = {}
+    for name, entry in card_map.items():
+        if "oracle_text" in entry:
+            by_name[name.lower()] = entry["oracle_text"]
+            canon = entry.get("scryfall") or ""
+            if canon:
+                by_name.setdefault(canon.lower(), entry["oracle_text"])
+
+    bulk: dict[str, str] = {}
+    if use_bulk:
+        with open(bulk_path, encoding="utf-8") as f:
+            cards = json.load(f)
+        for c in cards:
+            nm = (c.get("name") or "").lower()
+            if not nm:
+                continue
+            layout = c.get("layout") or ""
+            if "token" in layout:
+                bulk.setdefault(nm + " token", _oracle_from_bulk_card(c))
+                bulk.setdefault(nm, _oracle_from_bulk_card(c))
+            else:
+                if nm not in bulk:
+                    bulk[nm] = _oracle_from_bulk_card(c)
+                for face in c.get("card_faces") or []:
+                    fn = (face.get("name") or "").lower()
+                    if fn:
+                        bulk.setdefault(fn, face.get("oracle_text") or "")
+
+    def lookup(name: str) -> str | None:
+        low = name.lower()
+        if low in by_name:
+            return by_name[low]
+        if low in bulk:
+            return bulk[low]
+        return None
+
+    return lookup
+
+
+# ---------------------------------------------------------------------------
+# Prompt parsing
+# ---------------------------------------------------------------------------
+
+_RE_MENU_LINE = re.compile(r"^\s+\d+\.\s+(.*)$")
+# P/T tokens include live-substituted forms: 3/3, */*, */3, 1+*/2, X/X
+_RE_PT_SUFFIX = re.compile(r"\s+[\dXx*+]*[\d*X]/[\dXx*+]*[\d*X]$")
+_RE_HASH_SUFFIX = re.compile(r"\s+#\d+$")
+_RE_XN_SUFFIX = re.compile(r"\s+x\d+$")
+_RE_PAREN_PT = re.compile(r"\s*\([\dXx*+]*[\d*X]/[\dXx*+]*[\d*X]\)")
+
+_SECTION_HEADERS = {
+    "YOUR BOARD:": "your_board",
+    "OPP BOARD:": "opp_board",
+    "ATTACKING YOU:": "attacking",
+    "HAND:": "hand",
+}
+# Lines that terminate a board/hand section (combat analysis, zones, plans).
+_RE_SECTION_BREAK = re.compile(
+    r"^(Atk:|Crackback:|Computed optimal|!!|⚠|STACK|GRAVEYARD|REVEALED|"
+    r"OPP REVEALED|RECENT|EXCLUDED|Respond with|GAME PLAN|TURN PLAN|"
+    r"TURN CONSISTENCY|Decision:|BOARD: Empty|=== |CANDIDATE-MENU|Opp hand:|"
+    r"On the (play|draw)\.|Pending decision:|Life: |Mana: |Land: |Timing: |"
+    r"T\d+ (YOUR|OPP) )"
+)
+
+_MENU_PREFIXES = (
+    ("Play Land: ", "strip"),
+    ("Play ", "strip"),
+    ("Cast ", "strip_ok"),
+    ("Attack with: ", "strip_pt"),
+    ("Do not attack with ", "strip"),
+    ("Attack with ", "strip"),
+    ("Block with: ", "strip"),
+    ("Do not block with ", "strip"),
+    ("Activate Ability: ", "strip"),
+    ("use ", "strip"),
+    ("Activate ", "strip"),
+    ("Search out ", "strip"),
+)
+_NO_CARD_MENU = re.compile(
+    r"^(Pass$|Done\b|Action: |Keep\b|Mulligan\b|Play$|Draw$|Cancel\b|"
+    r"No attacks|No blocks|Decline to block|Declare no attackers|"
+    r"Declare no blockers|Fail to find)"
+)
+
+
+def _clean_name(name: str) -> str:
+    name = name.strip()
+    name = _RE_PAREN_PT.sub("", name)
+    name = re.sub(r"\s*\[0 POWER[^\]]*\]", "", name)
+    # Suffixes stack ("Llanowar Elves #1 1/1", "Nightmare x2 */*") — strip to
+    # a fixpoint, not a single pass.
+    while True:
+        before = name
+        for pat in (_RE_HASH_SUFFIX, _RE_PT_SUFFIX, _RE_XN_SUFFIX):
+            name = pat.sub("", name)
+        if name == before:
+            break
+    if name.startswith("*"):  # token marker
+        name = name[1:]
+    return name.strip()
+
+
+def _menu_entry_names(entry: str, unparsed: Counter) -> list[str]:
+    entry = entry.strip()
+    if _NO_CARD_MENU.match(entry):
+        return []
+    # XMage renders activated abilities as raw ability text ("{T}: Draw a
+    # card, then discard a card."). Those entries carry their own rules text
+    # and no card name — they are not coverage gaps.
+    if entry.startswith("{"):
+        return []
+    # "Block X with Y" (MZ block menus) — two names, split on last " with ".
+    if entry.startswith("Block ") and not entry.startswith("Block with"):
+        body = entry[len("Block "):]
+        if " with " in body:
+            attacker, blocker = body.rsplit(" with ", 1)
+            return [_clean_name(attacker), _clean_name(blocker)]
+    # "Target X with Y's ability" (production ability-target rows).
+    if entry.startswith("Target ") and entry.endswith("'s ability") and " with " in entry:
+        body = entry[len("Target "):-len("'s ability")]
+        target, source = body.rsplit(" with ", 1)
+        return [_clean_name(target), _clean_name(source)]
+    for prefix, mode in _MENU_PREFIXES:
+        if entry.startswith(prefix):
+            rest = entry[len(prefix):]
+            if mode == "strip_ok":
+                rest = re.sub(r"\s*\[OK\]$", "", rest)
+            if mode == "strip_pt":
+                rest = _RE_PAREN_PT.sub("", rest)
+                rest = re.sub(r"\s*\[0 POWER[^\]]*\]", "", rest)
+            return [_clean_name(rest)]
+    unparsed["menu"] += 1
+    return []
+
+
+_RE_HAND_CARD = re.compile(
+    r"^\s{2}(\S.*?)"                      # display name (+ optional tag/cost)
+    r"(?:\s+\((?:AURA|ENCHANT|EQUIP|ART|PW)\))?"
+    r"(?:\s+\{[^\s\[]*\})?"               # mana cost
+    r"\s+\[[SI],[^\]]*\]"                 # [timing,castability]
+)
+
+
+def _board_line_name(line: str) -> str | None:
+    """Board-section line -> card name, or None if it is not a card line."""
+    if not line.startswith("  ") or line.startswith("    ") or line.strip() == "":
+        return None
+    body = line[2:]
+    if body.startswith((">>", "If ", "(empty)")):
+        return None
+    # Combat-gate shape appends " - <oracle>"; production appends flag/counter
+    # suffixes.
+    body = body.split(" - ")[0]
+    body = re.sub(r"\s*\[[^\]]*\]", "", body)      # [T,FLY] / [tapped] / [cannot attack: ...]
+    body = re.sub(r"\s*\([^)]*\)", "", body)       # (Type — Sub) / (2Coun)
+    return _clean_name(body) or None
+
+
+def audit_prompt(user: str, lookup, stats: dict) -> None:
+    """Accumulate mention classifications for one rendered prompt."""
+    prompt_norm = normalize(user)
+    lines = user.splitlines()
+    context: str | None = None
+    in_menu = False
+    seen: set[tuple[str, str]] = set()
+
+    def _hit(ctx: str, name: str) -> None:
+        if not name or (ctx, name) in seen:
+            return
+        seen.add((ctx, name))
+        cls = classify_mention(name, prompt_norm, lookup)
+        stats[ctx][cls] += 1
+        if cls in ("uncovered", "unresolved"):
+            stats["examples"][ctx].setdefault(cls, [])
+            ex = stats["examples"][ctx][cls]
+            if len(ex) < 8 and name not in ex:
+                ex.append(name)
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith(("Legal:", "Candidate:")):
+            in_menu = True
+            context = None
+            continue
+        if in_menu:
+            m = _RE_MENU_LINE.match(line)
+            if m:
+                for name in _menu_entry_names(m.group(1), stats["unparsed_lines"]):
+                    _hit("menu", name)
+                continue
+            in_menu = False
+        header = _SECTION_HEADERS.get(stripped)
+        if header:
+            context = header
+            continue
+        if context and _RE_SECTION_BREAK.match(stripped) and not line.startswith("  "):
+            context = None
+            continue
+        if context == "hand":
+            m = _RE_HAND_CARD.match(line)
+            if m:
+                _hit("hand", _clean_name(m.group(1)))
+            # non-matching lines are oracle continuation / analysis text
+            continue
+        if context in ("your_board", "opp_board", "attacking"):
+            name = _board_line_name(line)
+            if name:
+                _hit(context, name)
+            continue
+
+
+def new_stats() -> dict:
+    stats: dict = {ctx: Counter() for ctx in CONTEXTS}
+    stats["unparsed_lines"] = Counter()
+    stats["examples"] = {ctx: {} for ctx in CONTEXTS}
+    return stats
+
+
+def audit_records(records, lookup, stats: dict | None = None) -> dict:
+    """Audit an iterable of rendered records (dicts with a ``user`` field)."""
+    stats = stats if stats is not None else new_stats()
+    n = 0
+    for rec in records:
+        user = rec.get("user") or ""
+        if not user:
+            stats["unparsed_lines"]["record_without_user"] += 1
+            continue
+        audit_prompt(user, lookup, stats)
+        n += 1
+    stats["records_audited"] = stats.get("records_audited", 0) + n
+    return stats
+
+
+def summarize(stats: dict) -> dict:
+    """Per-context percentages + overall coverage (fail-closed denominator).
+
+    coverage = covered / (covered + uncovered + unresolved).
+    keyword_only and no_text are excluded: there is no text to attach.
+    """
+    out: dict = {"contexts": {}, "records_audited": stats.get("records_audited", 0)}
+    tot_cov = tot_den = 0
+    for ctx in CONTEXTS:
+        c = stats[ctx]
+        denom = c["covered"] + c["uncovered"] + c["unresolved"]
+        out["contexts"][ctx] = {
+            "covered": c["covered"],
+            "uncovered": c["uncovered"],
+            "unresolved": c["unresolved"],
+            "keyword_only": c["keyword_only"],
+            "no_text": c["no_text"],
+            "coverage": round(c["covered"] / denom, 4) if denom else None,
+        }
+        tot_cov += c["covered"]
+        tot_den += denom
+    out["overall_coverage"] = round(tot_cov / tot_den, 4) if tot_den else None
+    out["overall_mentions_with_text_expected"] = tot_den
+    out["unparsed_lines"] = dict(stats["unparsed_lines"])
+    out["examples"] = {
+        ctx: {k: v[:5] for k, v in stats["examples"][ctx].items()}
+        for ctx in CONTEXTS
+        if stats["examples"][ctx]
+    }
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _iter_jsonl(path: Path):
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Oracle-text coverage audit over rendered prompt JSONL files.")
+    ap.add_argument("files", nargs="+", type=Path)
+    ap.add_argument("--bulk", action="store_true",
+                    help="also load the local Scryfall bulk cache (needed for real-replay gate corpora)")
+    ap.add_argument("--json", type=Path, default=None, help="write summary JSON here")
+    args = ap.parse_args(argv)
+
+    lookup = build_lookup(use_bulk=args.bulk)
+    results: dict[str, dict] = {}
+    for path in args.files:
+        stats = audit_records(_iter_jsonl(path), lookup)
+        summary = summarize(stats)
+        results[str(path)] = summary
+        print(f"\n=== {path} ({summary['records_audited']} records) ===")
+        for ctx, row in summary["contexts"].items():
+            cov = row["coverage"]
+            cov_s = f"{cov * 100:5.1f}%" if cov is not None else "  n/a"
+            print(f"  {ctx:<11s} coverage={cov_s}  covered={row['covered']:<6d} "
+                  f"uncovered={row['uncovered']:<6d} unresolved={row['unresolved']:<5d} "
+                  f"keyword_only={row['keyword_only']:<5d} no_text={row['no_text']}")
+        oc = summary["overall_coverage"]
+        print(f"  overall     {oc * 100:.1f}%" if oc is not None else "  overall     n/a")
+        if summary["unparsed_lines"]:
+            print(f"  unparsed_lines: {summary['unparsed_lines']}")
+        for ctx, ex in summary.get("examples", {}).items():
+            for cls, names in ex.items():
+                print(f"  example {ctx}/{cls}: {names}")
+    if args.json:
+        args.json.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/training/parse_magezero_log.py
+++ b/tools/training/parse_magezero_log.py
@@ -423,8 +423,20 @@ def parse_pool_actions(text: str) -> list[tuple[str, float, int]]:
 
 
 def parse_card_list(text: str) -> list[str]:
+    """Split a ``-> Hand: [...]`` payload into card names.
+
+    The GameStateEvaluator2 emitter appends an evaluator score to every hand
+    entry ("Adarkar Wastes:5"); other emitters of the same line shape do not
+    (8,185 of 18,943 hand lines on mz_train_smoke.log carry it). The suffix is
+    log noise, not part of the card name — strip it the same way
+    parse_permanents already does, or a quarter of combat-row hand mentions
+    render as nonexistent card names ("Negate:5") that no card lookup can
+    resolve.
+    """
     text = text.strip()
-    return [c.strip() for c in text.split(";")] if text else []
+    if not text:
+        return []
+    return [re.sub(r":\d+$", "", c.strip()).strip() for c in text.split(";")]
 
 
 # Separator commas in logList output are NOT followed by a space; commas
@@ -445,6 +457,15 @@ def parse_named_hand_cards(text: str) -> list[str]:
 
 
 def parse_permanents(text: str) -> list[dict[str, Any]]:
+    """Split a ``-> Permanents: [...]`` payload into board entries.
+
+    XMage appends state markers to the name ("Kitsa, Otterball Elite,tapped,
+    attacking"). ``,tapped`` was always extracted; ``,attacking``/``,blocking``
+    were not, so priority-row prompts rendered nonexistent card names like
+    "Skrelv, Defector Mite,attacking" that no card lookup can resolve. All
+    three markers are extracted into flags; flag keys are only present when
+    True (matches the combat scanner's row shape).
+    """
     text = text.strip()
     if not text:
         return []
@@ -453,10 +474,14 @@ def parse_permanents(text: str) -> list[dict[str, Any]]:
         entry = entry.strip()
         if not entry:
             continue
-        tapped = ",tapped" in entry
-        name = entry.replace(",tapped", "").strip()
-        name = re.sub(r":\d+$", "", name).strip()
-        result.append({"name": name, "tapped": tapped})
+        flags = {}
+        for marker in ("tapped", "attacking", "blocking"):
+            token = f",{marker}"
+            if token in entry:
+                flags[marker] = True
+                entry = entry.replace(token, "")
+        name = re.sub(r":\d+$", "", entry.strip()).strip()
+        result.append({"name": name, "tapped": flags.pop("tapped", False), **flags})
     return result
 
 

--- a/tools/training/run_wp3_pipeline.py
+++ b/tools/training/run_wp3_pipeline.py
@@ -52,6 +52,7 @@ for p in [str(SRC), str(REPO)]:
 from tools.training import build_magezero_bridge as BRIDGE
 from tools.training import magezero_combat_micro as COMBAT
 from tools.training import magezero_filters as FILTERS
+from tools.training import oracle_coverage as ORACLE
 from tools.training import parse_magezero_log as PARSER
 
 # ---------------------------------------------------------------------------
@@ -271,6 +272,70 @@ def stage_render(
 
 
 # ---------------------------------------------------------------------------
+# Stage 5b: Oracle-text coverage (fail-closed metric)
+# ---------------------------------------------------------------------------
+
+
+def stage_oracle_coverage(
+    rendered: dict[str, list[dict]],
+    min_coverage: float | None,
+) -> dict[str, Any]:
+    """Measure oracle-text coverage over every rendered prompt.
+
+    The transfer medium for card generalization is TEXT (a bare card name
+    teaches name->action; oracle text teaches role->action), so the fraction
+    of card-name mentions carrying oracle text is a first-class corpus
+    metric. ``unresolved`` names (no LOCAL oracle source) count AGAINST
+    coverage — a card we cannot ground is a gap, not an excuse.
+
+    With ``min_coverage`` set, a corpus below the floor aborts the pipeline
+    (exit 43). Default is off so existing invocations are unchanged.
+    """
+    lookup = ORACLE.build_lookup()
+    stats = ORACLE.new_stats()
+    for records in rendered.values():
+        ORACLE.audit_records(records, lookup, stats)
+    summary = ORACLE.summarize(stats)
+    summary["mention_accounting"] = {
+        k: BRIDGE.ORACLE_STATS.get(k, 0)
+        for k in ("oracle_attached", "oracle_no_text", "oracle_unresolved", "no_targets_stripped")
+    }
+
+    print(f"  records audited: {summary['records_audited']}")
+    for ctx, row in summary["contexts"].items():
+        cov = row["coverage"]
+        cov_s = f"{cov * 100:5.1f}%" if cov is not None else "  n/a"
+        print(
+            f"  {ctx:<11s} coverage={cov_s}  covered={row['covered']} "
+            f"uncovered={row['uncovered']} unresolved={row['unresolved']} "
+            f"keyword_only={row['keyword_only']} no_text={row['no_text']}"
+        )
+    overall = summary["overall_coverage"]
+    print(f"  overall oracle_text_coverage: "
+          f"{overall if overall is not None else 'n/a (no mentions)'}")
+    if summary["unparsed_lines"]:
+        print(f"  unparsed lines (counted, fail-closed): {summary['unparsed_lines']}")
+
+    if min_coverage is not None:
+        if overall is None:
+            print(
+                f"\nORACLE COVERAGE FLOOR FAILED: no card mentions found to measure "
+                f"(floor {min_coverage}). Corpus REJECTED.",
+                file=sys.stderr,
+            )
+            raise SystemExit(43)
+        if overall < min_coverage:
+            print(
+                f"\nORACLE COVERAGE FLOOR FAILED: {overall:.4f} < {min_coverage} "
+                f"(--min-oracle-coverage). Corpus REJECTED.",
+                file=sys.stderr,
+            )
+            raise SystemExit(43)
+        print(f"  floor check: {overall:.4f} >= {min_coverage} PASS")
+    return summary
+
+
+# ---------------------------------------------------------------------------
 # Stage 6: Leak scan
 # ---------------------------------------------------------------------------
 
@@ -387,6 +452,7 @@ def stage_write(
     attackers_blockers_total: int,
     elapsed: float,
     combat_info: dict[str, Any] | None = None,
+    oracle_summary: dict[str, Any] | None = None,
 ) -> dict:
     """Write per-split JSONL files and manifest. Returns manifest dict."""
     outdir.mkdir(parents=True, exist_ok=True)
@@ -403,6 +469,9 @@ def stage_write(
         "filter_counts": dict(filter_counts),
         "splits": {},
     }
+
+    if oracle_summary is not None:
+        manifest["oracle_text_coverage"] = oracle_summary
 
     if combat_info is not None:
         hist = combat_info.get("histograms_filtered", {})
@@ -572,6 +641,38 @@ def stage_report(
         lines.append(json.dumps(combat.get("accounting", {}), indent=2, sort_keys=True))
         lines.append("```")
         lines.append("")
+    oracle = manifest.get("oracle_text_coverage")
+    if oracle:
+        lines.append("## Oracle-Text Coverage")
+        lines.append("")
+        lines.append(
+            "Fraction of card-name mentions whose oracle text appears in the same "
+            "prompt (denominator excludes cards with keyword-only or no oracle "
+            "text; `unresolved` = no LOCAL oracle source, counted AGAINST coverage)."
+        )
+        lines.append("")
+        lines.append("| Context | Coverage | Covered | Uncovered | Unresolved | Keyword-only | No-text |")
+        lines.append("|---------|----------|---------|-----------|------------|--------------|---------|")
+        for ctx, row in oracle.get("contexts", {}).items():
+            cov = row.get("coverage")
+            cov_s = f"{cov * 100:.1f}%" if cov is not None else "n/a"
+            lines.append(
+                f"| {ctx} | {cov_s} | {row['covered']} | {row['uncovered']} | "
+                f"{row['unresolved']} | {row['keyword_only']} | {row['no_text']} |"
+            )
+        oc = oracle.get("overall_coverage")
+        lines.append("")
+        lines.append(f"**Overall: {oc * 100:.1f}%**" if oc is not None else "**Overall: n/a**")
+        if oracle.get("unparsed_lines"):
+            lines.append("")
+            lines.append(f"Unparsed lines (counted, fail-closed): `{oracle['unparsed_lines']}`")
+        if oracle.get("examples"):
+            lines.append("")
+            lines.append("Example gaps per context:")
+            for ctx, ex in oracle["examples"].items():
+                for cls, names in ex.items():
+                    lines.append(f"- {ctx}/{cls}: {', '.join(names)}")
+        lines.append("")
     lines.append("## Split Sizes")
     lines.append("")
     lines.append("| Split | Records |")
@@ -679,6 +780,7 @@ def run_pipeline(
     include_combat: bool = False,
     primary_deck: str | None = None,
     decks_dir: str | None = None,
+    min_oracle_coverage: float | None = None,
 ) -> dict[str, Any]:
     """Run the full WP-3 pipeline.
 
@@ -686,6 +788,7 @@ def run_pipeline(
     """
     t0 = time.time()
     outdir.mkdir(parents=True, exist_ok=True)
+    BRIDGE.ORACLE_STATS.clear()  # per-run mention accounting
 
     # ── Stage 1: Parse ────────────────────────────────────────────────────
     print("Stage 1/5 — Parse logs")
@@ -794,6 +897,10 @@ def run_pipeline(
     print("Leak scan — checking rendered prompts for training-set artifacts...")
     stage_leak_scan(rendered, raw_decisions + combat_rows)
 
+    # ── Oracle-text coverage ───────────────────────────────────────────────
+    print("Oracle-text coverage — measuring card-mention text coverage...")
+    oracle_summary = stage_oracle_coverage(rendered, min_oracle_coverage)
+
     # ── Write output ────────────────────────────────────────────────────────
     elapsed = time.time() - t0
     manifest = stage_write(
@@ -806,6 +913,7 @@ def run_pipeline(
         attackers_blockers_total,
         elapsed,
         combat_info=combat_info,
+        oracle_summary=oracle_summary,
     )
 
     # ── Report ──────────────────────────────────────────────────────────────
@@ -829,6 +937,8 @@ def run_pipeline(
     print(f"  Training records:  {total_records}")
     print(f"  Attackers/blockers excluded: {attackers_blockers_total}")
     print(f"  Pass rate:         {pass_rate:.4f} ({pass_rate * 100:.1f}%)")
+    _oc = oracle_summary.get("overall_coverage")
+    print(f"  Oracle coverage:   {_oc:.4f}" if _oc is not None else "  Oracle coverage:   n/a")
     if include_combat and combat_info is not None:
         print(
             f"  Combat rows:       {len(combat_rows)} scanned, "
@@ -909,6 +1019,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="XMage deck directory holding the .dck lists "
         "(default: parse_magezero_log.DEFAULT_DECKS_DIR)",
     )
+    parser.add_argument(
+        "--min-oracle-coverage",
+        type=float,
+        default=None,
+        metavar="FRAC",
+        help="Fail-closed floor on overall oracle-text coverage (0..1). When "
+        "set, a corpus whose fraction of card mentions with attached oracle "
+        "text falls below FRAC aborts the pipeline (exit 43). Coverage is "
+        "always measured and reported; the floor is OFF by default.",
+    )
     return parser
 
 
@@ -986,6 +1106,7 @@ def main(argv: list[str] | None = None) -> int:
             include_combat=args.include_combat,
             primary_deck=args.primary_deck,
             decks_dir=args.decks_dir,
+            min_oracle_coverage=args.min_oracle_coverage,
         )
     except PARSER.DeckSignatureError as e:
         print(f"\nPipeline aborted (fail closed): {e}", file=sys.stderr)
@@ -994,6 +1115,9 @@ def main(argv: list[str] | None = None) -> int:
         if e.code == 42:
             print("\nPipeline aborted: pass rate tripwire or leak scan failed.", file=sys.stderr)
             return 42
+        if e.code == 43:
+            print("\nPipeline aborted: oracle-text coverage below --min-oracle-coverage.", file=sys.stderr)
+            return 43
         raise
 
     return 0

--- a/tools/training/wp3/PROGRESS-wp3-oracle-coverage.md
+++ b/tools/training/wp3/PROGRESS-wp3-oracle-coverage.md
@@ -1,0 +1,154 @@
+# PROGRESS: wp3-oracle-coverage — oracle-text coverage audit + enforcement
+
+Branch: `wp3-oracle-coverage`. MORNING PRIORITY item 2 (rl-pipeline-fix.md):
+the transfer medium for card generalization is TEXT — a bare card name in a
+prompt teaches name->action; oracle text teaches role->action. #461 fixed
+non-basic lands; this measures and fixes everything else in the WP-3 path.
+
+All numbers below are MEASURED on this machine (blackwell), 2026-07-31.
+
+## 1. Coverage BEFORE (committed corpus `wp3_v2_combat`, built from
+## mz_train_smoke.log at a9a3f23 with --include-combat --balance downsample-pass)
+
+Mention = one distinct card name per context per rendered prompt.
+Coverage = covered / (covered + uncovered + unresolved); `keyword_only` and
+`no_text` are excluded from the denominator (nothing to attach); `unresolved`
+(no LOCAL oracle source) counts AGAINST coverage.
+
+| Context     | Coverage | Covered | Uncovered | Unresolved | Keyword-only | No-text |
+|-------------|----------|---------|-----------|------------|--------------|---------|
+| menu        | 0.0%     | 0       | 8,046     | 166        | 1            | 671     |
+| hand        | 0.0%     | 0       | 17,761    | 630        | 0            | 1,285   |
+| your_board  | 0.0%     | 2       | 38,457    | 349        | 0            | 5,878   |
+| opp_board   | 0.0%     | 0       | 10,886    | 169        | 83           | 6,629   |
+| **overall** | **0.0%** (2 / 76,466) | | | | | |
+
+5 concrete missing examples per context (from the audit):
+- menu: Adarkar Wastes, Skrelv Defector Mite, Shardmage's Rescue, Bounce Off, Floodfarm Verge
+- hand: Floodfarm Verge, Meticulous Archive, Seachrome Coast, No More Lies, Soul Partition
+- your_board: Seachrome Coast, Skrelv Defector Mite, Combat Research, Meticulous Archive, Sheltered by Ghosts
+- opp_board: Burnout Bashtronaut, Rockface Village, Nova Hellkite, Hired Claw, Emberheart Challenger
+
+Root cause: `build_magezero_bridge._build_card`/`_build_hand_card` hardcoded
+`oracle_text: ""` (MZ logs carry names only, and `magezero_card_map.json`
+never carried oracle text), and the planner formatter suppresses board oracle
+for long-resident permanents (`turn_entered_battlefield=-1` made every MZ
+card look long-resident).
+
+## 2. Three corpus bugs found by the audit (all fixed, drop-and-count)
+
+1. **Hand score suffixes**: XMage's `GameStateEvaluator2.printBattlefield`
+   emits hand entries as `Name:5`; `parse_card_list` kept the suffix while
+   `parse_permanents` already stripped it. Measured: 8,185 of 18,943
+   `-> Hand:` lines in mz_train_smoke.log carry it; 2,412 of 9,489 combat-row
+   hand mentions rendered as nonexistent names ("Negate:5").
+2. **Combat markers as names**: `parse_permanents` extracted `,tapped` but
+   not `,attacking`/`,blocking`, so priority prompts rendered names like
+   "Skrelv, Defector Mite,attacking". Now extracted into flags; the bridge
+   honours them for the LOCAL seat only ([ATK]/[BLK] flags) — an
+   is_attacking-marked OPPONENT card would make the production formatter run
+   block analysis on fabricated 0/0 stats (same rule magezero_combat_micro
+   already enforced).
+3. **False [NO TARGETS] tags**: with oracle text attached, the production
+   formatter's removal analysis computes target pools from the opponent's
+   TYPED board. MZ boards are untyped, so the tag comes out false for any
+   removal spell whenever the opponent actually has creatures — while the
+   MageZero gold action frequently casts exactly that spell (contradictory
+   label). The bridge sanitizer strips the tag and counts it
+   (5,529 strips across 6,921 rendered records). `[RM:...]` tags are kept:
+   they derive from the card's own oracle text.
+
+## 3. The fix
+
+- `tools/training/wp3/enrich_card_map.py` (new): enriches
+  `magezero_card_map.json` with `oracle_text` (+ printed power/toughness,
+  stored not rendered) from the LOCAL Scryfall bulk
+  (`~/.arenamcp/cache/scryfall/default_cards.json`), no network. Adds entries
+  for token/DFC names found in decisions files. Result: **98 entries, 98
+  resolved locally, 0 unresolved** ("Incubator Token" resolves via
+  double-faced-token face names). Names with no local source would be tagged
+  `oracle_source: none_local` and rendered bare — never fabricated.
+- `build_magezero_bridge.py`: attaches the map's oracle text to hand and
+  battlefield card dicts; `turn_entered_battlefield` set to the current turn
+  so the planner formatter actually renders the text (entry turn is not
+  recoverable from MZ logs; with untyped cards the field's only
+  prompt-visible effect is that render gate). Deliberately does NOT attach
+  type_line/power/toughness: typing MZ cards as creatures makes the formatter
+  print fabricated 0/0 stats and run the combat solver, whose
+  "Computed optimal" lines are fail-closed-rejected by the combat adapter.
+- `run_wp3_pipeline.py`: new stage measures coverage on every rendered
+  corpus; `oracle_text_coverage` (per-context + overall + examples +
+  mention accounting) lands in `manifest.json` and `REPORT.md`;
+  `--min-oracle-coverage FRAC` is a fail-closed floor (exit 43; also trips
+  when there are zero measurable mentions). Default OFF.
+- `tools/training/oracle_coverage.py` (new): the audit module + CLI
+  (`--bulk` for real-replay gate corpora). Fail closed: unparseable lines
+  are counted per context, never skipped.
+
+## 4. Coverage AFTER (same log, same flags, fixed code;
+## outdir wp3_smoke_oracle, 6,921 records: 5,459 priority + 1,291 attack + 171 block)
+
+| Context     | Coverage | Covered | Uncovered | Unresolved | Keyword-only | No-text |
+|-------------|----------|---------|-----------|------------|--------------|---------|
+| menu        | 88.1%    | 7,234   | 815       | 166        | 1            | 671     |
+| hand        | 100.0%   | 18,355  | 0         | 0          | 0            | 1,316   |
+| your_board  | 100.0%   | 38,821  | 0         | 0          | 0            | 5,874   |
+| opp_board   | 100.0%   | 11,041  | 0         | 0          | 83           | 6,627   |
+| **overall** | **98.7%** (75,451 / 76,432) | | | | | |
+
+Mention accounting from the build itself: 122,948 oracle attachments, 30
+resolved-but-textless (basics/vanilla), **0 unresolved**, 5,529 [NO TARGETS]
+strips. Unfixable cards (no local oracle source): **0**.
+
+Residual menu gap (11.9%): production menus are bare by design — a menu
+mention counts as covered when the card's text renders in hand/board of the
+same prompt. The remaining 815 uncovered are menu-only mentions (mostly
+stale/incomplete MZ hand attribution windows); the 166 unresolved are
+comma-split fragments of the known `segment_menu` fail-closed fallback
+("Cast Malcolm" + "Alluring Scoundrel" when the MCTS pool didn't confirm the
+merged name); 314 unparsed menu lines are ability-text fragments of the same
+split. These are log-fidelity limits, not renderer gaps.
+
+Side effects, measured:
+- Prompt length: train median 789 -> 2,505 chars, mean 815 -> 2,583, max
+  1,425 -> 5,216 (oracle text is the payload; system prompt unchanged).
+- `Mana:` lines gain source colors for suffix-typed lands (oracle mana
+  abilities now visible to the formatter).
+- Corpus deltas vs the committed build (same log): dedupe 1,598 -> 1,617
+  drops (cleaned names collapse more duplicates); records 6,924 -> 6,921.
+  Combat class histograms unchanged (all-in 74.5% floor breach still
+  flagged, per addendum 19 postscript).
+- Every corpus rebuilt after this prompt change must be regenerated (the
+  system-prompt staleness guard is unchanged; the USER shape changed).
+
+## 5. Gate corpora (real-replay, audited with --bulk; measurement only)
+
+| Corpus | Records | menu | hand | your_board | opp_board | attacking | overall |
+|--------|---------|------|------|------------|-----------|-----------|---------|
+| gate_play_decisions_test.jsonl | 206 | 74.5% | 95.5% | 12.0% | 6.6% | n/a | 59.7% |
+| gate_strategic_decisions_test.jsonl | 550 | 55.1% | 95.5% | 9.0% | 5.5% | n/a | 41.6% |
+| combat_gate_test.jsonl | 6,848 | 97.8% | n/a | 95.8% | 96.0% | 96.9% | 96.4% |
+
+The `gate_b5_*_test.jsonl` files matched by the task's glob are RESPONSE
+files (model outputs, no prompts) — nothing to audit there; the prompt-side
+gate corpora are the three above.
+
+Reading: the low board coverage in the two priority-gate corpora is the
+production planner's deliberate for_planner trim (long-resident permanents
+render flags, not text — real entry turns are known there). Whether that trim
+is still right given the role->action transfer argument is a PRODUCT prompt
+decision (coach.py), deliberately not changed here; flagged for the owner.
+
+## 6. Verification
+
+- 232 tests pass: full touched-module batch (`test_parse_magezero_log`,
+  `test_magezero_combat_micro`, `test_magezero_bridge_leaks`,
+  `test_run_wp3_pipeline`, `test_magezero_combat`, `test_magezero_filters`,
+  `test_battlefield_land_oracle`, `test_magezero_card_map`) + 26 new in
+  `tests/test_oracle_coverage.py` (parser strips, oracle attachment,
+  opp-never-attacking rule, [NO TARGETS] strip + count, audit
+  classification incl. {oT}/{T} dialect match, floor trips at exit 43,
+  floor-off default, no-mentions-with-floor fails closed).
+- Pipeline end-to-end on mz_train_smoke.log (201 MB): 32s, leak scan clean,
+  pass-rate tripwire 40.0% after downsample (43.1% raw — same as the
+  committed run), rendered records eyeballed against the raw log.

--- a/tools/training/wp3/build_mixture_manifest.py
+++ b/tools/training/wp3/build_mixture_manifest.py
@@ -51,7 +51,6 @@ import subprocess
 import sys
 import time
 from collections import Counter
-from pathlib import Path
 
 DEFAULT_VOCAB = os.path.expanduser("~/.arenamcp/mtgjson/name_index.json")
 

--- a/tools/training/wp3/build_unseen_gate_corpus.py
+++ b/tools/training/wp3/build_unseen_gate_corpus.py
@@ -62,7 +62,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import re
 import subprocess
 import sys
 import time

--- a/tools/training/wp3/enrich_card_map.py
+++ b/tools/training/wp3/enrich_card_map.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Enrich magezero_card_map.json with oracle text from the LOCAL Scryfall bulk.
+
+The MageZero corpus renders card names without oracle text because the card
+map (built by resolve_cards.py) never carried it. This script adds, from the
+local Scryfall bulk cache ONLY (no network — fail closed):
+
+  - ``oracle_text``  (all faces joined with " // ", reminder text kept: the
+                      production formatter strips it at render time)
+  - ``power`` / ``toughness``  (printed; stored for future use, NOT rendered)
+
+and adds NEW entries for names that appear in decisions JSONL files but are
+missing from the map (tokens, DFC faces). Names that resolve nowhere locally
+are counted and reported — never fabricated.
+
+Usage
+-----
+    python3 tools/training/wp3/enrich_card_map.py \
+        --names-from tools/training/data/wp3_v2_combat/decisions.jsonl \
+        --names-from tools/training/data/wp3_v2_combat/combat_decisions.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+MAP_PATH = REPO / "tools" / "training" / "magezero_card_map.json"
+BULK_PATH = Path.home() / ".arenamcp" / "cache" / "scryfall" / "default_cards.json"
+
+_COMBAT_SUFFIXES = (",attacking", ",blocking")
+
+
+def _oracle_from(card: dict) -> str:
+    text = card.get("oracle_text")
+    if text:
+        return text
+    faces = card.get("card_faces") or []
+    joined = " // ".join(f.get("oracle_text") or "" for f in faces).strip(" /")
+    return joined
+
+
+def _pt_from(card: dict) -> tuple[str | None, str | None]:
+    p, t = card.get("power"), card.get("toughness")
+    if p is None or t is None:
+        for f in card.get("card_faces") or []:
+            if f.get("power") is not None:
+                return f.get("power"), f.get("toughness")
+    return p, t
+
+
+def load_bulk_indexes(bulk_path: Path) -> tuple[dict, dict, dict]:
+    """Return (by_name, by_face_name, tokens_by_name), all lowercase-keyed.
+
+    Non-token printings win name collisions; the first token printing wins
+    within tokens_by_name.
+    """
+    with open(bulk_path, encoding="utf-8") as f:
+        cards = json.load(f)
+    by_name: dict[str, dict] = {}
+    by_face: dict[str, dict] = {}
+    tokens: dict[str, dict] = {}
+    for c in cards:
+        name = (c.get("name") or "").lower()
+        if not name:
+            continue
+        layout = c.get("layout") or ""
+        is_token = "token" in layout
+        if is_token:
+            tokens.setdefault(name, c)
+            # Double-faced tokens ("Incubator // Phyrexian"): XMage names one
+            # face ("Incubator Token"), so register faces too.
+            for f in c.get("card_faces") or []:
+                fname = (f.get("name") or "").lower()
+                if fname:
+                    tokens.setdefault(fname, c)
+        else:
+            by_name.setdefault(name, c)
+            for f in c.get("card_faces") or []:
+                fname = (f.get("name") or "").lower()
+                if fname:
+                    by_face.setdefault(fname, c)
+    return by_name, by_face, tokens
+
+
+import re as _re
+
+
+def _clean(n: str) -> str:
+    """Apply the same log-noise strips the parsers now apply at source
+    (defensive: decisions files built by older parser code carry them)."""
+    for suf in _COMBAT_SUFFIXES:
+        if n.endswith(suf):
+            n = n[: -len(suf)]
+    return _re.sub(r":\d+$", "", n).strip()
+
+
+def collect_names(paths: list[Path]) -> set[str]:
+    names: set[str] = set()
+    for p in paths:
+        with open(p, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = json.loads(line)
+                for n in row.get("hand", []) or []:
+                    names.add(_clean(n))
+                for side in ("battlefield_self", "battlefield_opp"):
+                    for c in row.get(side, []) or []:
+                        n = c.get("name", "") if isinstance(c, dict) else str(c)
+                        names.add(_clean(n))
+                if row.get("creature"):
+                    names.add(_clean(row["creature"]))
+    names.discard("")
+    return names
+
+
+def resolve(name: str, entry: dict | None, by_name: dict, by_face: dict, tokens: dict) -> tuple[dict | None, str]:
+    """Return (bulk_card, how) for a map name, or (None, 'miss')."""
+    low = name.lower()
+    # Token-suffixed XMage names ("Map Token") -> Scryfall token "Map"
+    if low.endswith(" token"):
+        base = low[: -len(" token")].strip()
+        if base in tokens:
+            return tokens[base], "token"
+        if base in by_name:
+            return by_name[base], "token_as_card"
+    if entry:
+        canon = (entry.get("scryfall") or "").lower()
+        if canon and canon in by_name:
+            return by_name[canon], "canonical"
+    if low in by_name:
+        return by_name[low], "exact"
+    if low in by_face:
+        return by_face[low], "face"
+    if low in tokens:
+        return tokens[low], "token_exact"
+    return None, "miss"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--names-from", action="append", type=Path, default=[],
+                    help="decisions JSONL to scan for card names missing from the map")
+    ap.add_argument("--map", type=Path, default=MAP_PATH)
+    ap.add_argument("--bulk", type=Path, default=BULK_PATH)
+    args = ap.parse_args(argv)
+
+    if not args.bulk.exists():
+        print(f"FAIL CLOSED: local Scryfall bulk not found at {args.bulk}; no network fallback.",
+              file=sys.stderr)
+        return 2
+
+    card_map: dict[str, dict] = json.loads(args.map.read_text(encoding="utf-8"))
+    print(f"card map: {len(card_map)} entries")
+
+    extra = collect_names(args.names_from)
+    new_names = sorted(n for n in extra if n not in card_map)
+    print(f"decisions scan: {len(extra)} distinct names, {len(new_names)} not in map: {new_names}")
+
+    print(f"loading local bulk {args.bulk} ...")
+    by_name, by_face, tokens = load_bulk_indexes(args.bulk)
+    print(f"bulk: {len(by_name)} names, {len(by_face)} faces, {len(tokens)} tokens")
+
+    enriched = 0
+    misses: list[str] = []
+    how_hist: dict[str, int] = {}
+    for name in sorted(set(card_map) | set(new_names)):
+        entry = card_map.get(name)
+        card, how = resolve(name, entry, by_name, by_face, tokens)
+        how_hist[how] = how_hist.get(how, 0) + 1
+        if card is None:
+            misses.append(name)
+            if entry is None:
+                card_map[name] = {
+                    "exact": False,
+                    "found": False,
+                    "scryfall": name,
+                    "type_line": "",
+                    "mana_cost": "",
+                    "oracle_source": "none_local",
+                }
+            else:
+                entry["oracle_source"] = "none_local"
+            continue
+        if entry is None:
+            entry = {
+                "exact": False,
+                "found": True,
+                "scryfall": card.get("name", name),
+                "type_line": card.get("type_line", ""),
+                "mana_cost": card.get("mana_cost", ""),
+            }
+            card_map[name] = entry
+        entry["oracle_text"] = _oracle_from(card)
+        p, t = _pt_from(card)
+        if p is not None and t is not None:
+            entry["power"], entry["toughness"] = p, t
+        entry["oracle_source"] = f"local_bulk:{how}"
+        enriched += 1
+
+    args.map.write_text(json.dumps(card_map, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+                        encoding="utf-8")
+    print(f"wrote {args.map}: {len(card_map)} entries, {enriched} enriched, "
+          f"{len(misses)} unresolved locally")
+    print(f"resolution histogram: {dict(sorted(how_hist.items()))}")
+    if misses:
+        print("UNRESOLVED (counted, not fabricated):")
+        for m in misses:
+            print(f"  - {m}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
MORNING PRIORITY item 2 (rl-pipeline-fix.md): oracle-text coverage audit + enforcement. All numbers measured on blackwell, 2026-07-31.

## Coverage BEFORE (committed `wp3_v2_combat`, mz_train_smoke.log at a9a3f23)

Mention = distinct card name per context per rendered prompt. Coverage = covered / (covered + uncovered + unresolved); keyword-only and textless cards excluded from the denominator; `unresolved` (no LOCAL oracle source) counts against.

| Context | Coverage | Covered | Uncovered | Unresolved |
|---------|----------|---------|-----------|------------|
| menu | 0.0% | 0 | 8,046 | 166 |
| hand | 0.0% | 0 | 17,761 | 630 |
| your_board | 0.0% | 2 | 38,457 | 349 |
| opp_board | 0.0% | 0 | 10,886 | 169 |
| **overall** | **0.0%** (2 / 76,466) | | | |

Missing examples — menu: Adarkar Wastes, Skrelv Defector Mite, Shardmage's Rescue, Bounce Off, Floodfarm Verge; hand: Floodfarm Verge, Meticulous Archive, Seachrome Coast, No More Lies, Soul Partition; your_board: Seachrome Coast, Skrelv Defector Mite, Combat Research, Meticulous Archive, Sheltered by Ghosts; opp_board: Burnout Bashtronaut, Rockface Village, Nova Hellkite, Hired Claw, Emberheart Challenger.

## Coverage AFTER (same log, same flags, this branch; 6,921 records)

| Context | Coverage | Covered | Uncovered | Unresolved |
|---------|----------|---------|-----------|------------|
| menu | 88.1% | 7,234 | 815 | 166 |
| hand | 100.0% | 18,355 | 0 | 0 |
| your_board | 100.0% | 38,821 | 0 | 0 |
| opp_board | 100.0% | 11,041 | 0 | 0 |
| **overall** | **98.7%** (75,451 / 76,432) | | | |

122,948 oracle attachments at build time, 0 unresolved names, unfixable cards (no local oracle source): 0. Residual menu gap: production menus are bare by design; a menu mention counts via the card's text in hand/board of the same prompt. The 815 uncovered are menu-only mentions (stale MZ hand-attribution windows); the 166 unresolved + 314 unparsed menu lines are comma-split fragments of the known `segment_menu` fail-closed fallback.

## What changed

- `wp3/enrich_card_map.py` (new): oracle text from the LOCAL Scryfall bulk into `magezero_card_map.json` (98/98 names resolved; misses would be tagged `none_local` and rendered bare, never fabricated).
- `build_magezero_bridge.py`: attaches oracle text to hand + battlefield cards; `turn_entered_battlefield=current` so the planner formatter renders it. type_line/P-T deliberately NOT attached (would print fabricated 0/0 stats and trigger solver lines the combat adapter fail-closed-rejects). `[NO TARGETS]` stripped and counted (5,529 strips / 6,921 records): its input (typed opponent board) is systematically absent in MZ data and the tag contradicted the MageZero gold action.
- Three corpus bugs found by the audit, fixed drop-and-count in `parse_magezero_log.py`: `Name:5` evaluator-score hand suffixes (8,185/18,943 hand lines; 2,412/9,489 combat hand mentions rendered as nonexistent names), and `,attacking`/`,blocking` markers rendering inside card names (extracted into flags; honoured for the LOCAL seat only — an is_attacking-marked opponent card makes the formatter run block analysis on fabricated 0/0 stats).
- `oracle_coverage.py` (new): audit module + CLI; fail closed (unparsed lines counted per context; unresolved counts against coverage).
- `run_wp3_pipeline.py`: `oracle_text_coverage` in manifest + REPORT.md; `--min-oracle-coverage` fail-closed floor (exit 43; also trips on zero measurable mentions). Default OFF.

## Gate corpora (measured with --bulk; measurement only)

| Corpus | Records | menu | hand | your_board | opp_board | attacking | overall |
|--------|---------|------|------|------------|-----------|-----------|---------|
| gate_play_decisions_test | 206 | 74.5% | 95.5% | 12.0% | 6.6% | n/a | 59.7% |
| gate_strategic_decisions_test | 550 | 55.1% | 95.5% | 9.0% | 5.5% | n/a | 41.6% |
| combat_gate_test | 6,848 | 97.8% | n/a | 95.8% | 96.0% | 96.9% | 96.4% |

`gate_b5_*_test.jsonl` are response files (no prompts) — nothing to audit. Low board coverage in the priority gates is the production `for_planner` trim of long-resident permanents — a product prompt decision (coach.py), flagged for the owner, not changed here.

## Side effects, measured

- Prompt length: train median 789 -> 2,505 chars (mean 815 -> 2,583, max 5,216).
- Corpus rebuild required after merge (user-prompt shape changed); combat floor breach (all-in 74.5%) still flagged, unchanged.
- 232 tests pass (26 new in `tests/test_oracle_coverage.py`).
